### PR TITLE
feat(memory): add source-class migration and rehearsal

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -3129,14 +3129,7 @@ final class BrainDatabase: @unchecked Sendable {
         }
 
         let sourceFilter = normalizedSourceFilter(source)
-        var conditions = [
-            "c.id = ?",
-            "c.superseded_by IS NULL",
-            "c.aggregated_into IS NULL",
-            "c.archived_at IS NULL",
-            "COALESCE(c.archived, 0) = 0",
-            "COALESCE(c.status, 'active') = 'active'"
-        ]
+        var conditions = ["c.id = ?", try searchableChunkWhereClause(alias: "c")]
         if project != nil { conditions.append("(c.project = ? OR c.project IS NULL)") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
         if tag != nil { conditions.append("c.tags LIKE ?") }

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -1248,11 +1248,7 @@ final class BrainDatabase: @unchecked Sendable {
         let sourceFilter = normalizedSourceFilter(source)
         var conditions = [
             "\(tableName) MATCH ?",
-            "c.superseded_by IS NULL",
-            "c.aggregated_into IS NULL",
-            "c.archived_at IS NULL",
-            "COALESCE(c.archived, 0) = 0",
-            "COALESCE(c.status, 'active') = 'active'"
+            try searchableChunkWhereClause(alias: "c"),
         ]
         if project != nil { conditions.append("(c.project = ? OR c.project IS NULL)") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
@@ -1724,11 +1720,7 @@ final class BrainDatabase: @unchecked Sendable {
         let sourceFilter = normalizedSourceFilter(source)
         var conditions = [
             "chunks_fts MATCH ?",
-            "c.superseded_by IS NULL",
-            "c.aggregated_into IS NULL",
-            "c.archived_at IS NULL",
-            "COALESCE(c.archived, 0) = 0",
-            "COALESCE(c.status, 'active') = 'active'"
+            try searchableChunkWhereClause(alias: "c"),
         ]
         if project != nil { conditions.append("(c.project = ? OR c.project IS NULL)") }
         if sourceFilter != nil { conditions.append("c.source = ?") }
@@ -2372,6 +2364,9 @@ final class BrainDatabase: @unchecked Sendable {
         }
         if columns.contains("status") {
             clauses.append("COALESCE(\(alias).status, 'active') = 'active'")
+        }
+        if columns.contains("source_class") {
+            clauses.append("(\(alias).source_class IS NULL OR \(alias).source_class NOT IN ('desktop', 'brain-worker'))")
         }
         return clauses.isEmpty ? "1 = 1" : clauses.joined(separator: " AND ")
     }

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -907,6 +907,42 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(results.first?["chunk_id"] as? String, "test-chunk-1")
     }
 
+    func testFTSSearchHidesDesktopAndAlwaysExcludesBrainWorkersWhenSourceClassExists() throws {
+        db.exec("ALTER TABLE chunks ADD COLUMN source_class TEXT")
+        let rows: [(String, String?)] = [
+            ("source-class-cli", "cli-agent"),
+            ("source-class-desktop", "desktop"),
+            ("source-class-subagent", "subagent"),
+            ("source-class-brain-worker", "brain-worker"),
+            ("source-class-fleet", "fleet-coordination"),
+            ("source-class-null", nil),
+        ]
+        for (chunkID, sourceClass) in rows {
+            try db.insertChunk(
+                id: chunkID,
+                content: "SwiftSourceClassNeedle searchable contract \(chunkID)",
+                sessionId: "source-class-session",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 7
+            )
+            if let sourceClass {
+                db.exec("UPDATE chunks SET source_class = '\(sourceClass)' WHERE id = '\(chunkID)'")
+            }
+        }
+
+        let resultIDs = Set(try db.search(query: "SwiftSourceClassNeedle", limit: 20).compactMap {
+            $0["chunk_id"] as? String
+        })
+        let candidateIDs = Set(try db.searchCandidates(query: "SwiftSourceClassNeedle", limit: 20).map(\.id))
+        let expected = Set(["source-class-cli", "source-class-subagent", "source-class-fleet", "source-class-null"])
+
+        XCTAssertEqual(resultIDs, expected)
+        XCTAssertEqual(candidateIDs, expected)
+        XCTAssertFalse(resultIDs.contains("source-class-desktop"))
+        XCTAssertFalse(resultIDs.contains("source-class-brain-worker"))
+    }
+
     func testSearchSkipsTrigramFallbackWhenTableMissingAndMigrationsDisabled() throws {
         let legacyPath = NSTemporaryDirectory() + "brainbar-no-trigram-\(UUID().uuidString).db"
         try sqliteExecWrite(

--- a/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DatabaseTests.swift
@@ -941,6 +941,8 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(candidateIDs, expected)
         XCTAssertFalse(resultIDs.contains("source-class-desktop"))
         XCTAssertFalse(resultIDs.contains("source-class-brain-worker"))
+        XCTAssertTrue(try db.search(query: "source-class-desktop", limit: 1).isEmpty)
+        XCTAssertTrue(try db.search(query: "source-class-brain-worker", limit: 1).isEmpty)
     }
 
     func testSearchSkipsTrigramFallbackWhenTableMissingAndMigrationsDisabled() throws {

--- a/docs/operations/wave3-3a-two-host-live-runbook.md
+++ b/docs/operations/wave3-3a-two-host-live-runbook.md
@@ -6,14 +6,15 @@ This runbook is the source-class segment of the Wave 3 maintenance sitting. Exec
 
 ## Pinned artifacts and rehearsal measurements
 
-- Migration code commit: `be877608ae5ff14de079ccd40949ef14f88aa578`.
+- Migration/source-class code commit: `3964412f8291a083150a424e38df08ece817783d`.
+- Required deployed release before either host migrates: BrainLayer + BrainBar **v1.5.6 or later**. v1.5.5 carries the backup-race fix; v1.5.6 adds the Swift default-search source-class gate.
 - Command: `scripts/migrate_source_class.py` from a checkout containing that commit.
 - Rehearsal source: online SQLite backup from canonical opened `mode=ro` into gitignored `.tmp-wave3-3a/` (contingency route, not the LIVE primary route).
 - Timed contingency replay: 26.16 seconds wall-clock while live drain writes continued; 744,396 rows, 4,251,874 pages, 17,415,675,904 bytes. The pristine rehearsal copy passed `PRAGMA quick_check` before migration.
 - Rehearsal rows: 744,335 before and after.
-- Rehearsal migration: 198.82 seconds wall-clock on reviewed migration commit `be877608ae5ff14de079ccd40949ef14f88aa578` (`duration_seconds=198.79003841709346`).
-- Rehearsal distribution: NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 97,678; subagent 37,445.
-- Rehearsal migration WAL: 0 bytes before, 29,181,992-byte observed peak, 0 bytes at close after checkpoints.
+- Final-code rehearsal migration: 252.02 seconds wall-clock on commit `3964412f8291a083150a424e38df08ece817783d` (`duration_seconds=251.79996774997562`); exact-SHA idempotent rerun: 0.65 seconds.
+- Rehearsal distribution: NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 105,383; subagent 29,740.
+- Earlier monitored rehearsal migration WAL: 0 bytes before, 29,181,992-byte observed peak, 0 bytes at close after checkpoints; the final-code rerun was not separately peak-sampled.
 - Rehearsal rollback: restore by APFS re-copy in 0.00 seconds; restored row count 744,335 and `source_class` absent.
 
 ## Host receipt table
@@ -26,7 +27,10 @@ Fill every blank on each host. Do not copy Main values into M1.
 | Hostname |  |  |
 | Canonical DB path |  |  |
 | Checked-out commit |  |  |
-| BrainBar version (must be 1.5.4+) |  |  |
+| Installed BrainLayer / BrainBar versions (must be 1.5.6+) |  |  |
+| Installed CLI path + SHA-256 |  |  |
+| Executing BrainBarDaemon PID / path + SHA-256 |  |  |
+| Executing daemon `source_class` capability probe |  |  |
 | Free bytes |  |  |
 | Active labels receipt file |  |  |
 | Pause sentinel contents |  |  |
@@ -37,6 +41,7 @@ Fill every blank on each host. Do not copy Main values into M1.
 | Verified local raw backup ref |  |  |
 | Verified Drive file id / MD5 |  |  |
 | Backup wall-clock |  |  |
+| No-write observer before / after |  |  |
 | Migration wall-clock |  |  |
 | Rows after |  |  |
 | NULL / cli / desktop / subagent / brain-worker / fleet |  |  |
@@ -47,6 +52,50 @@ Fill every blank on each host. Do not copy Main values into M1.
 | Restarted labels |  |  |
 | Etan host acceptance |  |  |
 
+## 0. Deploy v1.5.6 first and prove the executing binaries
+
+The order is mandatory on **each host**: install v1.5.6, restart and probe the installed formula and BrainBarDaemon, then stop writers, back up, and migrate. The new Python watcher INSERT and Swift search clause both guard for an absent `source_class` column, so deploying v1.5.6 before the schema migration is safe. The reverse order is forbidden: migration must not make the contract live while an older BrainBar still exposes desktop rows.
+
+Run the supported release installers with Etan present. Do not substitute a worktree build:
+
+```bash
+set -euo pipefail
+export WAVE3A_REQUIRED_VERSION="1.5.6"
+brew update
+if brew list --formula brainlayer >/dev/null 2>&1; then
+  brew upgrade etanhey/layers/brainlayer || brew reinstall etanhey/layers/brainlayer
+else
+  brew install etanhey/layers/brainlayer
+fi
+scripts/brainlayer-update-brainbar.sh
+export WAVE3A_INSTALLED_CLI="$(command -v brainlayer)"
+test -x "$WAVE3A_INSTALLED_CLI"
+"$WAVE3A_INSTALLED_CLI" --version | tee "$HOME/.local/share/brainlayer/wave3a-installed-cli-version.txt"
+grep -F "$WAVE3A_REQUIRED_VERSION" "$HOME/.local/share/brainlayer/wave3a-installed-cli-version.txt"
+/usr/libexec/PlistBuddy -c 'Print:CFBundleShortVersionString' /Applications/BrainBar.app/Contents/Info.plist \
+  | tee "$HOME/.local/share/brainlayer/wave3a-brainbar-version.txt"
+grep -Fx "$WAVE3A_REQUIRED_VERSION" "$HOME/.local/share/brainlayer/wave3a-brainbar-version.txt"
+```
+
+Restart the daemon from the installed bundle, then bind the receipt to the process that is actually serving MCP:
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.brainlayer.brainbar-daemon"
+sleep 2
+export WAVE3A_DAEMON_PID="$(launchctl print "gui/$(id -u)/com.brainlayer.brainbar-daemon" | awk '/^[[:space:]]*pid = / {print $3; exit}')"
+test -n "$WAVE3A_DAEMON_PID"
+ps -p "$WAVE3A_DAEMON_PID" -o command= | tee "$HOME/.local/share/brainlayer/wave3a-daemon-command.txt"
+grep -F '/Applications/BrainBar.app/Contents/MacOS/BrainBarDaemon' "$HOME/.local/share/brainlayer/wave3a-daemon-command.txt"
+shasum -a 256 "$WAVE3A_INSTALLED_CLI" /Applications/BrainBar.app/Contents/MacOS/BrainBarDaemon \
+  | tee "$HOME/.local/share/brainlayer/wave3a-installed-sha256.txt"
+strings /Applications/BrainBar.app/Contents/MacOS/BrainBarDaemon | grep -F 'source_class' \
+  | tee "$HOME/.local/share/brainlayer/wave3a-daemon-source-class-capability.txt"
+QUERY=agent-html DEADLINE_SECS=30 scripts/smoke/firstturn-brainlayer-smoke.sh \
+  | tee "$HOME/.local/share/brainlayer/wave3a-pre-migration-real-mcp-smoke.out"
+```
+
+Do not enter host preflight unless all commands pass. Re-run this section independently on M1; never copy Main's receipt.
+
 ## 1. Host preflight and writer inventory
 
 From the pinned checkout, set only host-local absolute paths:
@@ -54,10 +103,10 @@ From the pinned checkout, set only host-local absolute paths:
 ```bash
 export WAVE3A_REPO="$PWD"
 export WAVE3A_PYTHON="$WAVE3A_REPO/.venv/bin/python"
-export WAVE3A_CLI="$WAVE3A_REPO/.venv/bin/brainlayer"
+export WAVE3A_CLI="$(command -v brainlayer)"
 export PYTHONPATH="$WAVE3A_REPO/src"
 export WAVE3A_DB="$($WAVE3A_PYTHON -c 'from brainlayer.paths import get_db_path; print(get_db_path())')"
-export WAVE3A_SHA="be877608ae5ff14de079ccd40949ef14f88aa578"
+export WAVE3A_SHA="3964412f8291a083150a424e38df08ece817783d"
 export WAVE3A_ACTOR="etan+brainlayerCodex"
 export WAVE3A_HOST="$(hostname -s | tr -cd 'A-Za-z0-9_-')"
 export WAVE3A_RUN_DIR="$HOME/.local/share/brainlayer/wave3-live-2026-08-11/$WAVE3A_HOST"
@@ -67,7 +116,7 @@ test -x "$WAVE3A_CLI"
 test "$(git rev-parse "$WAVE3A_SHA")" = "$WAVE3A_SHA"
 git merge-base --is-ancestor "$WAVE3A_SHA" HEAD
 test -f "$WAVE3A_DB"
-/usr/libexec/PlistBuddy -c 'Print:CFBundleShortVersionString' /Applications/BrainBar.app/Contents/Info.plist
+/usr/libexec/PlistBuddy -c 'Print:CFBundleShortVersionString' /Applications/BrainBar.app/Contents/Info.plist | grep -Fx '1.5.6'
 df -k "$(dirname "$WAVE3A_DB")"
 stat -f '%z' "$WAVE3A_DB"
 stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
@@ -76,10 +125,10 @@ pgrep -af '[b]rain_digest|[b]rainlayer.*digest' && exit 1 || true
 pgrep -af '[b]rainlayer.backup_daily|[b]ackup-daily.sh' && exit 1 || true
 ```
 
-Require more than 40 GiB free, no digest, no concurrent backup, and BrainBar 1.5.4 or later. Record the exact active set before changing launchd:
+Require more than 40 GiB free, no digest, no concurrent backup, and both installed/executing v1.5.6 proofs from §0. Record the exact active set before changing launchd. The broader pattern is intentional: `com.mcplayer.brainlayer-proxy` is a write-capable bridge even though its label does not start with `com.brainlayer`.
 
 ```bash
-launchctl list | awk '$3 ~ /^com\.brainlayer\./ {print $3}' | sort > "$WAVE3A_RUN_DIR/active-labels.before"
+launchctl list | awk '$3 ~ /^(com\.brainlayer\.|com\.mcplayer\.)/ {print $3}' | sort > "$WAVE3A_RUN_DIR/active-labels.before"
 : > "$WAVE3A_RUN_DIR/stopped-labels"
 cat "$WAVE3A_RUN_DIR/active-labels.before"
 grep -Fxq 'com.brainlayer.brainbar-daemon' "$WAVE3A_RUN_DIR/active-labels.before"
@@ -93,17 +142,21 @@ for label in \
   com.brainlayer.throughput-watchdog \
   com.brainlayer.health-check \
   com.brainlayer.backup-daily \
+  com.brainlayer.jsonl-backup \
   com.brainlayer.maintenance-nightly \
   com.brainlayer.maintenance-weekly \
   com.brainlayer.wal-checkpoint \
   com.brainlayer.repair-fts \
   com.brainlayer.decay \
+  com.brainlayer.p0-counter \
   com.brainlayer.index \
   com.brainlayer.watch \
   com.brainlayer.drain \
   com.brainlayer.hotlane-brainbar \
   com.brainlayer.enrichment \
-  com.brainlayer.brainbar; do
+  com.brainlayer.brainbar \
+  com.brainlayer.gemini-loopback \
+  com.mcplayer.brainlayer-proxy; do
   if grep -Fxq "$label" "$WAVE3A_RUN_DIR/active-labels.before"; then
     launchctl bootout "gui/$(id -u)/$label"
     printf '%s\n' "$label" >> "$WAVE3A_RUN_DIR/stopped-labels"
@@ -111,11 +164,29 @@ for label in \
 done
 ```
 
-Confirm no DB-writing process remains. Leave `com.brainlayer.brainbar-daemon` loaded only for the backup-pipeline request.
+`com.mcplayer.bus` may remain loaded: it is the event bus, not the BrainLayer MCP proxy and not a DB writer. Confirm no other DB-writing process or TCP bridge remains. Leave `com.brainlayer.brainbar-daemon` loaded only for the backup-pipeline request.
+
+```bash
+launchctl list | awk '$3 ~ /^(com\.brainlayer\.|com\.mcplayer\.)/ {print $3}' | sort \
+  > "$WAVE3A_RUN_DIR/active-labels.after-stop"
+for label in \
+  com.brainlayer.gemini-loopback \
+  com.brainlayer.p0-counter \
+  com.brainlayer.jsonl-backup \
+  com.brainlayer.watch \
+  com.brainlayer.drain \
+  com.brainlayer.enrichment \
+  com.mcplayer.brainlayer-proxy; do
+  ! grep -Fxq "$label" "$WAVE3A_RUN_DIR/active-labels.after-stop"
+done
+! lsof -nP -iTCP:48123 -sTCP:LISTEN
+pgrep -af '[b]rainlayer.*(watch|drain|enrich|p0-counter|jsonl-backup)' && exit 1 || true
+```
 
 ## 2. Checkpoint
 
 ```bash
+set -o pipefail
 /usr/bin/time -p "$WAVE3A_PYTHON" scripts/wal_checkpoint.py --mode TRUNCATE --retry-busy --json \
   | tee "$WAVE3A_RUN_DIR/checkpoint.json"
 stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
@@ -123,11 +194,52 @@ stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
 
 Stop if the checkpoint reports busy or returns nonzero.
 
-## 3. Primary LIVE backup route: backup pipeline
-
-This is the required Tuesday route. It depends on deployed BrainBar 1.5.4 carrying the core-profile gate fix for `brain_backup_vacuum_into`.
+Start one persistent read-only SQLite observer before either backup route. Its connection records `PRAGMA data_version` before the snapshot and again only after BrainBarDaemon is stopped. Any intervening commit makes the rollback snapshot non-authoritative, so the observer fails the gate and migration must not start.
 
 ```bash
+set -euo pipefail
+export WAVE3A_FENCE_READY="$WAVE3A_RUN_DIR/no-write-observer.ready.json"
+export WAVE3A_FENCE_RELEASE="$WAVE3A_RUN_DIR/no-write-observer.release"
+export WAVE3A_FENCE_RESULT="$WAVE3A_RUN_DIR/no-write-observer.result.json"
+rm -f "$WAVE3A_FENCE_READY" "$WAVE3A_FENCE_RELEASE" "$WAVE3A_FENCE_RESULT"
+"$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_FENCE_READY" "$WAVE3A_FENCE_RELEASE" "$WAVE3A_FENCE_RESULT" <<'PY' &
+import json, os, sqlite3, sys, time
+db, ready, release, result = sys.argv[1:]
+conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=60)
+conn.execute("PRAGMA query_only = ON")
+before = int(conn.execute("PRAGMA data_version").fetchone()[0])
+payload = {"pid": os.getpid(), "data_version_before": before}
+tmp = ready + ".tmp"
+open(tmp, "w", encoding="utf-8").write(json.dumps(payload, sort_keys=True) + "\n")
+os.replace(tmp, ready)
+while not os.path.exists(release):
+    time.sleep(0.05)
+after = int(conn.execute("PRAGMA data_version").fetchone()[0])
+conn.close()
+payload["data_version_after"] = after
+payload["unchanged"] = before == after
+open(result, "w", encoding="utf-8").write(json.dumps(payload, sort_keys=True) + "\n")
+raise SystemExit(0 if before == after else 1)
+PY
+export WAVE3A_FENCE_PID=$!
+cleanup_wave3a_fence() {
+  : > "$WAVE3A_FENCE_RELEASE"
+  wait "$WAVE3A_FENCE_PID" 2>/dev/null || true
+}
+trap cleanup_wave3a_fence EXIT
+while [ ! -f "$WAVE3A_FENCE_READY" ]; do
+  kill -0 "$WAVE3A_FENCE_PID"
+  sleep 0.1
+done
+cat "$WAVE3A_FENCE_READY"
+```
+
+## 3. Primary LIVE backup route: backup pipeline
+
+This is the required Tuesday route. Deployed v1.5.6 includes v1.5.5's backup-race fix and the v1.5.6 Swift source-class gate.
+
+```bash
+set -o pipefail
 export BRAINLAYER_BACKUP_FULL_VERIFY=1
 export BRAINLAYER_BACKUP_SQLITE_CHECK_TIMEOUT_SECONDS=3600
 /usr/bin/time -p "$WAVE3A_PYTHON" - "$WAVE3A_HOST" 2>&1 <<'PY' | tee "$WAVE3A_RUN_DIR/backup-pipeline.out"
@@ -162,9 +274,10 @@ PY
 
 ### Contingency only: rehearsal-proven online backup
 
-Do not choose this branch merely to save time. Use it only if the 1.5.4 backup pipeline fails, after Etan explicitly authorizes the contingency. It was rehearsal-proven with canonical opened `mode=ro`; page retries while drain was writing only stretched wall-clock time.
+Do not choose this branch merely to save time. Use it only if the deployed v1.5.6 backup pipeline fails, after Etan explicitly authorizes the contingency. It was rehearsal-proven with canonical opened `mode=ro`; page retries while drain was writing only stretched wall-clock time.
 
 ```bash
+set -o pipefail
 export WAVE3A_BACKUP_RAW="$WAVE3A_RUN_DIR/online-backup-contingency.db"
 test ! -e "$WAVE3A_BACKUP_RAW"
 /usr/bin/time -p "$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_BACKUP_RAW" <<'PY'
@@ -188,10 +301,16 @@ PY
 After either backup route succeeds, stop the remaining daemon before migration:
 
 ```bash
+set -euo pipefail
 if grep -Fxq 'com.brainlayer.brainbar-daemon' "$WAVE3A_RUN_DIR/active-labels.before"; then
   launchctl bootout "gui/$(id -u)/com.brainlayer.brainbar-daemon"
   printf '%s\n' 'com.brainlayer.brainbar-daemon' >> "$WAVE3A_RUN_DIR/stopped-labels"
 fi
+: > "$WAVE3A_FENCE_RELEASE"
+wait "$WAVE3A_FENCE_PID"
+unset WAVE3A_FENCE_PID
+trap - EXIT
+cat "$WAVE3A_FENCE_RESULT"
 "$WAVE3A_PYTHON" scripts/wal_checkpoint.py --mode TRUNCATE --retry-busy --json \
   | tee "$WAVE3A_RUN_DIR/checkpoint-after-backup.json"
 ```
@@ -201,6 +320,7 @@ fi
 The environment gate is intentionally scoped to this command. Without it the script refuses the configured canonical path.
 
 ```bash
+set -o pipefail
 /usr/bin/time -p env BRAINLAYER_OFFLINE_MIGRATOR_GATED_SWAP=1 \
   "$WAVE3A_PYTHON" scripts/migrate_source_class.py \
   --db "$WAVE3A_DB" \
@@ -219,8 +339,12 @@ Run this read-only receipt query:
 ```bash
 "$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_SHA" <<'PY'
 import json, sqlite3, sys
+import sqlite_vec
 db, expected_sha = sys.argv[1:3]
 c = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+c.enable_load_extension(True)
+c.load_extension(sqlite_vec.loadable_path())
+c.enable_load_extension(False)
 distribution = dict(("NULL" if k is None else k, v) for k, v in c.execute(
     "SELECT source_class, COUNT(*) FROM chunks GROUP BY source_class"
 ))
@@ -236,6 +360,8 @@ receipt = {
     "distribution": distribution,
     "invalid_classes": c.execute("SELECT COUNT(*) FROM chunks WHERE source_class IS NOT NULL AND source_class NOT IN ('cli-agent','desktop','subagent','brain-worker','fleet-coordination')").fetchone()[0],
     "brain_worker_fts_rows": c.execute("SELECT COUNT(*) FROM chunk_fts_rowids r JOIN chunks c ON c.id=r.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
+    "brain_worker_float_vector_rows": c.execute("SELECT COUNT(*) FROM chunk_vectors v JOIN chunks c ON c.id=v.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
+    "brain_worker_binary_vector_rows": c.execute("SELECT COUNT(*) FROM chunk_vectors_binary v JOIN chunks c ON c.id=v.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
     "schema_sha": schema.get("git_sha"),
     "event": event,
 }
@@ -244,6 +370,8 @@ print(json.dumps(receipt, indent=2, sort_keys=True))
 assert receipt["quick_check"] == "ok"
 assert receipt["invalid_classes"] == 0
 assert receipt["brain_worker_fts_rows"] == 0
+assert receipt["brain_worker_float_vector_rows"] == 0
+assert receipt["brain_worker_binary_vector_rows"] == 0
 assert receipt["schema_sha"] == expected_sha
 assert event[0] == expected_sha and event[2] == "success"
 PY
@@ -253,6 +381,7 @@ stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
 Required visibility probes before restart: one exact stored id from each class plus one NULL row. Exact expansion must work for all six; default search must show cli-agent, subagent, fleet-coordination, and NULL, while hiding desktop and brain-worker. The internal desktop opt-in must reveal desktop but never brain-worker:
 
 ```bash
+set -o pipefail
 "$WAVE3A_PYTHON" scripts/verify_source_class_visibility.py --db "$WAVE3A_DB" \
   | tee "$WAVE3A_RUN_DIR/source-class-visibility.json"
 ```
@@ -263,8 +392,18 @@ Restore labels from the saved inventory, except that enrichment remains skipped 
 
 ```bash
 while IFS= read -r label; do
-  if [ "$label" = "com.brainlayer.enrichment" ] && [ -f "$HOME/.local/share/brainlayer/pause.sentinel" ]; then
-    continue
+  if [ "$label" = "com.brainlayer.enrichment" ]; then
+    if "$WAVE3A_PYTHON" - "$label" <<'PY'
+import sys
+from datetime import UTC, datetime
+from brainlayer.pause import DEFAULT_PAUSE_SENTINEL_PATH, pause_applies_to_label, pause_sentinel_state
+label = sys.argv[1]
+payload, active, _stale = pause_sentinel_state(DEFAULT_PAUSE_SENTINEL_PATH, datetime.now(UTC))
+raise SystemExit(0 if active and pause_applies_to_label(payload, label) else 1)
+PY
+    then
+      continue
+    fi
   fi
   plist="$HOME/Library/LaunchAgents/$label.plist"
   test -f "$plist"
@@ -275,9 +414,36 @@ done < <(tail -r "$WAVE3A_RUN_DIR/stopped-labels")
 Then prove the executing binary serves a real request:
 
 ```bash
+set -euo pipefail
 launchctl print "gui/$(id -u)/com.brainlayer.brainbar-daemon" > "$WAVE3A_RUN_DIR/brainbar-daemon.print"
-QUERY=agent-html TIMEOUT_SECONDS=30 scripts/smoke/firstturn-brainlayer-smoke.sh \
-  | tee "$WAVE3A_RUN_DIR/real-mcp-smoke.out"
+export WAVE3A_DAEMON_PID="$(awk '/^[[:space:]]*pid = / {print $3; exit}' "$WAVE3A_RUN_DIR/brainbar-daemon.print")"
+test -n "$WAVE3A_DAEMON_PID"
+ps -p "$WAVE3A_DAEMON_PID" -o command= | tee "$WAVE3A_RUN_DIR/brainbar-daemon.command"
+grep -F '/Applications/BrainBar.app/Contents/MacOS/BrainBarDaemon' "$WAVE3A_RUN_DIR/brainbar-daemon.command"
+shasum -a 256 /Applications/BrainBar.app/Contents/MacOS/BrainBarDaemon \
+  | tee "$WAVE3A_RUN_DIR/brainbar-daemon.sha256"
+"$WAVE3A_PYTHON" - "$WAVE3A_RUN_DIR/source-class-visibility.json" "$WAVE3A_RUN_DIR/live-probes.env" <<'PY'
+import json, shlex, sys
+receipt = json.load(open(sys.argv[1], encoding="utf-8"))
+values = {
+    "WAVE3A_VISIBLE_ID": receipt["cli-agent"]["chunk_id"],
+    "WAVE3A_VISIBLE_TOKEN": receipt["cli-agent"]["token"],
+    "WAVE3A_DESKTOP_ID": receipt["desktop"]["chunk_id"],
+    "WAVE3A_DESKTOP_TOKEN": receipt["desktop"]["token"],
+}
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    for key, value in values.items():
+        handle.write(f"export {key}={shlex.quote(str(value))}\n")
+PY
+source "$WAVE3A_RUN_DIR/live-probes.env"
+QUERY="$WAVE3A_VISIBLE_TOKEN" NUM_RESULTS=100 RAW_OUTPUT_PATH="$WAVE3A_RUN_DIR/real-mcp-visible.raw.jsonl" \
+  DEADLINE_SECS=30 scripts/smoke/firstturn-brainlayer-smoke.sh \
+  | tee "$WAVE3A_RUN_DIR/real-mcp-visible.out"
+grep -F "$WAVE3A_VISIBLE_ID" "$WAVE3A_RUN_DIR/real-mcp-visible.raw.jsonl"
+QUERY="$WAVE3A_DESKTOP_TOKEN" NUM_RESULTS=100 RAW_OUTPUT_PATH="$WAVE3A_RUN_DIR/real-mcp-desktop.raw.jsonl" \
+  DEADLINE_SECS=30 scripts/smoke/firstturn-brainlayer-smoke.sh \
+  | tee "$WAVE3A_RUN_DIR/real-mcp-desktop.out"
+! grep -F "$WAVE3A_DESKTOP_ID" "$WAVE3A_RUN_DIR/real-mcp-desktop.raw.jsonl"
 "$WAVE3A_CLI" search "source class" -n 3 --text \
   | tee "$WAVE3A_RUN_DIR/real-cli-search.out"
 ```
@@ -320,14 +486,15 @@ The PR handoff fills the final-code rerun values here and in the collab append:
 | Check | Measured result |
 |---|---|
 | Canonical source writes | none |
-| Copy route | SQLite online backup; source `mode=ro` |
+| Tuesday LIVE primary route | deployed v1.5.6 backup pipeline; verified local raw snapshot plus uploaded Drive receipt required |
+| Rehearsal-proven contingency | SQLite online backup; source opened `mode=ro` |
 | Contingency online-backup wall-clock | 26.16 seconds under live drain writes; source opened `mode=ro` |
 | Rows before / after | 744,335 / 744,335 |
-| Migration wall-clock | 198.82 seconds (`duration_seconds=198.79003841709346`) |
-| WAL bytes before / observed peak / after | 0 / 29,181,992 / 0 |
-| Distribution | NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 97,678; subagent 37,445 |
-| Ledgers | exact final migration code SHA in both rows |
-| Quick check | `ok` in 503.49 seconds; both ledgers pin `be877608ae5ff14de079ccd40949ef14f88aa578`; zero invalid classes / brain-worker FTS rows |
-| Class visibility / expansion | six source buckets green against real copied rows |
+| Migration wall-clock | 252.02 seconds (`duration_seconds=251.79996774997562`); exact-SHA idempotent rerun 0.65 seconds |
+| WAL bytes before / observed peak / after | 0 / 29,181,992 / 0 in the earlier monitored rehearsal; final-code peak not separately sampled |
+| Distribution | NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 105,383; subagent 29,740 |
+| Ledgers | schema and event rows both pin `3964412f8291a083150a424e38df08ece817783d`; event status `success` |
+| Quick check | `ok` in 712.79 seconds; zero invalid classes; zero brain-worker FTS, float-vector, and binary-vector rows |
+| Class visibility / expansion | six source buckets green against real copied rows; aggregate desktop audit sampled 72 tokens with zero leaked IDs |
 | Rollback | APFS re-copy, 0.00 seconds; 744,335 rows; `source_class` absent |
 | Repository gates | focused 198 passed; broad 3,969 passed / 10 skipped / 62 deselected / 2 xfailed; one unrelated MPS arbitration test separately diagnosed and deselected after a 997.19s no-progress compute call |

--- a/docs/operations/wave3-3a-two-host-live-runbook.md
+++ b/docs/operations/wave3-3a-two-host-live-runbook.md
@@ -10,8 +10,8 @@ This runbook is the source-class segment of the Wave 3 maintenance sitting. Exec
 - Required deployed release before either host migrates: BrainLayer + BrainBar **exactly v1.5.6**. v1.5.5 carries the backup-race fix; v1.5.6 adds the Swift default-search source-class gate.
 - Command: `scripts/migrate_source_class.py` from a checkout containing that commit.
 - Rehearsal source: online SQLite backup from canonical opened `mode=ro` into gitignored `.tmp-wave3-3a/` (contingency route, not the LIVE primary route).
-- Timed contingency replay: 26.16 seconds wall-clock while live drain writes continued; 744,396 rows, 4,251,874 pages, 17,415,675,904 bytes. The pristine rehearsal copy passed `PRAGMA quick_check` before migration.
-- Rehearsal rows: 744,335 before and after.
+- Timed contingency replay: `.tmp-wave3-3a/online-backup-timed.db`, completed 2026-08-10 13:39:47 IDT after 26.16 seconds while live drain writes continued; 744,396 rows, 4,251,874 pages, 17,415,675,904 bytes. This copy proved only the contingency mechanism.
+- Final migration rehearsal source: the earlier APFS clone `.tmp-wave3-3a/canonical-pristine.db`, captured 2026-08-10 12:44:04 IDT with 744,335 rows and a clean `PRAGMA quick_check`. Its migrated copy retained exactly 744,335 rows. The 61-row difference from the later online-backup snapshot is therefore between two independently timestamped live snapshots, not a migration row-count discrepancy.
 - Final-code rehearsal migration: 252.02 seconds wall-clock on commit `3964412f8291a083150a424e38df08ece817783d` (`duration_seconds=251.79996774997562`); exact-SHA idempotent rerun: 0.65 seconds.
 - Rehearsal distribution: NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 105,383; subagent 29,740.
 - Earlier monitored rehearsal migration WAL: 0 bytes before, 29,181,992-byte observed peak, 0 bytes at close after checkpoints; the final-code rerun was not separately peak-sampled.
@@ -70,8 +70,9 @@ fi
 scripts/brainlayer-update-brainbar.sh
 export WAVE3A_INSTALLED_CLI="$(command -v brainlayer)"
 test -x "$WAVE3A_INSTALLED_CLI"
-"$WAVE3A_INSTALLED_CLI" --version | tee "$HOME/.local/share/brainlayer/wave3a-installed-cli-version.txt"
-grep -F "$WAVE3A_REQUIRED_VERSION" "$HOME/.local/share/brainlayer/wave3a-installed-cli-version.txt"
+"$WAVE3A_INSTALLED_CLI" --version | awk '{print $NF}' \
+  | tee "$HOME/.local/share/brainlayer/wave3a-installed-cli-version.txt"
+grep -Fx "$WAVE3A_REQUIRED_VERSION" "$HOME/.local/share/brainlayer/wave3a-installed-cli-version.txt"
 /usr/libexec/PlistBuddy -c 'Print:CFBundleShortVersionString' /Applications/BrainBar.app/Contents/Info.plist \
   | tee "$HOME/.local/share/brainlayer/wave3a-brainbar-version.txt"
 grep -Fx "$WAVE3A_REQUIRED_VERSION" "$HOME/.local/share/brainlayer/wave3a-brainbar-version.txt"
@@ -114,12 +115,21 @@ mkdir -p "$WAVE3A_RUN_DIR"
 test -x "$WAVE3A_PYTHON"
 test -x "$WAVE3A_CLI"
 test "$(git rev-parse "$WAVE3A_SHA")" = "$WAVE3A_SHA"
-git merge-base --is-ancestor "$WAVE3A_SHA" HEAD
+test "$(git rev-parse HEAD)" = "$WAVE3A_SHA"
+test -z "$(git status --porcelain)"
 test -f "$WAVE3A_DB"
 /usr/libexec/PlistBuddy -c 'Print:CFBundleShortVersionString' /Applications/BrainBar.app/Contents/Info.plist | grep -Fx '1.5.6'
 df -k "$(dirname "$WAVE3A_DB")"
 stat -f '%z' "$WAVE3A_DB"
 stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
+export WAVE3A_ROWS_BEFORE="$("$WAVE3A_PYTHON" - "$WAVE3A_DB" <<'PY'
+import sqlite3, sys
+c = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+c.close()
+PY
+)"
+printf '%s\n' "$WAVE3A_ROWS_BEFORE" | tee "$WAVE3A_RUN_DIR/rows-before.txt"
 cat "$HOME/.local/share/brainlayer/pause.sentinel" 2>/dev/null || true
 pgrep -af '[b]rain_digest|[b]rainlayer.*digest' && exit 1 || true
 pgrep -af '[b]rainlayer.backup_daily|[b]ackup-daily.sh' && exit 1 || true
@@ -236,7 +246,7 @@ cat "$WAVE3A_FENCE_READY"
 
 ## 3. Primary LIVE backup route: backup pipeline
 
-This is the required Tuesday route. Deployed v1.5.6 includes v1.5.5's backup-race fix and the v1.5.6 Swift source-class gate.
+This is the required Tuesday route. Deployed v1.5.6 includes v1.5.5's backup-race fix and the v1.5.6 Swift source-class gate. The command enters through Python, but `create_sqlite_backup_artifact()` must send `brain_backup_vacuum_into` over the installed BrainBarDaemon socket; it does not perform SQLite backup locally. A successful terminal tool response plus the validated raw snapshot proves that daemon route executed.
 
 ```bash
 set -o pipefail
@@ -262,13 +272,15 @@ Before migration, require all of the following in the JSON receipt: `backup_log_
 ```bash
 export WAVE3A_BACKUP_RAW="<local_uncompressed_snapshot from receipt>"
 test -f "$WAVE3A_BACKUP_RAW"
-"$WAVE3A_PYTHON" - "$WAVE3A_BACKUP_RAW" <<'PY'
+"$WAVE3A_PYTHON" - "$WAVE3A_BACKUP_RAW" "$WAVE3A_ROWS_BEFORE" <<'PY'
 import sqlite3, sys
-p = sys.argv[1]
+p, expected_rows = sys.argv[1], int(sys.argv[2])
 c = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
-print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+rows = c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+print(rows)
 print(c.execute("PRAGMA quick_check").fetchone()[0])
 c.close()
+assert rows == expected_rows
 PY
 ```
 
@@ -289,12 +301,15 @@ src.backup(dst, pages=4096, sleep=0.050)
 dst.close()
 src.close()
 PY
-"$WAVE3A_PYTHON" - "$WAVE3A_BACKUP_RAW" <<'PY'
+"$WAVE3A_PYTHON" - "$WAVE3A_BACKUP_RAW" "$WAVE3A_ROWS_BEFORE" <<'PY'
 import sqlite3, sys
-c = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
-print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+p, expected_rows = sys.argv[1], int(sys.argv[2])
+c = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+rows = c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+print(rows)
 print(c.execute("PRAGMA quick_check").fetchone()[0])
 c.close()
+assert rows == expected_rows
 PY
 ```
 
@@ -337,10 +352,10 @@ If additional approved Wave 3 migrations are scheduled for the same maintenance 
 Run this read-only receipt query:
 
 ```bash
-"$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_SHA" <<'PY'
+"$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_SHA" "$WAVE3A_ROWS_BEFORE" <<'PY'
 import json, sqlite3, sys
 import sqlite_vec
-db, expected_sha = sys.argv[1:3]
+db, expected_sha, expected_rows = sys.argv[1], sys.argv[2], int(sys.argv[3])
 c = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
 c.enable_load_extension(True)
 c.load_extension(sqlite_vec.loadable_path())
@@ -368,6 +383,7 @@ receipt = {
 c.close()
 print(json.dumps(receipt, indent=2, sort_keys=True))
 assert receipt["quick_check"] == "ok"
+assert receipt["rows"] == expected_rows
 assert receipt["invalid_classes"] == 0
 assert receipt["brain_worker_fts_rows"] == 0
 assert receipt["brain_worker_float_vector_rows"] == 0

--- a/docs/operations/wave3-3a-two-host-live-runbook.md
+++ b/docs/operations/wave3-3a-two-host-live-runbook.md
@@ -1,0 +1,333 @@
+# Wave 3a two-host LIVE runbook
+
+Status: rehearsal-proven; LIVE execution scheduled for Tuesday 2026-08-11 at 20:00 IDT or later with Etan present.
+
+This runbook is the source-class segment of the Wave 3 maintenance sitting. Execute it on Main first, reconcile and probe Main, then repeat it on M1. Do not begin a host without Etan's explicit go. Keep enrichment off wherever the pause sentinel applies.
+
+## Pinned artifacts and rehearsal measurements
+
+- Migration code commit: `be877608ae5ff14de079ccd40949ef14f88aa578`.
+- Command: `scripts/migrate_source_class.py` from a checkout containing that commit.
+- Rehearsal source: online SQLite backup from canonical opened `mode=ro` into gitignored `.tmp-wave3-3a/` (contingency route, not the LIVE primary route).
+- Timed contingency replay: 26.16 seconds wall-clock while live drain writes continued; 744,396 rows, 4,251,874 pages, 17,415,675,904 bytes. The pristine rehearsal copy passed `PRAGMA quick_check` before migration.
+- Rehearsal rows: 744,335 before and after.
+- Rehearsal migration: 198.82 seconds wall-clock on reviewed migration commit `be877608ae5ff14de079ccd40949ef14f88aa578` (`duration_seconds=198.79003841709346`).
+- Rehearsal distribution: NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 97,678; subagent 37,445.
+- Rehearsal migration WAL: 0 bytes before, 29,181,992-byte observed peak, 0 bytes at close after checkpoints.
+- Rehearsal rollback: restore by APFS re-copy in 0.00 seconds; restored row count 744,335 and `source_class` absent.
+
+## Host receipt table
+
+Fill every blank on each host. Do not copy Main values into M1.
+
+| Field | Main | M1 |
+|---|---|---|
+| Operator / Etan go time |  |  |
+| Hostname |  |  |
+| Canonical DB path |  |  |
+| Checked-out commit |  |  |
+| BrainBar version (must be 1.5.4+) |  |  |
+| Free bytes |  |  |
+| Active labels receipt file |  |  |
+| Pause sentinel contents |  |  |
+| Rows before |  |  |
+| WAL bytes before stop |  |  |
+| Checkpoint result / WAL bytes after |  |  |
+| Backup-pipeline JSON receipt |  |  |
+| Verified local raw backup ref |  |  |
+| Verified Drive file id / MD5 |  |  |
+| Backup wall-clock |  |  |
+| Migration wall-clock |  |  |
+| Rows after |  |  |
+| NULL / cli / desktop / subagent / brain-worker / fleet |  |  |
+| Both ledger SHAs |  |  |
+| Migration WAL bytes after |  |  |
+| SQL reconcile |  |  |
+| Real service probes |  |  |
+| Restarted labels |  |  |
+| Etan host acceptance |  |  |
+
+## 1. Host preflight and writer inventory
+
+From the pinned checkout, set only host-local absolute paths:
+
+```bash
+export WAVE3A_REPO="$PWD"
+export WAVE3A_PYTHON="$WAVE3A_REPO/.venv/bin/python"
+export WAVE3A_CLI="$WAVE3A_REPO/.venv/bin/brainlayer"
+export PYTHONPATH="$WAVE3A_REPO/src"
+export WAVE3A_DB="$($WAVE3A_PYTHON -c 'from brainlayer.paths import get_db_path; print(get_db_path())')"
+export WAVE3A_SHA="be877608ae5ff14de079ccd40949ef14f88aa578"
+export WAVE3A_ACTOR="etan+brainlayerCodex"
+export WAVE3A_HOST="$(hostname -s | tr -cd 'A-Za-z0-9_-')"
+export WAVE3A_RUN_DIR="$HOME/.local/share/brainlayer/wave3-live-2026-08-11/$WAVE3A_HOST"
+mkdir -p "$WAVE3A_RUN_DIR"
+test -x "$WAVE3A_PYTHON"
+test -x "$WAVE3A_CLI"
+test "$(git rev-parse "$WAVE3A_SHA")" = "$WAVE3A_SHA"
+git merge-base --is-ancestor "$WAVE3A_SHA" HEAD
+test -f "$WAVE3A_DB"
+/usr/libexec/PlistBuddy -c 'Print:CFBundleShortVersionString' /Applications/BrainBar.app/Contents/Info.plist
+df -k "$(dirname "$WAVE3A_DB")"
+stat -f '%z' "$WAVE3A_DB"
+stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
+cat "$HOME/.local/share/brainlayer/pause.sentinel" 2>/dev/null || true
+pgrep -af '[b]rain_digest|[b]rainlayer.*digest' && exit 1 || true
+pgrep -af '[b]rainlayer.backup_daily|[b]ackup-daily.sh' && exit 1 || true
+```
+
+Require more than 40 GiB free, no digest, no concurrent backup, and BrainBar 1.5.4 or later. Record the exact active set before changing launchd:
+
+```bash
+launchctl list | awk '$3 ~ /^com\.brainlayer\./ {print $3}' | sort > "$WAVE3A_RUN_DIR/active-labels.before"
+: > "$WAVE3A_RUN_DIR/stopped-labels"
+cat "$WAVE3A_RUN_DIR/active-labels.before"
+grep -Fxq 'com.brainlayer.brainbar-daemon' "$WAVE3A_RUN_DIR/active-labels.before"
+```
+
+Stop auto-restart/watchdog labels first, then all DB writers and scheduled maintenance. Do not start enrichment if it was absent or sentinel-paused.
+
+```bash
+for label in \
+  com.brainlayer.tier0-watchdog \
+  com.brainlayer.throughput-watchdog \
+  com.brainlayer.health-check \
+  com.brainlayer.backup-daily \
+  com.brainlayer.maintenance-nightly \
+  com.brainlayer.maintenance-weekly \
+  com.brainlayer.wal-checkpoint \
+  com.brainlayer.repair-fts \
+  com.brainlayer.decay \
+  com.brainlayer.index \
+  com.brainlayer.watch \
+  com.brainlayer.drain \
+  com.brainlayer.hotlane-brainbar \
+  com.brainlayer.enrichment \
+  com.brainlayer.brainbar; do
+  if grep -Fxq "$label" "$WAVE3A_RUN_DIR/active-labels.before"; then
+    launchctl bootout "gui/$(id -u)/$label"
+    printf '%s\n' "$label" >> "$WAVE3A_RUN_DIR/stopped-labels"
+  fi
+done
+```
+
+Confirm no DB-writing process remains. Leave `com.brainlayer.brainbar-daemon` loaded only for the backup-pipeline request.
+
+## 2. Checkpoint
+
+```bash
+/usr/bin/time -p "$WAVE3A_PYTHON" scripts/wal_checkpoint.py --mode TRUNCATE --retry-busy --json \
+  | tee "$WAVE3A_RUN_DIR/checkpoint.json"
+stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
+```
+
+Stop if the checkpoint reports busy or returns nonzero.
+
+## 3. Primary LIVE backup route: backup pipeline
+
+This is the required Tuesday route. It depends on deployed BrainBar 1.5.4 carrying the core-profile gate fix for `brain_backup_vacuum_into`.
+
+```bash
+export BRAINLAYER_BACKUP_FULL_VERIFY=1
+export BRAINLAYER_BACKUP_SQLITE_CHECK_TIMEOUT_SECONDS=3600
+/usr/bin/time -p "$WAVE3A_PYTHON" - "$WAVE3A_HOST" 2>&1 <<'PY' | tee "$WAVE3A_RUN_DIR/backup-pipeline.out"
+import json, sys
+from brainlayer.backup_daily import run_backup
+result = run_backup(
+    date_stamp=f"2026-08-11-wave3a-{sys.argv[1]}",
+    remove_local_after_upload=False,
+)
+print(json.dumps(result, sort_keys=True))
+if not result.get("verified") or not result.get("uploaded"):
+    raise SystemExit(1)
+PY
+tail -n 1 "$HOME/.local/share/brainlayer/logs/backup-daily.log" \
+  | tee "$WAVE3A_RUN_DIR/backup-pipeline.json"
+```
+
+Before migration, require all of the following in the JSON receipt: `backup_log_provenance=real`, `verified=true`, `uploaded=true`, a Drive file id, matching verification checks, and a non-null `local_uncompressed_snapshot`. Assign that exact raw path and verify its row count read-only:
+
+```bash
+export WAVE3A_BACKUP_RAW="<local_uncompressed_snapshot from receipt>"
+test -f "$WAVE3A_BACKUP_RAW"
+"$WAVE3A_PYTHON" - "$WAVE3A_BACKUP_RAW" <<'PY'
+import sqlite3, sys
+p = sys.argv[1]
+c = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+print(c.execute("PRAGMA quick_check").fetchone()[0])
+c.close()
+PY
+```
+
+### Contingency only: rehearsal-proven online backup
+
+Do not choose this branch merely to save time. Use it only if the 1.5.4 backup pipeline fails, after Etan explicitly authorizes the contingency. It was rehearsal-proven with canonical opened `mode=ro`; page retries while drain was writing only stretched wall-clock time.
+
+```bash
+export WAVE3A_BACKUP_RAW="$WAVE3A_RUN_DIR/online-backup-contingency.db"
+test ! -e "$WAVE3A_BACKUP_RAW"
+/usr/bin/time -p "$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_BACKUP_RAW" <<'PY'
+import sqlite3, sys
+source, destination = sys.argv[1:3]
+src = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+dst = sqlite3.connect(destination)
+src.backup(dst, pages=4096, sleep=0.050)
+dst.close()
+src.close()
+PY
+"$WAVE3A_PYTHON" - "$WAVE3A_BACKUP_RAW" <<'PY'
+import sqlite3, sys
+c = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+print(c.execute("PRAGMA quick_check").fetchone()[0])
+c.close()
+PY
+```
+
+After either backup route succeeds, stop the remaining daemon before migration:
+
+```bash
+if grep -Fxq 'com.brainlayer.brainbar-daemon' "$WAVE3A_RUN_DIR/active-labels.before"; then
+  launchctl bootout "gui/$(id -u)/com.brainlayer.brainbar-daemon"
+  printf '%s\n' 'com.brainlayer.brainbar-daemon' >> "$WAVE3A_RUN_DIR/stopped-labels"
+fi
+"$WAVE3A_PYTHON" scripts/wal_checkpoint.py --mode TRUNCATE --retry-busy --json \
+  | tee "$WAVE3A_RUN_DIR/checkpoint-after-backup.json"
+```
+
+## 4. Migrate in one supervised sitting
+
+The environment gate is intentionally scoped to this command. Without it the script refuses the configured canonical path.
+
+```bash
+/usr/bin/time -p env BRAINLAYER_OFFLINE_MIGRATOR_GATED_SWAP=1 \
+  "$WAVE3A_PYTHON" scripts/migrate_source_class.py \
+  --db "$WAVE3A_DB" \
+  --git-sha "$WAVE3A_SHA" \
+  --actor "$WAVE3A_ACTOR" \
+  --batch-size 5000 \
+  | tee "$WAVE3A_RUN_DIR/source-class-migration.json"
+```
+
+If additional approved Wave 3 migrations are scheduled for the same maintenance window, execute their pinned commands now, before reconcile and restart. Never invent or substitute an unpinned 3b/3c command.
+
+## 5. Reconcile and verify
+
+Run this read-only receipt query:
+
+```bash
+"$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_SHA" <<'PY'
+import json, sqlite3, sys
+db, expected_sha = sys.argv[1:3]
+c = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+distribution = dict(("NULL" if k is None else k, v) for k, v in c.execute(
+    "SELECT source_class, COUNT(*) FROM chunks GROUP BY source_class"
+))
+schema = json.loads(c.execute(
+    "SELECT details FROM schema_migrations WHERE name='2026_08_10_source_class_v1'"
+).fetchone()[0])
+event = c.execute(
+    "SELECT commit_hash, actor, status FROM migration_events WHERE id='schema:2026_08_10_source_class_v1'"
+).fetchone()
+receipt = {
+    "quick_check": c.execute("PRAGMA quick_check").fetchone()[0],
+    "rows": c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0],
+    "distribution": distribution,
+    "invalid_classes": c.execute("SELECT COUNT(*) FROM chunks WHERE source_class IS NOT NULL AND source_class NOT IN ('cli-agent','desktop','subagent','brain-worker','fleet-coordination')").fetchone()[0],
+    "brain_worker_fts_rows": c.execute("SELECT COUNT(*) FROM chunk_fts_rowids r JOIN chunks c ON c.id=r.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
+    "schema_sha": schema.get("git_sha"),
+    "event": event,
+}
+c.close()
+print(json.dumps(receipt, indent=2, sort_keys=True))
+assert receipt["quick_check"] == "ok"
+assert receipt["invalid_classes"] == 0
+assert receipt["brain_worker_fts_rows"] == 0
+assert receipt["schema_sha"] == expected_sha
+assert event[0] == expected_sha and event[2] == "success"
+PY
+stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
+```
+
+Required visibility probes before restart: one exact stored id from each class plus one NULL row. Exact expansion must work for all six; default search must show cli-agent, subagent, fleet-coordination, and NULL, while hiding desktop and brain-worker. The internal desktop opt-in must reveal desktop but never brain-worker:
+
+```bash
+"$WAVE3A_PYTHON" scripts/verify_source_class_visibility.py --db "$WAVE3A_DB" \
+  | tee "$WAVE3A_RUN_DIR/source-class-visibility.json"
+```
+
+## 6. Restart exactly the prior active set and probe the real service
+
+Restore labels from the saved inventory, except that enrichment remains skipped when absent before or named by the pause sentinel:
+
+```bash
+while IFS= read -r label; do
+  if [ "$label" = "com.brainlayer.enrichment" ] && [ -f "$HOME/.local/share/brainlayer/pause.sentinel" ]; then
+    continue
+  fi
+  plist="$HOME/Library/LaunchAgents/$label.plist"
+  test -f "$plist"
+  launchctl bootstrap "gui/$(id -u)" "$plist"
+done < <(tail -r "$WAVE3A_RUN_DIR/stopped-labels")
+```
+
+Then prove the executing binary serves a real request:
+
+```bash
+launchctl print "gui/$(id -u)/com.brainlayer.brainbar-daemon" > "$WAVE3A_RUN_DIR/brainbar-daemon.print"
+QUERY=agent-html TIMEOUT_SECONDS=30 scripts/smoke/firstturn-brainlayer-smoke.sh \
+  | tee "$WAVE3A_RUN_DIR/real-mcp-smoke.out"
+"$WAVE3A_CLI" search "source class" -n 3 --text \
+  | tee "$WAVE3A_RUN_DIR/real-cli-search.out"
+```
+
+Stop and rollback if any SQL reconcile, visibility probe, or real-service probe fails.
+
+## 7. Rollback = re-copy the verified backup
+
+Keep all writers stopped. If failure is detected after services were restarted, repeat the stop phase for the saved active set and confirm the database has no writer before continuing. Preserve the failed database rather than deleting it. Re-copy the verified raw backup on the same volume, quick-check the restore candidate, then atomically put it at the canonical path:
+
+```bash
+export WAVE3A_FAILED_DB="$WAVE3A_RUN_DIR/failed-after-wave3a.db"
+export WAVE3A_RESTORE_DB="$(dirname "$WAVE3A_DB")/.brainlayer-wave3a-restore.db"
+test ! -e "$WAVE3A_FAILED_DB"
+test ! -e "$WAVE3A_FAILED_DB-wal"
+test ! -e "$WAVE3A_FAILED_DB-shm"
+test ! -e "$WAVE3A_RESTORE_DB"
+cp -p "$WAVE3A_BACKUP_RAW" "$WAVE3A_RESTORE_DB"
+"$WAVE3A_PYTHON" - "$WAVE3A_RESTORE_DB" <<'PY'
+import sqlite3, sys
+c = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+assert c.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+c.close()
+PY
+if [ -e "$WAVE3A_DB-wal" ]; then mv "$WAVE3A_DB-wal" "$WAVE3A_FAILED_DB-wal"; fi
+if [ -e "$WAVE3A_DB-shm" ]; then mv "$WAVE3A_DB-shm" "$WAVE3A_FAILED_DB-shm"; fi
+mv "$WAVE3A_DB" "$WAVE3A_FAILED_DB"
+mv "$WAVE3A_RESTORE_DB" "$WAVE3A_DB"
+test ! -e "$WAVE3A_DB-wal"
+test ! -e "$WAVE3A_DB-shm"
+```
+
+Checkpoint, restart only the prior active labels, and rerun the real-service probes. Record the rollback wall-clock and restored row count in the host table.
+
+## Rehearsal receipt
+
+The PR handoff fills the final-code rerun values here and in the collab append:
+
+| Check | Measured result |
+|---|---|
+| Canonical source writes | none |
+| Copy route | SQLite online backup; source `mode=ro` |
+| Contingency online-backup wall-clock | 26.16 seconds under live drain writes; source opened `mode=ro` |
+| Rows before / after | 744,335 / 744,335 |
+| Migration wall-clock | 198.82 seconds (`duration_seconds=198.79003841709346`) |
+| WAL bytes before / observed peak / after | 0 / 29,181,992 / 0 |
+| Distribution | NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 97,678; subagent 37,445 |
+| Ledgers | exact final migration code SHA in both rows |
+| Quick check | `ok` in 503.49 seconds; both ledgers pin `be877608ae5ff14de079ccd40949ef14f88aa578`; zero invalid classes / brain-worker FTS rows |
+| Class visibility / expansion | six source buckets green against real copied rows |
+| Rollback | APFS re-copy, 0.00 seconds; 744,335 rows; `source_class` absent |
+| Repository gates | focused 198 passed; broad 3,969 passed / 10 skipped / 62 deselected / 2 xfailed; one unrelated MPS arbitration test separately diagnosed and deselected after a 997.19s no-progress compute call |

--- a/docs/operations/wave3-3a-two-host-live-runbook.md
+++ b/docs/operations/wave3-3a-two-host-live-runbook.md
@@ -7,7 +7,7 @@ This runbook is the source-class segment of the Wave 3 maintenance sitting. Exec
 ## Pinned artifacts and rehearsal measurements
 
 - Migration/source-class code commit: `3964412f8291a083150a424e38df08ece817783d`.
-- Required deployed release before either host migrates: BrainLayer + BrainBar **v1.5.6 or later**. v1.5.5 carries the backup-race fix; v1.5.6 adds the Swift default-search source-class gate.
+- Required deployed release before either host migrates: BrainLayer + BrainBar **exactly v1.5.6**. v1.5.5 carries the backup-race fix; v1.5.6 adds the Swift default-search source-class gate.
 - Command: `scripts/migrate_source_class.py` from a checkout containing that commit.
 - Rehearsal source: online SQLite backup from canonical opened `mode=ro` into gitignored `.tmp-wave3-3a/` (contingency route, not the LIVE primary route).
 - Timed contingency replay: 26.16 seconds wall-clock while live drain writes continued; 744,396 rows, 4,251,874 pages, 17,415,675,904 bytes. The pristine rehearsal copy passed `PRAGMA quick_check` before migration.
@@ -27,7 +27,7 @@ Fill every blank on each host. Do not copy Main values into M1.
 | Hostname |  |  |
 | Canonical DB path |  |  |
 | Checked-out commit |  |  |
-| Installed BrainLayer / BrainBar versions (must be 1.5.6+) |  |  |
+| Installed BrainLayer / BrainBar versions (must be exactly 1.5.6) |  |  |
 | Installed CLI path + SHA-256 |  |  |
 | Executing BrainBarDaemon PID / path + SHA-256 |  |  |
 | Executing daemon `source_class` capability probe |  |  |
@@ -497,4 +497,4 @@ The PR handoff fills the final-code rerun values here and in the collab append:
 | Quick check | `ok` in 712.79 seconds; zero invalid classes; zero brain-worker FTS, float-vector, and binary-vector rows |
 | Class visibility / expansion | six source buckets green against real copied rows; aggregate desktop audit sampled 72 tokens with zero leaked IDs |
 | Rollback | APFS re-copy, 0.00 seconds; 744,335 rows; `source_class` absent |
-| Repository gates | focused 198 passed; broad 3,969 passed / 10 skipped / 62 deselected / 2 xfailed; one unrelated MPS arbitration test separately diagnosed and deselected after a 997.19s no-progress compute call |
+| Repository gates | focused source-class 251 passed; final search/cache 42 passed; additional search scopes 92 passed / 1 xfailed with the protected production-DB latency probe refused by the test-path guard; Swift Database/KG 119 passed; full Swift reached 850 passed / 10 skipped with 7 unrelated timing failures while another lane held 24 deliberate CPU spinners |

--- a/docs/operations/wave3-source-class-review-disposition.md
+++ b/docs/operations/wave3-source-class-review-disposition.md
@@ -1,0 +1,12 @@
+# Wave 3 source-class review disposition
+
+Status: SKIPPED — CodeRabbit CLI returned `rate_limit` (free OSS reset: 10 minutes) on 2026-08-10.
+
+Fallback: completed the CodeRabbit red-team and blue-team prompt reviews against the uncommitted diff.
+
+- HIGH: none.
+- MEDIUM: ordinary workflow and Cursor coding-agent rows retained the interim `ISOLATE` policy, contradicting the approved source-class visibility contract — FIXED by making both searchable `KEEP` sources and updating end-to-end watcher tests.
+- MEDIUM: idempotent migration reruns accepted a different code SHA than the recorded ledger entry — FIXED by rejecting SHA mismatch and adding a regression test.
+- LOW: historical recon rows without readable source JSONL needed a stable path signature — FIXED by recognizing `brain-worker`, `session-miner`, and `weave` path segments under `subagents`.
+
+Verification: focused policy, migration, watcher, queue/drain, upsert, and retro-quarantine suites pass after dispositions.

--- a/docs/operations/wave3-source-class-review-disposition.md
+++ b/docs/operations/wave3-source-class-review-disposition.md
@@ -1,6 +1,6 @@
 # Wave 3 source-class review disposition
 
-Status: SKIPPED — CodeRabbit CLI returned `rate_limit` (free OSS reset: 10 minutes) on 2026-08-10.
+Status: COMPLETE — the first CodeRabbit CLI attempt returned `rate_limit`; the retry reviewed the exact branch diff against `origin/main` on 2026-08-10.
 
 Fallback: completed the CodeRabbit red-team and blue-team prompt reviews against the uncommitted diff.
 
@@ -10,3 +10,11 @@ Fallback: completed the CodeRabbit red-team and blue-team prompt reviews against
 - LOW: historical recon rows without readable source JSONL needed a stable path signature — FIXED by recognizing `brain-worker`, `session-miner`, and `weave` path segments under `subagents`.
 
 Verification: focused policy, migration, watcher, queue/drain, upsert, and retro-quarantine suites pass after dispositions.
+
+The exact-diff retry reported three additional valid findings:
+
+- MAJOR: rollback did not relocate canonical WAL/SHM sidecars before installing the restored DB — FIXED in the runbook, including an assertion that neither canonical sidecar remains.
+- MAJOR: malformed JSON or invalid distribution in the idempotent migration branch leaked its SQLite connection — FIXED with unconditional cleanup and a RED-first malformed-ledger regression test.
+- MINOR: `sqlite3.total_changes` overcounted logical FTS deletions and omitted `chunk_fts_rowids` from the receipt — FIXED with count-before-delete across all four tables and RED-first receipt assertions.
+
+Verification after the retry: focused migration suite passes 6/6; runbook shell blocks parse with `bash -n`; final reviewed migration commit is rehearsed separately and pinned by exact SHA in both ledgers.

--- a/docs/operations/wave3-source-class-review-disposition.md
+++ b/docs/operations/wave3-source-class-review-disposition.md
@@ -18,3 +18,19 @@ The exact-diff retry reported three additional valid findings:
 - MINOR: `sqlite3.total_changes` overcounted logical FTS deletions and omitted `chunk_fts_rowids` from the receipt — FIXED with count-before-delete across all four tables and RED-first receipt assertions.
 
 Verification after the retry: focused migration suite passes 6/6; runbook shell blocks parse with `bash -n`; final reviewed migration commit is rehearsed separately and pinned by exact SHA in both ledgers.
+
+## Hosted Codex and pair-review MUST_FIX disposition
+
+- FIXED: the fleet's executing Swift path now applies the same default visibility contract in `BrainDatabase` FTS and candidate searches. Desktop and brain-worker rows are hidden, NULL remains visible, and schema-absent compatibility keeps v1.5.6 safe to deploy before migration.
+- FIXED: source role is derived from durable attribution/provenance and exact paths, never from an arbitrary content mention. Historical `provenance_class=recon-agent` remains authoritative as brain-worker even if its source JSONL is no longer readable.
+- FIXED: brain-worker migration cleanup removes FTS, float-vector, and binary-vector index rows. The migrator and runbook verifier explicitly load vec0 before touching the virtual vector tables.
+- FIXED: KNN candidate expansion counts only source-class-eligible vector rows, for both float and binary arms, so hidden rows do not exhaust the overfetch budget.
+- FIXED: source-class values are exact-taxonomy validated at index, vector upsert, drain, and replay boundaries; replay now restores the class.
+- FIXED: watcher direct INSERT guards on column presence. The LIVE runbook requires v1.5.6 install, restart, executing-binary path/hash/capability probes, then writer stop, backup, and migration on each host. Migrating before that deploy proof is forbidden.
+- FIXED: writer inventory covers `com.brainlayer.*` plus `com.mcplayer.*`; the stop/assert list includes gemini-loopback, p0-counter, jsonl-backup, and the BrainLayer proxy/TCP bridge.
+- FIXED: rollback authority is proven by one persistent read-only connection comparing `PRAGMA data_version` before backup and only after the remaining daemon is stopped. Pipeline failures propagate under `pipefail`.
+- FIXED: pause-sentinel parsing matches the exact active label; worktree/package project parsing no longer mislabels fleet coordination; the aggregate desktop verifier cannot pass on a single convenient row.
+- NOT ADOPTED: classifying role from migration-row content. The project letter requires class at ingest, and arbitrary content can mention a role without being that role; durable attribution/provenance is the authoritative signal.
+- DEFERRED (nonblocking N3): retry attempts still overwrite the fixed migration-event row rather than retaining a separate per-attempt audit history. The successful immutable schema ledger and final success event remain exact-SHA pinned; adding an attempt-history table is outside this migration's gate.
+
+Final real-copy evidence at `3964412f8291a083150a424e38df08ece817783d`: 744,335 rows preserved; 84 brain-workers retained as class but removed from all search indexes; six-bucket visibility/expansion green; aggregate desktop audit sampled 72 tokens with no leak; `PRAGMA quick_check=ok`; exact-SHA idempotent rerun green.

--- a/docs/operations/wave3-source-class-review-disposition.md
+++ b/docs/operations/wave3-source-class-review-disposition.md
@@ -34,3 +34,11 @@ Verification after the retry: focused migration suite passes 6/6; runbook shell 
 - DEFERRED (nonblocking N3): retry attempts still overwrite the fixed migration-event row rather than retaining a separate per-attempt audit history. The successful immutable schema ledger and final success event remain exact-SHA pinned; adding an attempt-history table is outside this migration's gate.
 
 Final real-copy evidence at `3964412f8291a083150a424e38df08ece817783d`: 744,335 rows preserved; 84 brain-workers retained as class but removed from all search indexes; six-bucket visibility/expansion green; aggregate desktop audit sampled 72 tokens with no leak; `PRAGMA quick_check=ok`; exact-SHA idempotent rerun green.
+
+## Final local CodeRabbit exact-diff disposition
+
+- MAJOR: Swift exact-ID search bypassed the searchable clause — FIXED. Default `search()` exact-ID lookups now hide desktop and brain-worker; `expandChunk` remains the explicit exact-expansion path for every class.
+- MAJOR: the BrainBar helper fast profile suppressed KNN retry even when hidden source-class rows exhausted the initial 400 candidates — FIXED. It preserves the bounded first attempt and permits only the existing source-class-aware retry.
+- MAJOR: a 60-second hybrid cache entry could survive a cross-process NULL-to-desktop class update — FIXED. Every entry records SQLite `data_version` and is returned only when the current value matches.
+- MINOR: raw MCP smoke receipts inherited caller umask — FIXED. New and existing output files are forced to mode 0600 before the response is written; a real socket smoke verified the mode.
+- MINOR: the prose allowed later v1.5.6+ releases while preflight required exact 1.5.6 — FIXED by making this scheduled Tuesday run require exact v1.5.6 consistently.

--- a/scripts/migrate_source_class.py
+++ b/scripts/migrate_source_class.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Run the supervised source_class migration on an offline database copy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from brainlayer.source_class_migration import migrate_source_class
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, required=True, help="offline database copy")
+    parser.add_argument("--git-sha", required=True, help="exact 40-character migration commit SHA")
+    parser.add_argument("--actor", required=True, help="operator identity for the ledger")
+    parser.add_argument("--batch-size", type=int, default=5_000)
+    args = parser.parse_args()
+    receipt = migrate_source_class(
+        args.db,
+        git_sha=args.git_sha,
+        actor=args.actor,
+        batch_size=args.batch_size,
+    )
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -158,6 +158,24 @@ map_changed_files_to_pytests() {
           fi
         done
         ;;
+      src/brainlayer/vector_store.py|src/brainlayer/search_repo.py)
+        for rel in test_source_class.py test_vector_store_schema_flags.py test_vector_store_upsert_transactions.py; do
+          test_path="$TEST_ROOT/$rel"
+          if [ -f "$test_path" ]; then
+            append_unique "$test_path"
+            mapped=1
+          fi
+        done
+        ;;
+      src/brainlayer/index_new.py)
+        for rel in test_source_class.py test_ingest_t3.py test_context_pipeline.py; do
+          test_path="$TEST_ROOT/$rel"
+          if [ -f "$test_path" ]; then
+            append_unique "$test_path"
+            mapped=1
+          fi
+        done
+        ;;
       tests/*.py|tests/**/*.py)
         test_path="$TEST_ROOT/${changed#tests/}"
         if [ -f "$test_path" ]; then

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -159,7 +159,7 @@ map_changed_files_to_pytests() {
         done
         ;;
       src/brainlayer/vector_store.py|src/brainlayer/search_repo.py)
-        for rel in test_source_class.py test_vector_store_schema_flags.py test_vector_store_upsert_transactions.py; do
+        for rel in test_source_class.py test_vector_store_schema_flags.py test_vector_store_upsert_transactions.py test_hybrid_search.py test_vector_store_readonly.py test_search_trigram_fts.py test_precompact_chunk_origin.py; do
           test_path="$TEST_ROOT/$rel"
           if [ -f "$test_path" ]; then
             append_unique "$test_path"

--- a/scripts/smoke/firstturn-brainlayer-smoke.sh
+++ b/scripts/smoke/firstturn-brainlayer-smoke.sh
@@ -61,7 +61,15 @@ if [[ -z "$out" ]]; then
 fi
 
 if [[ -n "$RAW_OUTPUT_PATH" ]]; then
-  printf '%s\n' "$out" > "$RAW_OUTPUT_PATH"
+  if [[ -e "$RAW_OUTPUT_PATH" ]]; then
+    chmod 600 "$RAW_OUTPUT_PATH"
+  fi
+  (
+    umask 077
+    : > "$RAW_OUTPUT_PATH"
+    chmod 600 "$RAW_OUTPUT_PATH"
+    printf '%s\n' "$out" > "$RAW_OUTPUT_PATH"
+  )
 fi
 
 if [[ "$rc" -eq 124 ]]; then

--- a/scripts/smoke/firstturn-brainlayer-smoke.sh
+++ b/scripts/smoke/firstturn-brainlayer-smoke.sh
@@ -8,12 +8,21 @@
 # Environment:
 #   DEADLINE_SECS=8    Response deadline for tools/list + query
 #   QUERY=agent-html   Query passed to brain_search
+#   NUM_RESULTS=1      brain_search result limit
+#   RAW_OUTPUT_PATH=   Optional file receiving the raw JSON-RPC response
 
 set -euo pipefail
 
 SOCK="${1:-/tmp/brainbar.sock}"
 DEADLINE_SECS="${DEADLINE_SECS:-8}"
 QUERY="${QUERY:-agent-html}"
+NUM_RESULTS="${NUM_RESULTS:-1}"
+RAW_OUTPUT_PATH="${RAW_OUTPUT_PATH:-}"
+
+if [[ ! "$NUM_RESULTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "FAIL: NUM_RESULTS must be a positive integer"
+  exit 2
+fi
 
 for cmd in date grep python3 socat timeout; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -32,7 +41,7 @@ init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 inited='{"jsonrpc":"2.0","method":"notifications/initialized"}'
 listtools='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 json_query="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$QUERY")"
-callsearch='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"brain_search","arguments":{"query":'"$json_query"',"num_results":1}}}'
+callsearch='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"brain_search","arguments":{"query":'"$json_query"',"num_results":'"$NUM_RESULTS"'}}}'
 
 echo "== first-turn BrainLayer smoke =="
 echo "socket: $SOCK   deadline: ${DEADLINE_SECS}s   query: $QUERY"
@@ -49,6 +58,10 @@ elapsed=$((end - start))
 if [[ -z "$out" ]]; then
   echo "FAIL: no output from MCP socket (rc=$rc, ${elapsed}s)"
   exit 2
+fi
+
+if [[ -n "$RAW_OUTPUT_PATH" ]]; then
+  printf '%s\n' "$out" > "$RAW_OUTPUT_PATH"
 fi
 
 if [[ "$rc" -eq 124 ]]; then

--- a/scripts/verify_source_class_visibility.py
+++ b/scripts/verify_source_class_visibility.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Verify source-class search visibility and exact expansion on a migrated DB."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from brainlayer.vector_store import VectorStore
+
+VISIBLE_CLASSES = ("cli-agent", "subagent", "fleet-coordination")
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9]{7,}")
+
+
+def _ids(result: dict[str, list]) -> set[str]:
+    return set(result.get("ids", [[]])[0])
+
+
+def _candidate_rows(store: VectorStore, source_class: str | None) -> list[tuple[str, str]]:
+    predicate = "c.source_class IS NULL" if source_class is None else "c.source_class = ?"
+    params = () if source_class is None else (source_class,)
+    return list(
+        store.conn.cursor().execute(
+            f"""
+            SELECT c.id, c.content
+            FROM chunks c
+            JOIN chunk_fts_rowids r ON r.chunk_id = c.id
+            WHERE {predicate}
+              AND COALESCE(c.archived, 0) = 0
+              AND c.superseded_by IS NULL
+              AND c.aggregated_into IS NULL
+              AND c.archived_at IS NULL
+              AND LENGTH(COALESCE(c.content, '')) >= 16
+            ORDER BY c.rowid
+            LIMIT 250
+            """,
+            params,
+        )
+    )
+
+
+def _find_search_probe(store: VectorStore, source_class: str | None) -> dict[str, object]:
+    expected_default = source_class in VISIBLE_CLASSES or source_class is None
+    expected_opt_in = source_class != "brain-worker"
+    for chunk_id, content in _candidate_rows(store, source_class):
+        for token in dict.fromkeys(_TOKEN_RE.findall(content)):
+            count_row = (
+                store.conn.cursor()
+                .execute(
+                    "SELECT COUNT(*) FROM chunks_fts WHERE chunks_fts MATCH ?",
+                    (token,),
+                )
+                .fetchone()
+            )
+            if count_row is None or not 1 <= int(count_row[0]) <= 50:
+                continue
+            default_ids = _ids(
+                store.search(
+                    query_text=token,
+                    n_results=100,
+                    include_audit=True,
+                    include_operational=True,
+                    include_checkpoints=True,
+                )
+            )
+            opt_in_ids = _ids(
+                store.search(
+                    query_text=token,
+                    n_results=100,
+                    include_audit=True,
+                    include_operational=True,
+                    include_checkpoints=True,
+                    include_hidden_source_classes=True,
+                )
+            )
+            if (chunk_id in default_ids) != expected_default:
+                continue
+            if (chunk_id in opt_in_ids) != expected_opt_in:
+                continue
+            return {
+                "chunk_id": chunk_id,
+                "token": token,
+                "default_visible": chunk_id in default_ids,
+                "desktop_opt_in_visible": chunk_id in opt_in_ids,
+            }
+    label = "NULL" if source_class is None else source_class
+    raise RuntimeError(f"could not find a deterministic FTS visibility probe for {label}")
+
+
+def verify(db_path: Path) -> dict[str, object]:
+    store = VectorStore(db_path.expanduser().resolve(), readonly=True)
+    try:
+        receipt: dict[str, object] = {}
+        for source_class in (*VISIBLE_CLASSES, "desktop", None):
+            label = "NULL" if source_class is None else source_class
+            probe = _find_search_probe(store, source_class)
+            context = store.get_context(str(probe["chunk_id"]), include_audit=True, include_checkpoints=True)
+            probe["exact_expansion"] = (context.get("target") or {}).get("id") == probe["chunk_id"]
+            if not probe["exact_expansion"]:
+                raise RuntimeError(f"exact expansion failed for {label}")
+            receipt[label] = probe
+
+        brain_worker_row = (
+            store.conn.cursor()
+            .execute("SELECT id FROM chunks WHERE source_class = 'brain-worker' ORDER BY rowid LIMIT 1")
+            .fetchone()
+        )
+        if brain_worker_row is None:
+            raise RuntimeError("no brain-worker row exists for exact-expansion verification")
+        brain_worker_id = str(brain_worker_row[0])
+        context = store.get_context(brain_worker_id, include_audit=True, include_checkpoints=True)
+        fts_count = int(
+            store.conn.cursor()
+            .execute("SELECT COUNT(*) FROM chunk_fts_rowids WHERE chunk_id = ?", (brain_worker_id,))
+            .fetchone()[0]
+        )
+        if (context.get("target") or {}).get("id") != brain_worker_id or fts_count != 0:
+            raise RuntimeError("brain-worker must expand exactly while remaining outside search indexes")
+        receipt["brain-worker"] = {
+            "chunk_id": brain_worker_id,
+            "default_visible": False,
+            "desktop_opt_in_visible": False,
+            "exact_expansion": True,
+            "fts_rows": fts_count,
+        }
+        return receipt
+    finally:
+        store.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, required=True)
+    args = parser.parse_args()
+    print(json.dumps(verify(args.db), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_source_class_visibility.py
+++ b/scripts/verify_source_class_visibility.py
@@ -95,6 +95,51 @@ def _find_search_probe(store: VectorStore, source_class: str | None) -> dict[str
     raise RuntimeError(f"could not find a deterministic FTS visibility probe for {label}")
 
 
+def _audit_hidden_class_default_visibility(store: VectorStore, source_class: str) -> dict[str, object]:
+    """Fail on any hidden-class id returned by the sampled default-search corpus."""
+    checked_tokens: set[str] = set()
+    leaked_ids: set[str] = set()
+    cursor = store.conn.cursor()
+    for _chunk_id, content in _candidate_rows(store, source_class):
+        for token in dict.fromkeys(_TOKEN_RE.findall(content)):
+            if token in checked_tokens:
+                continue
+            count_row = cursor.execute(
+                "SELECT COUNT(*) FROM chunks_fts WHERE chunks_fts MATCH ?",
+                (token,),
+            ).fetchone()
+            if count_row is None or not 1 <= int(count_row[0]) <= 50:
+                continue
+            checked_tokens.add(token)
+            result_ids = _ids(
+                store.search(
+                    query_text=token,
+                    n_results=100,
+                    include_audit=True,
+                    include_operational=True,
+                    include_checkpoints=True,
+                )
+            )
+            if result_ids:
+                placeholders = ",".join("?" for _ in result_ids)
+                leaked_ids.update(
+                    str(row[0])
+                    for row in cursor.execute(
+                        f"SELECT id FROM chunks WHERE source_class = ? AND id IN ({placeholders})",
+                        (source_class, *sorted(result_ids)),
+                    )
+                )
+            if len(checked_tokens) >= 250:
+                break
+        if len(checked_tokens) >= 250:
+            break
+    if not checked_tokens:
+        raise RuntimeError(f"could not build aggregate visibility audit for {source_class}")
+    if leaked_ids:
+        raise RuntimeError(f"{source_class} default-search leak: {sorted(leaked_ids)[:20]}")
+    return {"sampled_tokens": len(checked_tokens), "leaked_ids": []}
+
+
 def verify(db_path: Path) -> dict[str, object]:
     store = VectorStore(db_path.expanduser().resolve(), readonly=True)
     try:
@@ -108,6 +153,8 @@ def verify(db_path: Path) -> dict[str, object]:
                 raise RuntimeError(f"exact expansion failed for {label}")
             receipt[label] = probe
 
+        receipt["desktop"]["aggregate_default_visibility"] = _audit_hidden_class_default_visibility(store, "desktop")
+
         brain_worker_row = (
             store.conn.cursor()
             .execute("SELECT id FROM chunks WHERE source_class = 'brain-worker' ORDER BY rowid LIMIT 1")
@@ -117,19 +164,34 @@ def verify(db_path: Path) -> dict[str, object]:
             raise RuntimeError("no brain-worker row exists for exact-expansion verification")
         brain_worker_id = str(brain_worker_row[0])
         context = store.get_context(brain_worker_id, include_audit=True, include_checkpoints=True)
-        fts_count = int(
-            store.conn.cursor()
-            .execute("SELECT COUNT(*) FROM chunk_fts_rowids WHERE chunk_id = ?", (brain_worker_id,))
-            .fetchone()[0]
-        )
-        if (context.get("target") or {}).get("id") != brain_worker_id or fts_count != 0:
+        tables = {
+            str(row[0])
+            for row in store.conn.cursor().execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")
+        }
+        index_counts = {}
+        for table in (
+            "chunks_fts",
+            "chunks_fts_operational",
+            "chunks_fts_trigram",
+            "chunk_fts_rowids",
+            "chunk_vectors",
+            "chunk_vectors_binary",
+        ):
+            if table not in tables:
+                continue
+            index_counts[table] = int(
+                store.conn.cursor()
+                .execute(f'SELECT COUNT(*) FROM "{table}" WHERE chunk_id = ?', (brain_worker_id,))
+                .fetchone()[0]
+            )
+        if (context.get("target") or {}).get("id") != brain_worker_id or any(index_counts.values()):
             raise RuntimeError("brain-worker must expand exactly while remaining outside search indexes")
         receipt["brain-worker"] = {
             "chunk_id": brain_worker_id,
             "default_visible": False,
             "desktop_opt_in_visible": False,
             "exact_expansion": True,
-            "fts_rows": fts_count,
+            "index_rows": index_counts,
         }
         return receipt
     finally:

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -20,6 +20,7 @@ from .t3_provenance import T3_APP_SESSION, is_t3_app_initiated_codex_session
 
 SearchPolicy = Literal["KEEP", "ISOLATE", "OUT"]
 EffectiveVisibility = Literal["default", "operational", "cold"]
+SourceClass = Literal["cli-agent", "desktop", "subagent", "brain-worker", "fleet-coordination"]
 
 RECON_BRAIN_WORKER_RE = re.compile(r"\bbrain[-_ ]?worker\b", re.IGNORECASE)
 RECON_WEAVE_RE = re.compile(r"(?<!\w)/weave\b|\bweave[-_ ]+(?:worker|agent|recon)\b", re.IGNORECASE)
@@ -49,6 +50,7 @@ class ProvenanceDecision:
     provenance_tag: str
     search_policy: SearchPolicy
     reason: str
+    source_class: SourceClass | None
 
 
 def _abspath(source_file: str | Path) -> Path:
@@ -154,33 +156,73 @@ def classify_provenance(
         )
     )
     if is_t3_app_session:
-        return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session")
+        return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session", "desktop")
 
     if has_recon_agent_signature(content) or _has_recon_path_signature(path):
-        return ProvenanceDecision("recon-agent", "OUT", "recon Agent-tool signature wins precedence")
+        return ProvenanceDecision("recon-agent", "OUT", "recon Agent-tool signature wins precedence", "brain-worker")
 
     if _has_segment(path, "wf_*"):
-        return ProvenanceDecision("workflow-agent", "ISOLATE", "workflow wf_* path segment")
+        repo = _repo_from_project_segment(_project_segment(path))
+        source_class: SourceClass = "fleet-coordination" if repo in FLEET_REPOS else "subagent"
+        return ProvenanceDecision("workflow-agent", "KEEP", "ordinary workflow subagent", source_class)
 
     if _under_provider_sessions(path, ".codex"):
-        return ProvenanceDecision("codex-session", "KEEP", "Codex session root stays searchable")
+        return ProvenanceDecision("codex-session", "KEEP", "Codex session root stays searchable", "cli-agent")
 
     if _under_cursor_agent_transcripts(path):
-        return ProvenanceDecision("cursor-gather", "ISOLATE", "Cursor agent-transcripts root")
+        return ProvenanceDecision("cursor-gather", "KEEP", "Cursor coding-agent transcript root", "cli-agent")
 
     if _under_provider_sessions(path, ".gemini"):
-        return ProvenanceDecision("gemini-session", "KEEP", "Gemini session root stays searchable")
+        return ProvenanceDecision("gemini-session", "KEEP", "Gemini session root stays searchable", "cli-agent")
 
     if _is_subagent(path):
         repo = _repo_from_project_segment(_project_segment(path))
         if repo in FLEET_REPOS:
-            return ProvenanceDecision("fleet-subagent", "KEEP", f"fleet subagent project token {repo}")
-        return ProvenanceDecision("product-subagent", "KEEP", "non-fleet product subagent")
+            return ProvenanceDecision(
+                "fleet-subagent", "KEEP", f"fleet subagent project token {repo}", "fleet-coordination"
+            )
+        return ProvenanceDecision("product-subagent", "KEEP", "non-fleet product subagent", "subagent")
 
     if _is_direct_claude_session(path):
-        return ProvenanceDecision("direct-session", "KEEP", "direct/control Claude session")
+        return ProvenanceDecision("direct-session", "KEEP", "direct/control Claude session", "cli-agent")
 
-    return ProvenanceDecision("unknown", "KEEP", "no agent provenance rule matched")
+    return ProvenanceDecision("unknown", "KEEP", "no agent provenance rule matched", None)
+
+
+def derive_source_class(
+    source_file: str,
+    *,
+    provenance_class: str | None = None,
+    source: str | None = None,
+    content: str | None = None,
+) -> SourceClass | None:
+    """Return the five-value source class only when provenance is unambiguous."""
+    provenance_map: dict[str, SourceClass] = {
+        T3_APP_SESSION: "desktop",
+        "t3-thread": "desktop",
+        "recon-agent": "brain-worker",
+        "fleet-subagent": "fleet-coordination",
+        "product-subagent": "subagent",
+        "codex-session": "cli-agent",
+        "cursor-gather": "cli-agent",
+        "gemini-session": "cli-agent",
+        "direct-session": "cli-agent",
+    }
+    if provenance_class in provenance_map:
+        return provenance_map[provenance_class]
+    path_class = classify_provenance(
+        source_file,
+        content=content,
+        t3_linked_session_ids=set(),
+    ).source_class
+    if path_class is not None:
+        return path_class
+    normalized_source = str(source or "").strip().casefold().replace("-", "_")
+    if normalized_source in {"t3", "chatgpt", "claude_desktop", "gemini_desktop"}:
+        return "desktop"
+    if normalized_source in {"claude_code", "codex", "gemini_cli", "cursor", "antigravity"}:
+        return "cli-agent"
+    return None
 
 
 def effective_visibility(decision: ProvenanceDecision, content_class: str | None) -> EffectiveVisibility:

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -12,15 +12,16 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from .content_class import normalize_content_class
-from .ingest_denylist import is_denylisted
+from .ingest_denylist import is_denylisted, memory_reader_attribution
 from .t3_provenance import T3_APP_SESSION, is_t3_app_initiated_codex_session
 
 SearchPolicy = Literal["KEEP", "ISOLATE", "OUT"]
 EffectiveVisibility = Literal["default", "operational", "cold"]
 SourceClass = Literal["cli-agent", "desktop", "subagent", "brain-worker", "fleet-coordination"]
+SOURCE_CLASSES = frozenset({"cli-agent", "desktop", "subagent", "brain-worker", "fleet-coordination"})
 
 RECON_BRAIN_WORKER_RE = re.compile(r"\bbrain[-_ ]?worker\b", re.IGNORECASE)
 RECON_WEAVE_RE = re.compile(r"(?<!\w)/weave\b|\bweave[-_ ]+(?:worker|agent|recon)\b", re.IGNORECASE)
@@ -93,8 +94,13 @@ def _repo_from_project_segment(segment: str | None) -> str | None:
     for marker in ("-Gits-", "--config-"):
         if marker not in normalized:
             continue
-        repo = normalized.rsplit(marker, 1)[-1].strip("-")
-        return repo.casefold() if repo else None
+        repo = normalized.rsplit(marker, 1)[-1].strip("-").casefold()
+        if not repo:
+            return None
+        for fleet_repo in sorted(FLEET_REPOS, key=len, reverse=True):
+            if repo == fleet_repo or repo.startswith(f"{fleet_repo}-"):
+                return fleet_repo
+        return repo
     return normalized.rsplit("-", 1)[-1].casefold() if normalized else None
 
 
@@ -123,7 +129,7 @@ def has_recon_agent_signature(content: str | None) -> bool:
 def _has_recon_path_signature(path: Path) -> bool:
     markers = {"brain-worker", "session-miner", "weave"}
     parts = path.parts
-    marker_indexes = [index for index, part in enumerate(parts) if part in markers]
+    marker_indexes = [index for index, part in enumerate(parts) if part.casefold().replace("_", "-") in markers]
     if not marker_indexes:
         return False
 
@@ -158,8 +164,9 @@ def classify_provenance(
     if is_t3_app_session:
         return ProvenanceDecision(T3_APP_SESSION, "KEEP", "T3 runtime cursor links Codex session", "desktop")
 
-    if has_recon_agent_signature(content) or _has_recon_path_signature(path):
-        return ProvenanceDecision("recon-agent", "OUT", "recon Agent-tool signature wins precedence", "brain-worker")
+    del content
+    if memory_reader_attribution(path) is not None or _has_recon_path_signature(path):
+        return ProvenanceDecision("recon-agent", "OUT", "memory-reader attribution wins precedence", "brain-worker")
 
     if _has_segment(path, "wf_*"):
         repo = _repo_from_project_segment(_project_segment(path))
@@ -200,7 +207,6 @@ def derive_source_class(
     provenance_map: dict[str, SourceClass] = {
         T3_APP_SESSION: "desktop",
         "t3-thread": "desktop",
-        "recon-agent": "brain-worker",
         "fleet-subagent": "fleet-coordination",
         "product-subagent": "subagent",
         "codex-session": "cli-agent",
@@ -208,6 +214,10 @@ def derive_source_class(
         "gemini-session": "cli-agent",
         "direct-session": "cli-agent",
     }
+    if provenance_class == "recon-agent":
+        decision = classify_provenance(source_file, t3_linked_session_ids=set())
+        if decision.source_class is not None:
+            return decision.source_class
     if provenance_class in provenance_map:
         return provenance_map[provenance_class]
     path_class = classify_provenance(
@@ -223,6 +233,27 @@ def derive_source_class(
     if normalized_source in {"claude_code", "codex", "gemini_cli", "cursor", "antigravity"}:
         return "cli-agent"
     return None
+
+
+def normalize_source_class(value: object) -> SourceClass | None:
+    """Accept only an exact member of the five-value taxonomy."""
+    normalized = str(value or "").strip()
+    return cast(SourceClass, normalized) if normalized in SOURCE_CLASSES else None
+
+
+def resolve_source_class(
+    source_file: str,
+    *,
+    supplied_source_class: object = None,
+    provenance_class: str | None = None,
+    source: str | None = None,
+) -> SourceClass | None:
+    """Prefer independently derived provenance; use only a valid supplied fallback."""
+    return derive_source_class(
+        source_file,
+        provenance_class=provenance_class,
+        source=source,
+    ) or normalize_source_class(supplied_source_class)
 
 
 def effective_visibility(decision: ProvenanceDecision, content_class: str | None) -> EffectiveVisibility:

--- a/src/brainlayer/agent_provenance.py
+++ b/src/brainlayer/agent_provenance.py
@@ -207,6 +207,7 @@ def derive_source_class(
     provenance_map: dict[str, SourceClass] = {
         T3_APP_SESSION: "desktop",
         "t3-thread": "desktop",
+        "recon-agent": "brain-worker",
         "fleet-subagent": "fleet-coordination",
         "product-subagent": "subagent",
         "codex-session": "cli-agent",
@@ -214,10 +215,6 @@ def derive_source_class(
         "gemini-session": "cli-agent",
         "direct-session": "cli-agent",
     }
-    if provenance_class == "recon-agent":
-        decision = classify_provenance(source_file, t3_linked_session_ids=set())
-        if decision.source_class is not None:
-            return decision.source_class
     if provenance_class in provenance_map:
         return provenance_map[provenance_class]
     path_class = classify_provenance(

--- a/src/brainlayer/dedupe.py
+++ b/src/brainlayer/dedupe.py
@@ -665,6 +665,13 @@ def merge_existing_chunk_seen(
         updates["importance"] = merged_importance
     if merged_half_life is not None:
         updates["half_life_days"] = merged_half_life
+    from .agent_provenance import normalize_source_class
+
+    incoming_source_class = normalize_source_class(incoming.get("source_class"))
+    if incoming_source_class is not None and "source_class" in {
+        row[1] for row in cursor.execute("PRAGMA table_info(chunks)")
+    }:
+        updates["source_class"] = incoming_source_class
     assignments = ", ".join(f"{column} = ?" for column in updates)
 
     for attempt in range(BUSY_RETRY_ATTEMPTS):

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -19,6 +19,7 @@ import apsw
 import sqlite_vec
 
 from ._helpers import _is_sqlite_busy_error, serialize_f32
+from .agent_provenance import normalize_source_class
 from .chunk_origin import CHUNK_ORIGIN_UNKNOWN, detect_chunk_origin
 from .content_class import classify_content_class, normalize_content_class
 from .dedupe import (
@@ -926,8 +927,9 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         values["content_class"] = event.get("content_class")
     if event.get("provenance_class"):
         values["provenance_class"] = event.get("provenance_class")
-    if event.get("source_class") and "source_class" in _columns(conn, "chunks"):
-        values["source_class"] = event.get("source_class")
+    source_class = normalize_source_class(event.get("source_class"))
+    if source_class is not None and "source_class" in _columns(conn, "chunks"):
+        values["source_class"] = source_class
     stored_chunk_id = _insert_or_merge_chunk(
         conn,
         values,

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -926,6 +926,8 @@ def _apply_watcher(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         values["content_class"] = event.get("content_class")
     if event.get("provenance_class"):
         values["provenance_class"] = event.get("provenance_class")
+    if event.get("source_class") and "source_class" in _columns(conn, "chunks"):
+        values["source_class"] = event.get("source_class")
     stored_chunk_id = _insert_or_merge_chunk(
         conn,
         values,

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 from typing import Callable, List, Optional
 
+from .agent_provenance import derive_source_class
 from .claude_paths import extract_claude_conversation_id as _extract_claude_conversation_id
 from .embeddings import embed_chunks
 from .pipeline.chunk import Chunk
@@ -116,6 +117,13 @@ def index_chunks_to_sqlite(
                 "sender": metadata.get("sender"),
                 "source": metadata.get("source", "claude_code"),
                 "provenance_class": metadata.get("provenance_class"),
+                "source_class": metadata.get("source_class")
+                or derive_source_class(
+                    source_file,
+                    provenance_class=metadata.get("provenance_class"),
+                    source=metadata.get("source", "claude_code"),
+                    content=chunk.content,
+                ),
                 "source_uri": metadata.get("source_uri"),
                 "allow_duplicate": metadata.get("allow_duplicate", False),
             }

--- a/src/brainlayer/index_new.py
+++ b/src/brainlayer/index_new.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Callable, List, Optional
 
-from .agent_provenance import derive_source_class
+from .agent_provenance import resolve_source_class
 from .claude_paths import extract_claude_conversation_id as _extract_claude_conversation_id
 from .embeddings import embed_chunks
 from .pipeline.chunk import Chunk
@@ -117,12 +117,11 @@ def index_chunks_to_sqlite(
                 "sender": metadata.get("sender"),
                 "source": metadata.get("source", "claude_code"),
                 "provenance_class": metadata.get("provenance_class"),
-                "source_class": metadata.get("source_class")
-                or derive_source_class(
+                "source_class": resolve_source_class(
                     source_file,
+                    supplied_source_class=metadata.get("source_class"),
                     provenance_class=metadata.get("provenance_class"),
                     source=metadata.get("source", "claude_code"),
-                    content=chunk.content,
                 ),
                 "source_uri": metadata.get("source_uri"),
                 "allow_duplicate": metadata.get("allow_duplicate", False),

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 BRAINLAYER_INGEST_DENYLIST_ENV = "BRAINLAYER_INGEST_DENYLIST"
 
-DEFAULT_INGEST_DENYLIST = ("~/.claude/projects/**/wf_*/**",)
+# The class rule is deliberately narrower than the historical wf_* blanket:
+# only memory-reading workers are out of the index. Explicit deployment globs
+# remain available through BRAINLAYER_INGEST_DENYLIST.
+DEFAULT_INGEST_DENYLIST: tuple[str, ...] = ()
+MEMORY_READER_ATTRIBUTIONS = frozenset({"brain-worker", "session-miner", "weave"})
 
 
 @dataclass(frozen=True)
@@ -67,6 +71,14 @@ def _match_parts(path_parts: tuple[str, ...], pattern_parts: tuple[str, ...]) ->
 def _is_claude_subagent(path: Path) -> bool:
     parts = path.parts
     return ".claude" in parts and "projects" in parts and "subagents" in parts
+
+
+def _has_memory_reader_path_signature(path: Path) -> bool:
+    if "subagents" not in path.parts:
+        return False
+    subagents_index = path.parts.index("subagents")
+    markers = {part.casefold().replace("_", "-") for part in path.parts[subagents_index + 1 :]}
+    return bool(markers & MEMORY_READER_ATTRIBUTIONS)
 
 
 def _claude_subagent_attribution(path: Path) -> str | None:
@@ -162,6 +174,9 @@ def is_denylisted(path: str | Path, *, unknown_subagent_is_denylisted: bool = Tr
             if _match_parts(candidate.parts, expanded_pattern.parts):
                 return True
     if BRAINLAYER_INGEST_DENYLIST_ENV not in os.environ and _is_claude_subagent(candidate):
+        if _has_memory_reader_path_signature(candidate):
+            return True
         attribution = _claude_subagent_attribution(candidate)
-        return (attribution is None and unknown_subagent_is_denylisted) or attribution == "brain-worker"
+        normalized = str(attribution or "").strip().casefold().replace("_", "-")
+        return (attribution is None and unknown_subagent_is_denylisted) or normalized in MEMORY_READER_ATTRIBUTIONS
     return False

--- a/src/brainlayer/ingest_denylist.py
+++ b/src/brainlayer/ingest_denylist.py
@@ -81,6 +81,22 @@ def _has_memory_reader_path_signature(path: Path) -> bool:
     return bool(markers & MEMORY_READER_ATTRIBUTIONS)
 
 
+def memory_reader_attribution(path: str | Path) -> str | None:
+    """Return an exact memory-reader role from path/JSONL attribution, never task text."""
+    candidate = Path(os.path.abspath(os.path.expanduser(str(path))))
+    if not _is_claude_subagent(candidate):
+        return None
+    if "subagents" in candidate.parts:
+        subagents_index = candidate.parts.index("subagents")
+        for part in candidate.parts[subagents_index + 1 :]:
+            normalized = part.strip().casefold().replace("_", "-")
+            if normalized in MEMORY_READER_ATTRIBUTIONS:
+                return normalized
+    attribution = _claude_subagent_attribution(candidate)
+    normalized = str(attribution or "").strip().casefold().replace("_", "-")
+    return normalized if normalized in MEMORY_READER_ATTRIBUTIONS else None
+
+
 def _claude_subagent_attribution(path: Path) -> str | None:
     """Incrementally read the first stable worker attribution from an appending JSONL."""
     try:
@@ -174,7 +190,7 @@ def is_denylisted(path: str | Path, *, unknown_subagent_is_denylisted: bool = Tr
             if _match_parts(candidate.parts, expanded_pattern.parts):
                 return True
     if BRAINLAYER_INGEST_DENYLIST_ENV not in os.environ and _is_claude_subagent(candidate):
-        if _has_memory_reader_path_signature(candidate):
+        if memory_reader_attribution(candidate) is not None:
             return True
         attribution = _claude_subagent_attribution(candidate)
         normalized = str(attribution or "").strip().casefold().replace("_", "-")

--- a/src/brainlayer/queue_io.py
+++ b/src/brainlayer/queue_io.py
@@ -111,6 +111,7 @@ def enqueue_watcher_chunk(
     chunk_origin: str | None = None,
     content_class: str | None = None,
     provenance_class: str | None = None,
+    source_class: str | None = None,
     queue_dir: Path | None = None,
 ) -> Path:
     event = {
@@ -134,6 +135,8 @@ def enqueue_watcher_chunk(
         event["content_class"] = content_class
     if provenance_class is not None:
         event["provenance_class"] = provenance_class
+    if source_class is not None:
+        event["source_class"] = source_class
     return enqueue_jsonl(
         event,
         source="watcher",

--- a/src/brainlayer/runtime_store.py
+++ b/src/brainlayer/runtime_store.py
@@ -459,6 +459,7 @@ class WriterRuntimeStore(VectorStore):
             self._has_chunk_origin = "chunk_origin" in chunk_columns
             self._has_content_class = "content_class" in chunk_columns
             self._has_provenance_class = "provenance_class" in chunk_columns
+            self._has_source_class = "source_class" in chunk_columns
             self._has_superseded_by = "superseded_by" in chunk_columns
             self._has_invalid_at = "invalid_at" in chunk_columns
             self._binary_index_available = "chunk_vectors_binary" in objects

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -405,6 +405,24 @@ def _content_class_expr(store: Any, alias: str | None = None) -> str:
     return f"'{DEFAULT_CONTENT_CLASS}'"
 
 
+def _source_class_where(
+    store: Any,
+    *,
+    alias: str | None = None,
+    include_hidden_source_classes: bool = False,
+) -> str | None:
+    """Build the unadvertised source-class visibility gate.
+
+    Legacy NULL rows stay visible. The internal opt-in reveals desktop rows,
+    while brain-worker rows remain excluded even if a legacy leak exists.
+    """
+    if not getattr(store, "_has_source_class", False):
+        return None
+    column = f"{alias}.source_class" if alias else "source_class"
+    hidden = "('brain-worker')" if include_hidden_source_classes else "('desktop', 'brain-worker')"
+    return f"({column} IS NULL OR {column} NOT IN {hidden})"
+
+
 def _effective_project_filter(project_filter: Optional[str], consumer_scope: ConsumerScope | None) -> Optional[str]:
     if consumer_scope is not None:
         return consumer_scope.project_filter
@@ -1079,6 +1097,7 @@ class SearchMixin:
         include_audit: bool = False,
         include_operational: bool = False,
         content_class_filter: Optional[str] = None,
+        include_hidden_source_classes: bool = False,
         consumer_scope: ConsumerScope | None = None,
     ) -> Dict[str, List]:
         """Search chunks by embedding or text.
@@ -1157,6 +1176,13 @@ class SearchMixin:
             if content_class_clause:
                 where_clauses.append(content_class_clause)
                 filter_params.extend(content_class_params)
+            source_class_clause = _source_class_where(
+                self,
+                alias="c",
+                include_hidden_source_classes=include_hidden_source_classes,
+            )
+            if source_class_clause:
+                where_clauses.append(source_class_clause)
             if not include_audit:
                 where_clauses.append(self._audit_recursion_exclusion_sql("c.id", "c.tags", "c.content"))
             if not include_checkpoints:
@@ -1278,6 +1304,12 @@ class SearchMixin:
             if content_class_clause:
                 where_clauses.append(content_class_clause)
                 params.extend(content_class_params)
+            source_class_clause = _source_class_where(
+                self,
+                include_hidden_source_classes=include_hidden_source_classes,
+            )
+            if source_class_clause:
+                where_clauses.append(source_class_clause)
             if not include_audit:
                 where_clauses.append(self._audit_recursion_exclusion_sql("id", "tags", "content"))
             if not include_checkpoints:
@@ -1517,6 +1549,7 @@ class SearchMixin:
         include_operational: bool = False,
         content_class_filter: Optional[str] = None,
         brainbar_helper_fast_profile: bool = False,
+        include_hidden_source_classes: bool = False,
         consumer_scope: ConsumerScope | None = None,
     ) -> Dict[str, List]:
         """Run KNN search against binary-quantized vectors."""
@@ -1584,6 +1617,13 @@ class SearchMixin:
         if content_class_clause:
             where_clauses.append(content_class_clause)
             filter_params.extend(content_class_params)
+        source_class_clause = _source_class_where(
+            self,
+            alias="c",
+            include_hidden_source_classes=include_hidden_source_classes,
+        )
+        if source_class_clause:
+            where_clauses.append(source_class_clause)
         if not include_audit:
             where_clauses.append(self._audit_recursion_exclusion_sql("c.id", "c.tags", "c.content"))
         if not include_checkpoints:
@@ -1785,6 +1825,7 @@ class SearchMixin:
         include_audit: bool = False,
         include_operational: bool = False,
         content_class_filter: Optional[str] = None,
+        include_hidden_source_classes: bool = False,
         profile_query_id: str | None = None,
         profile_scope: str = "search.repo",
         brainbar_helper_fast_profile: bool = False,
@@ -1854,6 +1895,7 @@ class SearchMixin:
             filter_meta_noise,
             brainbar_helper_fast_profile,
             consumer_scope.cache_key() if consumer_scope is not None else None,
+            include_hidden_source_classes,
         )
         now = time.monotonic()
         if cache_key in _hybrid_cache:
@@ -1907,6 +1949,7 @@ class SearchMixin:
                 include_operational=include_operational,
                 content_class_filter=content_class_filter,
                 brainbar_helper_fast_profile=brainbar_helper_fast_profile,
+                include_hidden_source_classes=include_hidden_source_classes,
                 consumer_scope=consumer_scope,
             )
             search_profile.emit(
@@ -1952,6 +1995,7 @@ class SearchMixin:
                 include_audit=include_audit,
                 include_operational=include_operational,
                 content_class_filter=content_class_filter,
+                include_hidden_source_classes=include_hidden_source_classes,
                 consumer_scope=consumer_scope,
             )
             search_profile.emit(
@@ -2036,6 +2080,13 @@ class SearchMixin:
             if content_class_clause:
                 fts_extra.append(f"AND {content_class_clause}")
                 fts_filter_params.extend(content_class_params)
+            source_class_clause = _source_class_where(
+                self,
+                alias="c",
+                include_hidden_source_classes=include_hidden_source_classes,
+            )
+            if source_class_clause:
+                fts_extra.append(f"AND {source_class_clause}")
             if not include_audit:
                 fts_extra.append(f"AND {self._audit_recursion_exclusion_sql('c.id', 'c.tags', 'c.content')}")
             if not include_checkpoints:
@@ -2229,6 +2280,12 @@ class SearchMixin:
             if content_class_clause:
                 recent_extra.append(f"AND {content_class_clause}")
                 recent_params.extend(content_class_params)
+            source_class_clause = _source_class_where(
+                self,
+                include_hidden_source_classes=include_hidden_source_classes,
+            )
+            if source_class_clause:
+                recent_extra.append(f"AND {source_class_clause}")
             if not include_audit:
                 recent_extra.append(f"AND {self._audit_recursion_exclusion_sql('id', 'tags', 'content')}")
             if not include_checkpoints:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -119,8 +119,8 @@ AUDIT_RECURSION_TAG_PATTERNS = (
     "{tag_expr} GLOB 'r0[0-9]'",
 )
 
-# Module-level LRU cache: {cache_key: (result, timestamp)}
-_hybrid_cache: "OrderedDict[tuple, tuple[dict, float]]" = OrderedDict()
+# Module-level LRU cache: {cache_key: (result, timestamp, data_version)}
+_hybrid_cache: "OrderedDict[tuple, tuple[dict, float, int | None]]" = OrderedDict()
 
 
 def _env_flag_enabled(name: str) -> bool:
@@ -1739,7 +1739,8 @@ class SearchMixin:
                 ORDER BY v.distance
                 """
         results = list(cursor.execute(query, params))
-        if len(results) < n_results and not brainbar_helper_fast_profile:
+        source_class_filter_active = bool(getattr(self, "_has_source_class", False))
+        if len(results) < n_results and (not brainbar_helper_fast_profile or source_class_filter_active):
             retry_k = self._effective_knn_k(
                 n_results,
                 bool(needs_overfetch),
@@ -1965,8 +1966,13 @@ class SearchMixin:
         )
         now = time.monotonic()
         if cache_key in _hybrid_cache:
-            cached_result, cached_at = _hybrid_cache[cache_key]
-            if now - cached_at < _HYBRID_CACHE_TTL:
+            cached_result, cached_at, cached_data_version = _hybrid_cache[cache_key]
+            current_data_version = self._checkpoint_cache_data_version()
+            if (
+                now - cached_at < _HYBRID_CACHE_TTL
+                and current_data_version is not None
+                and cached_data_version == current_data_version
+            ):
                 _hybrid_cache.move_to_end(cache_key)  # LRU touch
                 cached_clone = _clone_hybrid_result(cached_result)
                 self._queue_retrieval_strengthening(cached_clone["ids"][0])
@@ -2637,7 +2643,11 @@ class SearchMixin:
         self._queue_retrieval_strengthening(ids)
 
         # ── Cache store ──────────────────────────────────────────────────────
-        _hybrid_cache[cache_key] = (_clone_hybrid_result(result), time.monotonic())
+        _hybrid_cache[cache_key] = (
+            _clone_hybrid_result(result),
+            time.monotonic(),
+            self._checkpoint_cache_data_version(),
+        )
         _hybrid_cache.move_to_end(cache_key)
         if len(_hybrid_cache) > _HYBRID_CACHE_MAX:
             _hybrid_cache.popitem(last=False)  # evict oldest

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -858,12 +858,59 @@ class SearchMixin:
             return expanded_k
         return min(expanded_k, max(n_results, _FILTERED_KNN_MAX))
 
+    def _source_class_filtered_knn_k(
+        self,
+        n_results: int,
+        include_hidden_source_classes: bool,
+        *,
+        cap_filtered: bool = True,
+    ) -> int:
+        if not getattr(self, "_has_source_class", False):
+            return n_results
+        cache_key = "opt_in" if include_hidden_source_classes else "default"
+        cache = getattr(self, "_source_class_count_cache", {})
+        current_data_version = self._checkpoint_cache_data_version()
+        cached = cache.get(cache_key)
+        if cached is not None and (current_data_version is None or cached[0] == current_data_version):
+            hidden_count = int(cached[1])
+        else:
+            hidden_values = ("brain-worker",) if include_hidden_source_classes else ("desktop", "brain-worker")
+            placeholders = ",".join("?" for _ in hidden_values)
+            hidden_count = 0
+            for attempt in range(3):
+                try:
+                    row = (
+                        self._read_cursor()
+                        .execute(
+                            f"SELECT COUNT(*) FROM chunks WHERE source_class IN ({placeholders})",
+                            hidden_values,
+                        )
+                        .fetchone()
+                    )
+                    hidden_count = int(row[0]) if row else 0
+                    cache = dict(cache)
+                    cache[cache_key] = (current_data_version, hidden_count)
+                    setattr(self, "_source_class_count_cache", cache)
+                    break
+                except (apsw.Error, TypeError, IndexError, ValueError) as exc:
+                    if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
+                        hidden_count = 0
+                        break
+                    _sleep(0.05 * (2**attempt))
+        if hidden_count <= 0:
+            return n_results
+        expanded_k = n_results + hidden_count
+        if not cap_filtered:
+            return expanded_k
+        return min(expanded_k, max(n_results, _FILTERED_KNN_MAX))
+
     def _effective_knn_k(
         self,
         n_results: int,
         needs_overfetch: bool,
         include_checkpoints: bool,
         include_audit: bool,
+        include_hidden_source_classes: bool = False,
         *,
         cap_filtered: bool = True,
     ) -> int:
@@ -876,6 +923,11 @@ class SearchMixin:
             cap_filtered=cap_filtered,
         )
         effective_k = self._audit_filtered_knn_k(effective_k, include_audit, cap_filtered=cap_filtered)
+        effective_k = self._source_class_filtered_knn_k(
+            effective_k,
+            include_hidden_source_classes,
+            cap_filtered=cap_filtered,
+        )
         return min(effective_k, _SQLITE_VEC_MAX_K)
 
     def _load_chunk_embeddings(self, chunk_ids: List[str]) -> Dict[str, np.ndarray]:
@@ -1214,7 +1266,13 @@ class SearchMixin:
                 or source_file_filter_like
                 or correction_category
             )
-            effective_k = self._effective_knn_k(n_results, bool(needs_overfetch), include_checkpoints, include_audit)
+            effective_k = self._effective_knn_k(
+                n_results,
+                bool(needs_overfetch),
+                include_checkpoints,
+                include_audit,
+                include_hidden_source_classes,
+            )
             params = [query_bytes, effective_k] + filter_params
             chunk_origin_expr = "c.chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
             content_class_expr = _content_class_expr(self, "c")
@@ -1241,6 +1299,7 @@ class SearchMixin:
                     bool(needs_overfetch),
                     include_checkpoints,
                     include_audit,
+                    include_hidden_source_classes,
                     cap_filtered=False,
                 )
                 if retry_k > effective_k:
@@ -1654,7 +1713,13 @@ class SearchMixin:
         if brainbar_helper_fast_profile:
             effective_k = min(max(n_results, _BRAINBAR_HELPER_FAST_K), _SQLITE_VEC_MAX_K)
         else:
-            effective_k = self._effective_knn_k(n_results, bool(needs_overfetch), include_checkpoints, include_audit)
+            effective_k = self._effective_knn_k(
+                n_results,
+                bool(needs_overfetch),
+                include_checkpoints,
+                include_audit,
+                include_hidden_source_classes,
+            )
         params = [query_bytes, effective_k] + filter_params
         chunk_origin_expr = "c.chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
         content_class_expr = _content_class_expr(self, "c")
@@ -1680,6 +1745,7 @@ class SearchMixin:
                 bool(needs_overfetch),
                 include_checkpoints,
                 include_audit,
+                include_hidden_source_classes,
                 cap_filtered=False,
             )
             if retry_k > effective_k:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -119,8 +119,11 @@ AUDIT_RECURSION_TAG_PATTERNS = (
     "{tag_expr} GLOB 'r0[0-9]'",
 )
 
-# Module-level LRU cache: {cache_key: (result, timestamp, data_version)}
-_hybrid_cache: "OrderedDict[tuple, tuple[dict, float, int | None]]" = OrderedDict()
+# Module-level LRU cache: {cache_key: (result, timestamp, reader_state)}.
+# reader_state contains an application-owned per-connection token because
+# PRAGMA data_version values from different SQLite connections are not
+# comparable.
+_hybrid_cache: "OrderedDict[tuple, tuple[dict, float, tuple[object, int] | None]]" = OrderedDict()
 
 
 def _env_flag_enabled(name: str) -> bool:
@@ -799,6 +802,30 @@ class SearchMixin:
                 _sleep(0.05 * (2**attempt))
         return None
 
+    def _reader_cache_state(self) -> tuple[object, int] | None:
+        """Return a connection-scoped token plus that connection's data version."""
+        for attempt in range(3):
+            try:
+                cursor = self._read_cursor()
+                row = cursor.execute("PRAGMA data_version").fetchone()
+                if not row:
+                    return None
+                local = getattr(self, "_local", None)
+                if local is not None:
+                    token = getattr(local, "reader_cache_token", None)
+                    if token is None:
+                        token = object()
+                        local.reader_cache_token = token
+                else:
+                    connection = cursor.get_connection()
+                    token = connection if connection is not None else cursor
+                return token, int(row[0])
+            except (apsw.Error, AttributeError, TypeError, IndexError, ValueError) as exc:
+                if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
+                    return None
+                _sleep(0.05 * (2**attempt))
+        return None
+
     def _checkpoint_filtered_knn_k(
         self,
         n_results: int,
@@ -867,11 +894,12 @@ class SearchMixin:
     ) -> int:
         if not getattr(self, "_has_source_class", False):
             return n_results
-        cache_key = "opt_in" if include_hidden_source_classes else "default"
+        visibility_key = "opt_in" if include_hidden_source_classes else "default"
         cache = getattr(self, "_source_class_count_cache", {})
-        current_data_version = self._checkpoint_cache_data_version()
+        reader_state = self._reader_cache_state()
+        cache_key = (visibility_key, reader_state[0]) if reader_state is not None else None
         cached = cache.get(cache_key)
-        if cached is not None and (current_data_version is None or cached[0] == current_data_version):
+        if cached is not None and reader_state is not None and cached[0] == reader_state[1]:
             hidden_count = int(cached[1])
         else:
             hidden_values = ("brain-worker",) if include_hidden_source_classes else ("desktop", "brain-worker")
@@ -889,8 +917,9 @@ class SearchMixin:
                     )
                     hidden_count = int(row[0]) if row else 0
                     cache = dict(cache)
-                    cache[cache_key] = (current_data_version, hidden_count)
-                    setattr(self, "_source_class_count_cache", cache)
+                    if cache_key is not None and reader_state is not None:
+                        cache[cache_key] = (reader_state[1], hidden_count)
+                        setattr(self, "_source_class_count_cache", cache)
                     break
                 except (apsw.Error, TypeError, IndexError, ValueError) as exc:
                     if not isinstance(exc, apsw.Error) or not _is_sqlite_busy_error(exc) or attempt == 2:
@@ -1966,12 +1995,12 @@ class SearchMixin:
         )
         now = time.monotonic()
         if cache_key in _hybrid_cache:
-            cached_result, cached_at, cached_data_version = _hybrid_cache[cache_key]
-            current_data_version = self._checkpoint_cache_data_version()
+            cached_result, cached_at, cached_reader_state = _hybrid_cache[cache_key]
+            current_reader_state = self._reader_cache_state()
             if (
                 now - cached_at < _HYBRID_CACHE_TTL
-                and current_data_version is not None
-                and cached_data_version == current_data_version
+                and current_reader_state is not None
+                and cached_reader_state == current_reader_state
             ):
                 _hybrid_cache.move_to_end(cache_key)  # LRU touch
                 cached_clone = _clone_hybrid_result(cached_result)
@@ -2646,7 +2675,7 @@ class SearchMixin:
         _hybrid_cache[cache_key] = (
             _clone_hybrid_result(result),
             time.monotonic(),
-            self._checkpoint_cache_data_version(),
+            self._reader_cache_state(),
         )
         _hybrid_cache.move_to_end(cache_key)
         if len(_hybrid_cache) > _HYBRID_CACHE_MAX:

--- a/src/brainlayer/source_class_migration.py
+++ b/src/brainlayer/source_class_migration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import sqlite3
 import time
@@ -39,8 +40,11 @@ def _validate_target(db_path: str | Path, git_sha: str) -> Path:
     if not _SHA_RE.fullmatch(git_sha):
         raise ValueError("git_sha must be an exact 40-character hexadecimal commit SHA")
     path = _resolved(db_path)
-    if path == _resolved(get_db_path()):
-        raise ValueError("source_class migration refuses the canonical BrainLayer database")
+    if path == _resolved(get_db_path()) and os.environ.get("BRAINLAYER_OFFLINE_MIGRATOR_GATED_SWAP") != "1":
+        raise ValueError(
+            "source_class migration refuses the canonical BrainLayer database unless "
+            "BRAINLAYER_OFFLINE_MIGRATOR_GATED_SWAP=1 is set for the supervised live run"
+        )
     if not path.is_file():
         raise FileNotFoundError(path)
     return path

--- a/src/brainlayer/source_class_migration.py
+++ b/src/brainlayer/source_class_migration.py
@@ -139,6 +139,19 @@ def _remove_brain_worker_fts_rows(conn: sqlite3.Connection) -> dict[str, int]:
     return removed
 
 
+def _remove_brain_worker_vector_rows(conn: sqlite3.Connection) -> dict[str, int]:
+    removed: dict[str, int] = {}
+    tables = _tables(conn)
+    target = "SELECT id FROM chunks WHERE source_class = 'brain-worker'"
+    for table in ("chunk_vectors", "chunk_vectors_binary"):
+        if table not in tables or "chunk_id" not in _columns(conn, table):
+            continue
+        count = int(conn.execute(f'SELECT COUNT(*) FROM "{table}" WHERE chunk_id IN ({target})').fetchone()[0])
+        conn.execute(f'DELETE FROM "{table}" WHERE chunk_id IN ({target})')
+        removed[table] = count
+    return removed
+
+
 def migrate_source_class(
     db_path: str | Path,
     *,
@@ -229,6 +242,7 @@ def migrate_source_class(
                 conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
 
         fts_removed = _remove_brain_worker_fts_rows(conn)
+        vector_removed = _remove_brain_worker_vector_rows(conn)
         distribution = _distribution(conn)
         _validate_distribution(distribution)
         row_count_after = int(conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
@@ -245,6 +259,7 @@ def migrate_source_class(
             "distribution": distribution,
             "batches": batches,
             "fts_rows_removed": fts_removed,
+            "vector_rows_removed": vector_removed,
             "duration_seconds": duration_seconds,
             "already_applied": False,
         }
@@ -272,7 +287,15 @@ def migrate_source_class(
                 str(path),
                 prior_fingerprint,
                 result_fingerprint,
-                json.dumps(["chunks.source_class", "idx_chunks_source_class", "chunks_fts"]),
+                json.dumps(
+                    [
+                        "chunks.source_class",
+                        "idx_chunks_source_class",
+                        "chunks_fts",
+                        "chunk_vectors",
+                        "chunk_vectors_binary",
+                    ]
+                ),
                 duration_seconds,
                 details,
             ),

--- a/src/brainlayer/source_class_migration.py
+++ b/src/brainlayer/source_class_migration.py
@@ -1,0 +1,315 @@
+"""Supervised offline migration for the chunks.source_class contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .agent_provenance import derive_source_class
+from .paths import get_db_path
+
+MIGRATION_NAME = "2026_08_10_source_class_v1"
+MIGRATION_EVENT_ID = "schema:2026_08_10_source_class_v1"
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_SOURCE_CLASSES = (
+    "cli-agent",
+    "desktop",
+    "subagent",
+    "brain-worker",
+    "fleet-coordination",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolved(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
+
+
+def _validate_target(db_path: str | Path, git_sha: str) -> Path:
+    if not _SHA_RE.fullmatch(git_sha):
+        raise ValueError("git_sha must be an exact 40-character hexadecimal commit SHA")
+    path = _resolved(db_path)
+    if path == _resolved(get_db_path()):
+        raise ValueError("source_class migration refuses the canonical BrainLayer database")
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    return {str(row[0]) for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+
+
+def _schema_fingerprint(conn: sqlite3.Connection) -> str:
+    rows = conn.execute("SELECT type, name, COALESCE(sql, '') FROM sqlite_master ORDER BY type, name").fetchall()
+    payload = json.dumps(rows, separators=(",", ":"), ensure_ascii=True).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _ensure_ledgers(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            name TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL,
+            details TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS migration_events (
+            id TEXT PRIMARY KEY,
+            from_pattern TEXT NOT NULL,
+            to_pattern TEXT NOT NULL,
+            commit_hash TEXT NOT NULL,
+            repo TEXT NOT NULL,
+            detected_at REAL NOT NULL,
+            confidence REAL,
+            memories_weakened INTEGER DEFAULT 0,
+            actor TEXT,
+            path TEXT,
+            prior_fingerprint TEXT,
+            result_fingerprint TEXT,
+            affected_objects TEXT,
+            status TEXT,
+            error TEXT,
+            duration_seconds REAL,
+            details TEXT
+        )
+        """
+    )
+    existing = _columns(conn, "migration_events")
+    for name, sql_type in (
+        ("actor", "TEXT"),
+        ("path", "TEXT"),
+        ("prior_fingerprint", "TEXT"),
+        ("result_fingerprint", "TEXT"),
+        ("affected_objects", "TEXT"),
+        ("status", "TEXT"),
+        ("error", "TEXT"),
+        ("duration_seconds", "REAL"),
+        ("details", "TEXT"),
+    ):
+        if name not in existing:
+            conn.execute(f'ALTER TABLE migration_events ADD COLUMN "{name}" {sql_type}')
+
+
+def _distribution(conn: sqlite3.Connection) -> dict[str, int]:
+    counts = Counter()
+    for source_class, count in conn.execute("SELECT source_class, COUNT(*) FROM chunks GROUP BY source_class"):
+        counts[source_class if source_class is not None else "NULL"] += int(count)
+    return dict(sorted(counts.items()))
+
+
+def _validate_distribution(distribution: dict[str, int]) -> None:
+    invalid = set(distribution) - {"NULL", *_SOURCE_CLASSES}
+    if invalid:
+        raise ValueError(f"unexpected source_class values: {sorted(invalid)}")
+
+
+def _remove_brain_worker_fts_rows(conn: sqlite3.Connection) -> dict[str, int]:
+    removed: dict[str, int] = {}
+    tables = _tables(conn)
+    for table in ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"):
+        if table not in tables or "chunk_id" not in _columns(conn, table):
+            continue
+        before = conn.total_changes
+        conn.execute(
+            f"DELETE FROM \"{table}\" WHERE chunk_id IN (SELECT id FROM chunks WHERE source_class = 'brain-worker')"
+        )
+        removed[table] = conn.total_changes - before
+    if "chunk_fts_rowids" in tables:
+        conn.execute(
+            "DELETE FROM chunk_fts_rowids WHERE chunk_id IN (SELECT id FROM chunks WHERE source_class = 'brain-worker')"
+        )
+    return removed
+
+
+def migrate_source_class(
+    db_path: str | Path,
+    *,
+    git_sha: str,
+    actor: str,
+    batch_size: int = 5_000,
+) -> dict[str, Any]:
+    """Migrate one non-canonical DB and return an auditable receipt."""
+    path = _validate_target(db_path, git_sha)
+    if batch_size < 1:
+        raise ValueError("batch_size must be positive")
+    if not actor.strip():
+        raise ValueError("actor must be non-empty")
+
+    started = time.monotonic()
+    conn = sqlite3.connect(path, timeout=60.0)
+    conn.execute("PRAGMA busy_timeout = 60000")
+    conn.execute("PRAGMA foreign_keys = ON")
+    prior_fingerprint = _schema_fingerprint(conn)
+    row_count_before = int(conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+    _ensure_ledgers(conn)
+    prior = conn.execute("SELECT details FROM schema_migrations WHERE name = ?", (MIGRATION_NAME,)).fetchone()
+    if prior is not None and "source_class" in _columns(conn, "chunks"):
+        receipt = json.loads(prior[0]) if prior[0] else {}
+        recorded_sha = str(receipt.get("git_sha") or "").casefold()
+        if recorded_sha != git_sha.casefold():
+            conn.close()
+            raise RuntimeError(
+                f"migration ledger SHA mismatch: recorded {recorded_sha or 'missing'}, requested {git_sha.casefold()}"
+            )
+        distribution = _distribution(conn)
+        _validate_distribution(distribution)
+        receipt.update(
+            {
+                "already_applied": True,
+                "row_count_before": row_count_before,
+                "row_count_after": row_count_before,
+                "distribution": distribution,
+            }
+        )
+        conn.close()
+        return receipt
+
+    error: str | None = None
+    try:
+        if "source_class" not in _columns(conn, "chunks"):
+            conn.execute("ALTER TABLE chunks ADD COLUMN source_class TEXT")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_chunks_source_class ON chunks(source_class)")
+        conn.commit()
+
+        select_columns = _columns(conn, "chunks")
+        provenance_expr = "provenance_class" if "provenance_class" in select_columns else "NULL"
+        source_expr = "source" if "source" in select_columns else "NULL"
+        last_rowid = 0
+        classified = 0
+        ambiguous = 0
+        batches = 0
+        while True:
+            rows = conn.execute(
+                f"""
+                SELECT rowid, id, source_file, {provenance_expr}, {source_expr}
+                FROM chunks
+                WHERE rowid > ? AND source_class IS NULL
+                ORDER BY rowid
+                LIMIT ?
+                """,
+                (last_rowid, batch_size),
+            ).fetchall()
+            if not rows:
+                break
+            updates: list[tuple[str, str]] = []
+            for rowid, chunk_id, source_file, provenance_class, source in rows:
+                last_rowid = int(rowid)
+                source_class = derive_source_class(
+                    str(source_file or ""), provenance_class=provenance_class, source=source
+                )
+                if source_class is None:
+                    ambiguous += 1
+                    continue
+                updates.append((source_class, str(chunk_id)))
+            if updates:
+                conn.executemany("UPDATE chunks SET source_class = ? WHERE id = ?", updates)
+                classified += len(updates)
+            conn.commit()
+            batches += 1
+            if batches % 3 == 0:
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+
+        fts_removed = _remove_brain_worker_fts_rows(conn)
+        distribution = _distribution(conn)
+        _validate_distribution(distribution)
+        row_count_after = int(conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+        result_fingerprint = _schema_fingerprint(conn)
+        duration_seconds = time.monotonic() - started
+        receipt: dict[str, Any] = {
+            "migration": MIGRATION_NAME,
+            "git_sha": git_sha.lower(),
+            "database": str(path),
+            "row_count_before": row_count_before,
+            "row_count_after": row_count_after,
+            "classified_rows": classified,
+            "ambiguous_rows": ambiguous,
+            "distribution": distribution,
+            "batches": batches,
+            "fts_rows_removed": fts_removed,
+            "duration_seconds": duration_seconds,
+            "already_applied": False,
+        }
+        details = json.dumps(receipt, sort_keys=True)
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_migrations(name, applied_at, details) VALUES (?, ?, ?)",
+            (MIGRATION_NAME, _utc_now(), details),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO migration_events(
+                id, from_pattern, to_pattern, commit_hash, repo, detected_at,
+                confidence, memories_weakened, actor, path, prior_fingerprint,
+                result_fingerprint, affected_objects, status, error,
+                duration_seconds, details
+            ) VALUES (?, ?, ?, ?, 'brainlayer', ?, 1.0, 0, ?, ?, ?, ?, ?, 'success', NULL, ?, ?)
+            """,
+            (
+                MIGRATION_EVENT_ID,
+                "chunks without source_class",
+                "chunks.source_class five-value taxonomy",
+                git_sha.lower(),
+                time.time(),
+                actor,
+                str(path),
+                prior_fingerprint,
+                result_fingerprint,
+                json.dumps(["chunks.source_class", "idx_chunks_source_class", "chunks_fts"]),
+                duration_seconds,
+                details,
+            ),
+        )
+        conn.commit()
+        return receipt
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        conn.rollback()
+        raise
+    finally:
+        if error is not None:
+            try:
+                _ensure_ledgers(conn)
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO migration_events(
+                        id, from_pattern, to_pattern, commit_hash, repo, detected_at,
+                        confidence, memories_weakened, actor, path, prior_fingerprint,
+                        affected_objects, status, error, duration_seconds
+                    ) VALUES (?, ?, ?, ?, 'brainlayer', ?, 1.0, 0, ?, ?, ?, ?, 'failure', ?, ?)
+                    """,
+                    (
+                        MIGRATION_EVENT_ID,
+                        "chunks without source_class",
+                        "chunks.source_class five-value taxonomy",
+                        git_sha.lower(),
+                        time.time(),
+                        actor,
+                        str(path),
+                        prior_fingerprint,
+                        json.dumps(["chunks.source_class"]),
+                        error,
+                        time.monotonic() - started,
+                    ),
+                )
+                conn.commit()
+            except sqlite3.Error:
+                pass
+        conn.close()

--- a/src/brainlayer/source_class_migration.py
+++ b/src/brainlayer/source_class_migration.py
@@ -129,18 +129,13 @@ def _validate_distribution(distribution: dict[str, int]) -> None:
 def _remove_brain_worker_fts_rows(conn: sqlite3.Connection) -> dict[str, int]:
     removed: dict[str, int] = {}
     tables = _tables(conn)
-    for table in ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram"):
+    target = "SELECT id FROM chunks WHERE source_class = 'brain-worker'"
+    for table in ("chunks_fts", "chunks_fts_operational", "chunks_fts_trigram", "chunk_fts_rowids"):
         if table not in tables or "chunk_id" not in _columns(conn, table):
             continue
-        before = conn.total_changes
-        conn.execute(
-            f"DELETE FROM \"{table}\" WHERE chunk_id IN (SELECT id FROM chunks WHERE source_class = 'brain-worker')"
-        )
-        removed[table] = conn.total_changes - before
-    if "chunk_fts_rowids" in tables:
-        conn.execute(
-            "DELETE FROM chunk_fts_rowids WHERE chunk_id IN (SELECT id FROM chunks WHERE source_class = 'brain-worker')"
-        )
+        count = int(conn.execute(f'SELECT COUNT(*) FROM "{table}" WHERE chunk_id IN ({target})').fetchone()[0])
+        conn.execute(f'DELETE FROM "{table}" WHERE chunk_id IN ({target})')
+        removed[table] = count
     return removed
 
 
@@ -167,25 +162,26 @@ def migrate_source_class(
     _ensure_ledgers(conn)
     prior = conn.execute("SELECT details FROM schema_migrations WHERE name = ?", (MIGRATION_NAME,)).fetchone()
     if prior is not None and "source_class" in _columns(conn, "chunks"):
-        receipt = json.loads(prior[0]) if prior[0] else {}
-        recorded_sha = str(receipt.get("git_sha") or "").casefold()
-        if recorded_sha != git_sha.casefold():
-            conn.close()
-            raise RuntimeError(
-                f"migration ledger SHA mismatch: recorded {recorded_sha or 'missing'}, requested {git_sha.casefold()}"
+        try:
+            receipt = json.loads(prior[0]) if prior[0] else {}
+            recorded_sha = str(receipt.get("git_sha") or "").casefold()
+            if recorded_sha != git_sha.casefold():
+                raise RuntimeError(
+                    f"migration ledger SHA mismatch: recorded {recorded_sha or 'missing'}, requested {git_sha.casefold()}"
+                )
+            distribution = _distribution(conn)
+            _validate_distribution(distribution)
+            receipt.update(
+                {
+                    "already_applied": True,
+                    "row_count_before": row_count_before,
+                    "row_count_after": row_count_before,
+                    "distribution": distribution,
+                }
             )
-        distribution = _distribution(conn)
-        _validate_distribution(distribution)
-        receipt.update(
-            {
-                "already_applied": True,
-                "row_count_before": row_count_before,
-                "row_count_after": row_count_before,
-                "distribution": distribution,
-            }
-        )
-        conn.close()
-        return receipt
+            return receipt
+        finally:
+            conn.close()
 
     error: str | None = None
     try:

--- a/src/brainlayer/source_class_migration.py
+++ b/src/brainlayer/source_class_migration.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import sqlite_vec
+
 from .agent_provenance import derive_source_class
 from .paths import get_db_path
 
@@ -62,6 +64,19 @@ def _schema_fingerprint(conn: sqlite3.Connection) -> str:
     rows = conn.execute("SELECT type, name, COALESCE(sql, '') FROM sqlite_master ORDER BY type, name").fetchall()
     payload = json.dumps(rows, separators=(",", ":"), ensure_ascii=True).encode()
     return hashlib.sha256(payload).hexdigest()
+
+
+def _load_vec0_if_needed(conn: sqlite3.Connection) -> None:
+    uses_vec0 = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND sql LIKE '%USING vec0%' LIMIT 1"
+    ).fetchone()
+    if uses_vec0 is None:
+        return
+    conn.enable_load_extension(True)
+    try:
+        conn.load_extension(sqlite_vec.loadable_path())
+    finally:
+        conn.enable_load_extension(False)
 
 
 def _ensure_ledgers(conn: sqlite3.Connection) -> None:
@@ -168,6 +183,7 @@ def migrate_source_class(
 
     started = time.monotonic()
     conn = sqlite3.connect(path, timeout=60.0)
+    _load_vec0_if_needed(conn)
     conn.execute("PRAGMA busy_timeout = 60000")
     conn.execute("PRAGMA foreign_keys = ON")
     prior_fingerprint = _schema_fingerprint(conn)

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -663,6 +663,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self._has_chunk_origin = "chunk_origin" in chunk_columns
         self._has_content_class = "content_class" in chunk_columns
         self._has_provenance_class = "provenance_class" in chunk_columns
+        self._has_source_class = "source_class" in chunk_columns
         self._has_superseded_by = "superseded_by" in chunk_columns
         self._has_invalid_at = "invalid_at" in chunk_columns
         self._binary_index_available = "chunk_vectors_binary" in existing_tables
@@ -808,6 +809,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 context_summary TEXT,
                 created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                 provenance_class TEXT,
+                source_class TEXT,
                 chunk_origin TEXT DEFAULT 'unknown',
                 content_class TEXT DEFAULT 'knowledge',
                 content_hash TEXT,
@@ -913,6 +915,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         self._has_chunk_origin = True
         self._has_content_class = True
         self._has_provenance_class = True
+        self._has_source_class = "source_class" in existing_cols
         self._has_superseded_by = True
         ensure_dedupe_schema(self.conn)
 
@@ -1047,6 +1050,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             ("idx_chunks_topic_cluster", "topic_cluster"),
         ]:
             cursor.execute(f"CREATE INDEX IF NOT EXISTS {idx} ON chunks({col})")
+        if self._has_source_class:
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_chunks_source_class ON chunks(source_class)")
         cursor.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_brick_id ON chunks(brick_id) WHERE brick_id IS NOT NULL"
         )
@@ -2591,11 +2596,19 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                             continue
 
                         has_provenance_class = getattr(self, "_has_provenance_class", False)
+                        has_source_class = getattr(self, "_has_source_class", False)
                         provenance_column = ", provenance_class" if has_provenance_class else ""
                         provenance_value = ", ?" if has_provenance_class else ""
                         provenance_update = (
                             ", provenance_class = COALESCE(excluded.provenance_class, chunks.provenance_class)"
                             if has_provenance_class
+                            else ""
+                        )
+                        source_class_column = ", source_class" if has_source_class else ""
+                        source_class_value = ", ?" if has_source_class else ""
+                        source_class_update = (
+                            ", source_class = COALESCE(excluded.source_class, chunks.source_class)"
+                            if has_source_class
                             else ""
                         )
                         cursor.execute(
@@ -2606,8 +2619,8 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                              conversation_id, position, sender, chunk_origin, tags, importance,
                              half_life_days, seen_count, last_seen_at, dedupe_hash, simhash,
                              simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
-                             brick_id, source_uri, status, ingested_at, topic_cluster{provenance_column})
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?{provenance_value})
+                             brick_id, source_uri, status, ingested_at, topic_cluster{provenance_column}{source_class_column})
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?{provenance_value}{source_class_value})
                             ON CONFLICT(id) DO UPDATE SET
                                 content = excluded.content,
                                 metadata = excluded.metadata,
@@ -2649,7 +2662,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                                     WHEN chunks.chunk_origin IS NULL
                                         THEN COALESCE(excluded.chunk_origin, 'unknown')
                                     ELSE chunks.chunk_origin
-                                END{provenance_update}
+                                END{provenance_update}{source_class_update}
                         """,
                             (
                                 chunk_id,
@@ -2683,6 +2696,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                                 chunk.get("ingested_at") or int(time.time()),
                                 chunk.get("topic_cluster"),
                                 *([chunk.get("provenance_class")] if has_provenance_class else []),
+                                *([chunk.get("source_class")] if has_source_class else []),
                             ),
                         )
                         self._upsert_chunk_vector(cursor, chunk_id, embedding)

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -43,6 +43,7 @@ from ._helpers import (
 from ._helpers import (
     source_aware_min_chars as source_aware_min_chars,
 )
+from .agent_provenance import normalize_source_class
 from .chunk_origin import (
     CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT,
     CHUNK_ORIGIN_UNKNOWN,
@@ -2537,7 +2538,11 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                     for chunk, embedding in sub_batch:
                         chunk_id = chunk["id"]
                         created_at = chunk.get("created_at") or datetime.now(timezone.utc).isoformat()
-                        chunk = {**chunk, "created_at": created_at}
+                        chunk = {
+                            **chunk,
+                            "created_at": created_at,
+                            "source_class": normalize_source_class(chunk.get("source_class")),
+                        }
                         tags_value = chunk.get("tags")
                         tags_json = json.dumps(tags_value) if isinstance(tags_value, (list, dict)) else tags_value
                         # T3 is intentionally a first-class mirror source.  Its

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -394,6 +394,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
             chunk_origin: str | None,
             content_class: str,
             provenance_class: str,
+            source_class: str | None,
         ) -> None:
             enqueue_watcher_chunk(
                 chunk_id=chunk_id,
@@ -411,6 +412,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                 chunk_origin=chunk_origin,
                 content_class=content_class,
                 provenance_class=provenance_class,
+                source_class=source_class,
             )
 
         for entry in entries:
@@ -531,9 +533,14 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                 visibility = effective_visibility(provenance_decision, base_content_class)
                 content_class = _content_class_for_visibility(base_content_class, visibility)
                 provenance_class = provenance_decision.provenance_tag
+                source_class = provenance_decision.source_class
+                if source_class == "brain-worker":
+                    skipped += 1
+                    continue
                 metadata["provenance_tag"] = provenance_decision.provenance_tag
                 metadata["provenance_search_policy"] = provenance_decision.search_policy
                 metadata["provenance_effective_visibility"] = visibility
+                metadata["source_class"] = source_class
 
                 if arbitrated:
                     try:
@@ -553,6 +560,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                             chunk_origin=chunk_origin,
                             content_class=content_class,
                             provenance_class=provenance_class,
+                            source_class=source_class,
                         )
                     except Exception:
                         entry_confirmed = False
@@ -628,9 +636,9 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     seen_count, last_seen_at, dedupe_hash, simhash,
                                     simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
                                     source_end_offset, source_last_queued_at,
-                                    ingested_at, content_class, provenance_class)
+                                    ingested_at, content_class, provenance_class, source_class)
                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                                           ?, ?, ?, ?, ?)""",
+                                           ?, ?, ?, ?, ?, ?)""",
                                 (
                                     chunk_id,
                                     clean_content,
@@ -659,6 +667,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     ingested_at,
                                     content_class,
                                     provenance_class,
+                                    source_class,
                                 ),
                             )
                             changed = store.conn.changes() > 0
@@ -693,6 +702,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                         chunk_origin=chunk_origin,
                                         content_class=content_class,
                                         provenance_class=provenance_class,
+                                        source_class=source_class,
                                     )
                                 except Exception:
                                     logger.exception("spill_failed chunk_id=%s source_file=%s", chunk_id, source_file)

--- a/src/brainlayer/watcher_bridge.py
+++ b/src/brainlayer/watcher_bridge.py
@@ -620,6 +620,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     "tags": tags,
                                     "created_at": created_at,
                                     "last_seen_at": created_at,
+                                    "source_class": source_class,
                                 },
                             ):
                                 record_direct_liveness(chunk_id, ingested_at)
@@ -628,17 +629,20 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                 transaction_started = False
                                 inserted += 1
                                 break
+                            has_source_class = bool(getattr(store, "_has_source_class", False))
+                            source_class_column = ", source_class" if has_source_class else ""
+                            source_class_placeholder = ", ?" if has_source_class else ""
                             cursor.execute(
-                                """INSERT OR IGNORE INTO chunks
+                                f"""INSERT OR IGNORE INTO chunks
                                    (id, content, metadata, source_file, project,
                                     content_type, value_type, char_count, source,
                                     created_at, conversation_id, sender, tags, chunk_origin,
                                     seen_count, last_seen_at, dedupe_hash, simhash,
                                     simhash_band_0, simhash_band_1, simhash_band_2, simhash_band_3,
                                     source_end_offset, source_last_queued_at,
-                                    ingested_at, content_class, provenance_class, source_class)
+                                    ingested_at, content_class, provenance_class{source_class_column})
                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                                           ?, ?, ?, ?, ?, ?)""",
+                                           ?, ?, ?, ?, ?{source_class_placeholder})""",
                                 (
                                     chunk_id,
                                     clean_content,
@@ -667,7 +671,7 @@ def create_flush_callback(db_path: Path | None = None, *, arbitrated: bool | Non
                                     ingested_at,
                                     content_class,
                                     provenance_class,
-                                    source_class,
+                                    *([source_class] if has_source_class else []),
                                 ),
                             )
                             changed = store.conn.changes() > 0

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -26,7 +26,7 @@ def test_classifies_provider_roots_and_workflow_paths(tmp_path: Path) -> None:
         (
             home / ".cursor" / "projects" / "brainlayer" / "agent-transcripts" / "session.jsonl",
             "cursor-gather",
-            "ISOLATE",
+            "KEEP",
         ),
         (
             home / ".gemini" / "sessions" / "session.jsonl",
@@ -44,7 +44,7 @@ def test_classifies_provider_roots_and_workflow_paths(tmp_path: Path) -> None:
             / "wf_c83ce37d"
             / "agent.jsonl",
             "workflow-agent",
-            "ISOLATE",
+            "KEEP",
         ),
     ]
 
@@ -206,11 +206,11 @@ def test_recon_path_signature_is_scoped_to_agent_transcript_roots(tmp_path: Path
     assert classify_provenance(str(recon_subagent)).provenance_tag == "recon-agent"
 
 
-def test_effective_visibility_preserves_keep_knowledge_and_decision_but_isolates_operational(
+def test_effective_visibility_preserves_searchable_source_classes_and_content_routing(
     tmp_path: Path,
 ) -> None:
     keep = classify_provenance(str(tmp_path / ".codex" / "sessions" / "session.jsonl"))
-    isolate = classify_provenance(
+    cursor = classify_provenance(
         str(tmp_path / ".cursor" / "projects" / "repo" / "agent-transcripts" / "session.jsonl")
     )
     gemini = classify_provenance(str(tmp_path / ".gemini" / "sessions" / "session.jsonl"))
@@ -218,7 +218,7 @@ def test_effective_visibility_preserves_keep_knowledge_and_decision_but_isolates
     assert effective_visibility(keep, "knowledge") == "default"
     assert effective_visibility(keep, "decision") == "default"
     assert effective_visibility(keep, "operational") == "operational"
-    assert effective_visibility(isolate, "knowledge") == "operational"
+    assert effective_visibility(cursor, "knowledge") == "default"
     assert effective_visibility(gemini, "knowledge") == "default"
 
 
@@ -255,8 +255,8 @@ def test_report_summarizes_tags_policies_and_effective_visibility_without_real_d
         "direct-session": 1,
         "gemini-session": 1,
     }
-    assert report["policies"] == {"KEEP": 3, "ISOLATE": 1, "OUT": 0}
-    assert report["effective_visibility"] == {"cold": 0, "default": 3, "operational": 1}
+    assert report["policies"] == {"KEEP": 4, "ISOLATE": 0, "OUT": 0}
+    assert report["effective_visibility"] == {"cold": 0, "default": 4, "operational": 0}
 
 
 def test_report_loads_t3_session_ids_once(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_agent_provenance.py
+++ b/tests/test_agent_provenance.py
@@ -118,10 +118,23 @@ def test_classifies_fleet_and_product_subagents_by_transferable_project_token(tm
     assert (hyphenated_fleet.provenance_tag, hyphenated_fleet.search_policy) == ("fleet-subagent", "KEEP")
     assert (product.provenance_tag, product.search_policy) == ("product-subagent", "KEEP")
     assert (product_with_fleet_prefix.provenance_tag, product_with_fleet_prefix.search_policy) == (
-        "product-subagent",
+        "fleet-subagent",
         "KEEP",
     )
     assert (mehayom.provenance_tag, mehayom.search_policy) == ("product-subagent", "KEEP")
+
+    worktree_fleet = classify_provenance(
+        str(
+            home
+            / ".claude"
+            / "projects"
+            / "-Users-someone-Gits-brainlayer--worktrees-brainlayer-worker-rs1wry"
+            / "session"
+            / "subagents"
+            / "agent-worker.jsonl"
+        )
+    )
+    assert (worktree_fleet.provenance_tag, worktree_fleet.search_policy) == ("fleet-subagent", "KEEP")
 
 
 def test_cursor_agent_transcripts_requires_cursor_ancestor(tmp_path: Path) -> None:
@@ -144,8 +157,8 @@ def test_direct_claude_sessions_stay_keep_and_never_isolate_or_out(tmp_path: Pat
     assert decision.search_policy == "KEEP"
 
 
-def test_recon_agent_signature_is_out_and_has_precedence_over_fleet_subagent(tmp_path: Path) -> None:
-    fleet_subagent = (
+def test_recon_agent_class_uses_attribution_not_content_mentions(tmp_path: Path) -> None:
+    ordinary_subagent = (
         tmp_path
         / "home"
         / ".claude"
@@ -153,18 +166,28 @@ def test_recon_agent_signature_is_out_and_has_precedence_over_fleet_subagent(tmp
         / "-Users-etanheyman-Gits-brainlayer"
         / "session"
         / "subagents"
-        / "agent-a25d6b3aa6880db8e.jsonl"
+        / "agent-ordinary.jsonl"
     )
+    ordinary_subagent.parent.mkdir(parents=True)
+    ordinary_subagent.write_text(json.dumps({"attributionAgent": "general-purpose"}) + "\n")
 
-    decision = classify_provenance(
-        str(fleet_subagent),
+    memory_reader = ordinary_subagent.with_name("agent-memory-reader.jsonl")
+    memory_reader.write_text(json.dumps({"attributionAgent": "brain_worker"}) + "\n")
+
+    ordinary = classify_provenance(
+        str(ordinary_subagent),
         content_class="knowledge",
-        content="Task for brain-worker: mine workflow JSONL transcripts and write the recon synthesis.",
+        content="The brain-worker taxonomy and /weave workflow are documented here.",
     )
+    recon = classify_provenance(str(memory_reader), content="ordinary payload with no role words")
 
     assert has_recon_agent_signature("session-miner should inspect these transcripts")
-    assert decision.provenance_tag == "recon-agent"
-    assert decision.search_policy == "OUT"
+    assert (ordinary.provenance_tag, ordinary.search_policy) == ("fleet-subagent", "KEEP")
+    assert (recon.provenance_tag, recon.search_policy, recon.source_class) == (
+        "recon-agent",
+        "OUT",
+        "brain-worker",
+    )
 
 
 def test_recon_agent_signature_does_not_match_plain_weave_verb(tmp_path: Path) -> None:
@@ -200,10 +223,12 @@ def test_recon_path_signature_is_scoped_to_agent_transcript_roots(tmp_path: Path
         / "session-miner"
         / "agent.jsonl"
     )
+    underscore_recon_subagent = recon_subagent.parent.parent / "brain_worker" / "agent.jsonl"
 
     assert classify_provenance(str(normal_project)).search_policy == "KEEP"
     assert classify_provenance(str(direct_weave_repo_session)).provenance_tag == "direct-session"
     assert classify_provenance(str(recon_subagent)).provenance_tag == "recon-agent"
+    assert classify_provenance(str(underscore_recon_subagent)).provenance_tag == "recon-agent"
 
 
 def test_effective_visibility_preserves_searchable_source_classes_and_content_routing(

--- a/tests/test_brainbar_helper_fast_profile.py
+++ b/tests/test_brainbar_helper_fast_profile.py
@@ -13,6 +13,8 @@ class RecordingCursor:
 
     def execute(self, sql, params=()):
         self.calls.append((sql, list(params)))
+        if sql.strip() == "PRAGMA data_version":
+            return self
         if "FROM chunks_fts " in sql and self.interrupt_fts:
             raise apsw.InterruptError("interrupted")
         if "FROM chunks_fts_trigram" in sql:
@@ -20,6 +22,9 @@ class RecordingCursor:
         if "FROM chunks_fts " in sql:
             return list(self.rows_by_table.get("chunks_fts", []))
         return []
+
+    def fetchone(self):
+        return (1,)
 
     def get_connection(self):
         return None
@@ -129,6 +134,25 @@ def test_brainbar_fast_profile_binary_search_uses_fixed_k_without_count_expansio
     assert len(store.cursor.calls) == 1
     assert store.cursor.calls[0][1][1] == 400
     assert store.effective_k_calls == []
+
+
+def test_brainbar_fast_profile_retries_when_source_class_filter_exhausts_initial_k():
+    store = RecordingBinaryStore()
+    store._has_source_class = True
+
+    results = store._binary_search(
+        query_embedding=[0.1, 0.2, 0.3],
+        n_results=50,
+        brainbar_helper_fast_profile=True,
+    )
+
+    assert results["ids"] == [[]]
+    assert len(store.cursor.calls) == 2
+    assert store.cursor.calls[0][1][1] == 400
+    assert store.cursor.calls[1][1][1] == 4096
+    assert store.effective_k_calls == [
+        ((50, False, False, False, False), {"cap_filtered": False}),
+    ]
 
 
 def test_brainbar_fast_profile_uses_primary_fts_only_and_threads_binary_flag():

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -92,6 +92,34 @@ def _chunk_vector_count(store: VectorStore, table: str) -> int:
     return cursor.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
 
 
+def test_hybrid_cache_rejects_result_after_cross_connection_source_class_change(store):
+    embedding = _embed("cross connection source class cache")
+    _insert_chunk(
+        store,
+        chunk_id="cache-source-class-row",
+        content="CrossConnectionSourceClassCacheNeedle",
+        embedding=embedding,
+    )
+
+    first = store.hybrid_search(
+        query_embedding=embedding,
+        query_text="CrossConnectionSourceClassCacheNeedle",
+        n_results=5,
+    )
+    assert "cache-source-class-row" in first["ids"][0]
+
+    writer = apsw.Connection(str(store.db_path))
+    writer.execute("UPDATE chunks SET source_class = 'desktop' WHERE id = ?", ("cache-source-class-row",))
+    writer.close()
+
+    second = store.hybrid_search(
+        query_embedding=embedding,
+        query_text="CrossConnectionSourceClassCacheNeedle",
+        n_results=5,
+    )
+    assert "cache-source-class-row" not in second["ids"][0]
+
+
 class TestBinaryIndexLifecycle:
     def test_binary_table_created(self, store):
         cursor = store.conn.cursor()

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import threading
 import uuid
 from datetime import datetime, timezone
 
@@ -118,6 +119,76 @@ def test_hybrid_cache_rejects_result_after_cross_connection_source_class_change(
         n_results=5,
     )
     assert "cache-source-class-row" not in second["ids"][0]
+
+
+def test_hybrid_cache_rejects_result_on_new_reader_with_same_data_version(store):
+    embedding = _embed("cross thread source class cache")
+    _insert_chunk(
+        store,
+        chunk_id="cache-cross-thread-source-class-row",
+        content="CrossThreadSourceClassCacheNeedle",
+        embedding=embedding,
+    )
+
+    results = []
+
+    def search():
+        results.append(
+            store.hybrid_search(
+                query_embedding=embedding,
+                query_text="CrossThreadSourceClassCacheNeedle",
+                n_results=5,
+            )
+        )
+
+    first_reader = threading.Thread(target=search)
+    first_reader.start()
+    first_reader.join()
+    assert "cache-cross-thread-source-class-row" in results[-1]["ids"][0]
+
+    writer = apsw.Connection(str(store.db_path))
+    writer.execute(
+        "UPDATE chunks SET source_class = 'desktop' WHERE id = ?",
+        ("cache-cross-thread-source-class-row",),
+    )
+    writer.close()
+
+    second_reader = threading.Thread(target=search)
+    second_reader.start()
+    second_reader.join()
+    assert "cache-cross-thread-source-class-row" not in results[-1]["ids"][0]
+
+
+def test_source_class_knn_count_cache_is_scoped_to_reader_connection(store):
+    embedding = _embed("cross thread hidden count")
+    _insert_chunk(
+        store,
+        chunk_id="cross-thread-hidden-count-row",
+        content="CrossThreadHiddenCountNeedle",
+        embedding=embedding,
+    )
+
+    effective_k = []
+
+    def calculate_k():
+        effective_k.append(store._source_class_filtered_knn_k(5, False))
+
+    first_reader = threading.Thread(target=calculate_k)
+    first_reader.start()
+    first_reader.join()
+    assert effective_k[-1] == 5
+
+    writer = apsw.Connection(str(store.db_path))
+    writer.execute(
+        "UPDATE chunks SET source_class = 'desktop' WHERE id = ?",
+        ("cross-thread-hidden-count-row",),
+    )
+    writer.close()
+
+    second_reader = threading.Thread(target=calculate_k)
+    second_reader.start()
+    second_reader.join()
+    assert effective_k[-1] == 6
 
 
 class TestBinaryIndexLifecycle:

--- a/tests/test_ingest_denylist.py
+++ b/tests/test_ingest_denylist.py
@@ -69,8 +69,20 @@ def test_default_policy_excludes_exact_brain_worker_but_keeps_raw_jsonl(monkeypa
     assert worker.exists()
 
 
-def test_known_drift_blanket_workflow_path_exclusion_keeps_raw_jsonl(monkeypatch, tmp_path):
-    """Document the shipped wf_* over-exclusion without presenting it as the BL-10 ruling."""
+def test_default_policy_excludes_all_memory_reader_attributions(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+
+    for attribution in ("brain-worker", "session-miner", "weave"):
+        worker = _write_subagent(
+            tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / f"agent-{attribution}.jsonl",
+            attribution,
+        )
+        assert is_denylisted(worker)
+        assert worker.exists()
+
+
+def test_default_policy_keeps_non_recon_workflow_subagent(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
     workflow = _write_subagent(
@@ -86,7 +98,7 @@ def test_known_drift_blanket_workflow_path_exclusion_keeps_raw_jsonl(monkeypatch
         "workflow-subagent",
     )
 
-    assert is_denylisted(workflow)
+    assert not is_denylisted(workflow)
     assert workflow.exists()
 
 

--- a/tests/test_precompact_chunk_origin.py
+++ b/tests/test_precompact_chunk_origin.py
@@ -37,14 +37,15 @@ def _insert_chunk(
     chunk_origin: str | None = None,
     created_at: str = "2026-05-16T10:00:00+00:00",
     conversation_id: str = "session-a",
+    source_class: str | None = None,
 ) -> None:
     cursor = store.conn.cursor()
     cursor.execute(
         """INSERT INTO chunks (
             id, content, metadata, source_file, project, content_type,
-            char_count, source, created_at, conversation_id, chunk_origin
-        ) VALUES (?, ?, '{}', 'test.jsonl', 'brainlayer', 'assistant_text', ?, 'claude_code', ?, ?, ?)""",
-        (chunk_id, content, len(content), created_at, conversation_id, chunk_origin),
+            char_count, source, created_at, conversation_id, chunk_origin, source_class
+        ) VALUES (?, ?, '{}', 'test.jsonl', 'brainlayer', 'assistant_text', ?, 'claude_code', ?, ?, ?, ?)""",
+        (chunk_id, content, len(content), created_at, conversation_id, chunk_origin, source_class),
     )
     cursor.execute(
         "INSERT INTO chunk_vectors (chunk_id, embedding) VALUES (?, ?)",
@@ -835,6 +836,58 @@ def test_binary_search_overfetches_when_checkpoint_filter_discards_nearest_neigh
     store.close()
 
     assert results["ids"][0] == ["normal-just-outside-binary-window"]
+
+
+def test_binary_search_overfetches_when_hidden_source_classes_are_nearest(tmp_path):
+    store = VectorStore(tmp_path / "binary-source-class-overfetch.db")
+    query_embedding = [1.0] + ([0.0] * 1023)
+    for index in range(5):
+        _insert_chunk(
+            store,
+            chunk_id=f"desktop-{index}",
+            content=f"hidden desktop memory {index}",
+            embedding=query_embedding,
+            source_class="desktop",
+        )
+    visible_embedding = [0.9, 0.1] + ([0.0] * 1022)
+    _insert_chunk(
+        store,
+        chunk_id="visible-cli",
+        content="visible CLI memory outside the initial KNN window",
+        embedding=visible_embedding,
+        source_class="cli-agent",
+    )
+    store.build_binary_index()
+
+    results = store._binary_search(query_embedding=query_embedding, n_results=1)
+    store.close()
+
+    assert results["ids"][0] == ["visible-cli"]
+
+
+def test_vector_search_overfetches_when_hidden_source_classes_are_nearest(tmp_path):
+    store = VectorStore(tmp_path / "float-source-class-overfetch.db")
+    query_embedding = [1.0] + ([0.0] * 1023)
+    for index in range(5):
+        _insert_chunk(
+            store,
+            chunk_id=f"desktop-float-{index}",
+            content=f"hidden desktop float memory {index}",
+            embedding=query_embedding,
+            source_class="desktop",
+        )
+    _insert_chunk(
+        store,
+        chunk_id="visible-cli-float",
+        content="visible CLI float memory outside the initial KNN window",
+        embedding=[0.9, 0.1] + ([0.0] * 1022),
+        source_class="cli-agent",
+    )
+
+    results = store.search(query_embedding=query_embedding, n_results=1)
+    store.close()
+
+    assert results["ids"][0] == ["visible-cli-float"]
 
 
 def test_brain_resume_returns_recent_checkpoint_partition(tmp_path, monkeypatch):

--- a/tests/test_retro_self_pollution_quarantine.py
+++ b/tests/test_retro_self_pollution_quarantine.py
@@ -199,7 +199,7 @@ def _call_record_manifest_for_plan(script: ModuleType, cursor: apsw.Cursor, chun
         script._record_manifest(cursor, chunk_ids, run_id="plan-run", timestamp="2026-07-08T00:00:00Z")
 
 
-def test_dry_run_uses_denylist_and_preserves_direct_sessions(tmp_path: Path, monkeypatch) -> None:
+def test_dry_run_uses_class_denylist_and_preserves_workflows_and_direct_sessions(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
     script = _load_script()
     db_path = tmp_path / "dry-run.db"
@@ -236,10 +236,10 @@ def test_dry_run_uses_denylist_and_preserves_direct_sessions(tmp_path: Path, mon
 
     report = script.run_dry_run(db_path, sample_size=10, random_seed=7)
 
-    assert report["counts"] == {"quarantine_set": 1, "preserved": 3, "total": 4}
-    assert report["provider_breakdown"]["quarantine_set"] == {"claude": 1}
-    assert report["provider_breakdown"]["preserved"] == {"codex": 1, "claude": 1, "other": 1}
-    assert report["audit"]["quarantine_sample_size"] == 1
+    assert report["counts"] == {"quarantine_set": 0, "preserved": 4, "total": 4}
+    assert report["provider_breakdown"]["quarantine_set"] == {}
+    assert report["provider_breakdown"]["preserved"] == {"codex": 1, "claude": 2, "other": 1}
+    assert report["audit"]["quarantine_sample_size"] == 0
     assert report["audit"]["direct_session_source_files_checked"] == 1
     assert report["audit"]["direct_session_false_positive_count"] == 0
     assert report["audit"]["stop_gate_passed"] is True
@@ -1302,15 +1302,7 @@ def test_run_apply_refuses_when_retrievability_proof_fails(tmp_path: Path, monke
     db_path = tmp_path / "apply-proof-gate.db"
     backup_path = tmp_path / "apply-proof-gate-backup.db"
     denied_source = (
-        tmp_path
-        / ".claude"
-        / "projects"
-        / "proj"
-        / "session"
-        / "subagents"
-        / "workflows"
-        / "wf_test"
-        / "agent-worker.jsonl"
+        tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "brain-worker" / "agent-worker.jsonl"
     )
     store = VectorStore(db_path)
     try:
@@ -1454,15 +1446,7 @@ def test_revert_proof_runs_only_on_snapshot_path(tmp_path: Path) -> None:
             store,
             chunk_id="claude-subagent",
             source_file=(
-                tmp_path
-                / ".claude"
-                / "projects"
-                / "proj"
-                / "session"
-                / "subagents"
-                / "workflows"
-                / "wf_test"
-                / "agent-a1.jsonl"
+                tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "brain-worker" / "agent-a1.jsonl"
             ),
             content="snapshot revert proof sentinel",
         )
@@ -1488,15 +1472,7 @@ def test_direct_script_execution_bootstraps_operational_fts_for_legacy_snapshot(
     db_path = tmp_path / "legacy-source.db"
     snapshot_path = tmp_path / "legacy-snapshot.db"
     source_file = (
-        tmp_path
-        / ".claude"
-        / "projects"
-        / "proj"
-        / "session"
-        / "subagents"
-        / "workflows"
-        / "wf_test"
-        / "agent-a1.jsonl"
+        tmp_path / ".claude" / "projects" / "proj" / "session" / "subagents" / "brain-worker" / "agent-a1.jsonl"
     )
     conn = apsw.Connection(str(db_path))
     try:

--- a/tests/test_run_tests_script.py
+++ b/tests/test_run_tests_script.py
@@ -244,6 +244,47 @@ def test_changed_only_scope_maps_watcher_source_to_jsonl_watcher_tests(tmp_path:
     assert f"{test_root}/ -v" not in logged
 
 
+def test_changed_only_scope_maps_source_class_storage_pipeline_to_safe_tests(tmp_path: Path) -> None:
+    test_root = tmp_path / "tests"
+    test_root.mkdir()
+    expected = (
+        "test_source_class.py",
+        "test_vector_store_schema_flags.py",
+        "test_vector_store_upsert_transactions.py",
+        "test_ingest_t3.py",
+        "test_context_pipeline.py",
+    )
+    for filename in (*expected, "test_think_recall_integration.py"):
+        (test_root / filename).write_text("test placeholder\n")
+
+    pytest_log, bun_log = _make_stub_bin(tmp_path, pytest_exit=0, bun_exit=0)
+
+    env = _script_env()
+    env["PATH"] = f"{tmp_path / 'bin'}:{env['PATH']}"
+    env["BRAINLAYER_TEST_ROOT"] = str(test_root)
+    env["BRAINLAYER_USE_UV"] = "0"
+    env["BRAINLAYER_PREPUSH"] = "1"
+    env["BRAINLAYER_PREPUSH_SCOPE"] = "changed-only"
+    env["BRAINLAYER_CHANGED_FILES"] = "\n".join(
+        [
+            "src/brainlayer/vector_store.py",
+            "src/brainlayer/search_repo.py",
+            "src/brainlayer/index_new.py",
+        ]
+    )
+    env["PYTEST_LOG"] = str(pytest_log)
+    env["BUN_LOG"] = str(bun_log)
+
+    result = subprocess.run(["bash", str(SCRIPT_PATH)], capture_output=True, text=True, env=env)
+
+    assert result.returncode == 0
+    logged = pytest_log.read_text()
+    assert "falling back to full pytest unit suite" not in result.stdout
+    assert f"{test_root}/ -v" not in logged
+    for filename in expected:
+        assert str(test_root / filename) in logged
+
+
 def test_changed_only_scope_falls_back_when_mapped_and_unmapped_sources_change(tmp_path: Path) -> None:
     test_root = tmp_path / "tests"
     test_root.mkdir()

--- a/tests/test_run_tests_script.py
+++ b/tests/test_run_tests_script.py
@@ -251,6 +251,10 @@ def test_changed_only_scope_maps_source_class_storage_pipeline_to_safe_tests(tmp
         "test_source_class.py",
         "test_vector_store_schema_flags.py",
         "test_vector_store_upsert_transactions.py",
+        "test_hybrid_search.py",
+        "test_vector_store_readonly.py",
+        "test_search_trigram_fts.py",
+        "test_precompact_chunk_origin.py",
         "test_ingest_t3.py",
         "test_context_pipeline.py",
     )

--- a/tests/test_source_class.py
+++ b/tests/test_source_class.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+
+from brainlayer.agent_provenance import classify_provenance
+from brainlayer.ingest_denylist import BRAINLAYER_INGEST_DENYLIST_ENV, is_denylisted
+from brainlayer.vector_store import VectorStore
+
+
+def _claude_subagent(tmp_path: Path, repo: str, name: str = "agent.jsonl") -> Path:
+    return tmp_path / ".claude" / "projects" / f"-Users-test-Gits-{repo}" / "session" / "subagents" / name
+
+
+def test_five_value_source_class_taxonomy_and_null_for_ambiguous(tmp_path: Path) -> None:
+    cases = [
+        (tmp_path / ".codex" / "sessions" / "session.jsonl", "cli-agent"),
+        (tmp_path / ".gemini" / "sessions" / "session.jsonl", "cli-agent"),
+        (_claude_subagent(tmp_path, "domica"), "subagent"),
+        (_claude_subagent(tmp_path, "brainlayer"), "fleet-coordination"),
+        (_claude_subagent(tmp_path, "brainlayer", "brain-worker"), "brain-worker"),
+        (tmp_path / "notes" / "unattributed.jsonl", None),
+    ]
+
+    for source_file, expected in cases:
+        decision = classify_provenance(str(source_file))
+        assert decision.source_class == expected
+
+
+def test_generic_workflow_subagent_is_not_blanket_denied(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(BRAINLAYER_INGEST_DENYLIST_ENV, raising=False)
+    workflow = _claude_subagent(tmp_path, "brainlayer", "workflows/wf_123/agent.jsonl")
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        json.dumps({"attributionAgent": "workflow-subagent"}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert not is_denylisted(workflow)
+    assert classify_provenance(str(workflow)).source_class == "fleet-coordination"
+
+
+def test_per_class_default_visibility_opt_in_and_exact_expansion(tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "source-classes.db")
+    rows = [
+        ("cli", "cli-agent"),
+        ("desktop", "desktop"),
+        ("subagent", "subagent"),
+        ("brain-worker", "brain-worker"),
+        ("fleet", "fleet-coordination"),
+        ("legacy", None),
+    ]
+    for position, (chunk_id, source_class) in enumerate(rows):
+        store.conn.cursor().execute(
+            """
+            INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type,
+                char_count, conversation_id, position, source_class
+            ) VALUES (?, ?, '{}', ?, 'brainlayer', 'user_message', ?, ?, ?, ?)
+            """,
+            (
+                chunk_id,
+                f"source visibility token {chunk_id}",
+                f"/{chunk_id}.jsonl",
+                len(chunk_id),
+                f"conversation-{chunk_id}",
+                position,
+                source_class,
+            ),
+        )
+
+    default_ids = set(store.search(query_text="source visibility token", n_results=20)["ids"][0])
+    opt_in_ids = set(
+        store.search(
+            query_text="source visibility token",
+            n_results=20,
+            include_hidden_source_classes=True,
+        )["ids"][0]
+    )
+
+    assert default_ids == {"cli", "subagent", "fleet", "legacy"}
+    assert opt_in_ids == {"cli", "desktop", "subagent", "fleet", "legacy"}
+    for chunk_id in ("cli", "desktop", "subagent", "fleet", "legacy"):
+        assert store.get_context(chunk_id)["target"]["id"] == chunk_id
+
+    store.close()

--- a/tests/test_source_class.py
+++ b/tests/test_source_class.py
@@ -78,7 +78,7 @@ def test_per_class_default_visibility_opt_in_and_exact_expansion(tmp_path: Path)
 
     assert default_ids == {"cli", "subagent", "fleet", "legacy"}
     assert opt_in_ids == {"cli", "desktop", "subagent", "fleet", "legacy"}
-    for chunk_id in ("cli", "desktop", "subagent", "fleet", "legacy"):
+    for chunk_id in ("cli", "desktop", "subagent", "brain-worker", "fleet", "legacy"):
         assert store.get_context(chunk_id)["target"]["id"] == chunk_id
 
     store.close()

--- a/tests/test_source_class.py
+++ b/tests/test_source_class.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from brainlayer.agent_provenance import classify_provenance
+from brainlayer.agent_provenance import classify_provenance, derive_source_class
 from brainlayer.embeddings import EmbeddedChunk
 from brainlayer.index_new import index_chunks_to_sqlite
 from brainlayer.ingest_denylist import BRAINLAYER_INGEST_DENYLIST_ENV, is_denylisted
@@ -30,6 +30,15 @@ def test_five_value_source_class_taxonomy_and_null_for_ambiguous(tmp_path: Path)
     for source_file, expected in cases:
         decision = classify_provenance(str(source_file))
         assert decision.source_class == expected
+
+    assert (
+        derive_source_class(
+            "/archived/source-no-longer-readable.jsonl",
+            provenance_class="recon-agent",
+            source="claude_code",
+        )
+        == "brain-worker"
+    )
 
 
 def test_generic_workflow_subagent_is_not_blanket_denied(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_source_class.py
+++ b/tests/test_source_class.py
@@ -1,9 +1,16 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from brainlayer.agent_provenance import classify_provenance
+from brainlayer.embeddings import EmbeddedChunk
+from brainlayer.index_new import index_chunks_to_sqlite
 from brainlayer.ingest_denylist import BRAINLAYER_INGEST_DENYLIST_ENV, is_denylisted
+from brainlayer.pipeline.chunk import Chunk
+from brainlayer.pipeline.classify import ContentType, ContentValue
 from brainlayer.vector_store import VectorStore
+from scripts.verify_source_class_visibility import _audit_hidden_class_default_visibility
 
 
 def _claude_subagent(tmp_path: Path, repo: str, name: str = "agent.jsonl") -> Path:
@@ -36,6 +43,31 @@ def test_generic_workflow_subagent_is_not_blanket_denied(monkeypatch, tmp_path: 
 
     assert not is_denylisted(workflow)
     assert classify_provenance(str(workflow)).source_class == "fleet-coordination"
+
+
+def test_indexer_rejects_unknown_supplied_source_class_and_uses_provenance(monkeypatch, tmp_path: Path) -> None:
+    source_file = tmp_path / ".codex" / "sessions" / "session.jsonl"
+    chunk = Chunk(
+        content="A normal Codex memory that must not accept a forged class label.",
+        content_type=ContentType.ASSISTANT_TEXT,
+        value=ContentValue.MEDIUM,
+        metadata={"chunk_id": "classified", "source_class": "brain_worker"},
+        char_count=61,
+    )
+    captured: dict[str, object] = {}
+
+    class FakeStore:
+        def upsert_chunks(self, chunks, embeddings, *, deadline_monotonic=None):
+            captured["chunks"] = chunks
+            return len(chunks)
+
+    monkeypatch.setattr(
+        "brainlayer.index_new.embed_chunks",
+        lambda chunks, on_progress=None: [EmbeddedChunk(chunk=chunk, embedding=[0.1])],
+    )
+
+    assert index_chunks_to_sqlite([chunk], str(source_file), store=FakeStore()) == 1
+    assert captured["chunks"][0]["source_class"] == "cli-agent"
 
 
 def test_per_class_default_visibility_opt_in_and_exact_expansion(tmp_path: Path) -> None:
@@ -81,4 +113,30 @@ def test_per_class_default_visibility_opt_in_and_exact_expansion(tmp_path: Path)
     for chunk_id in ("cli", "desktop", "subagent", "brain-worker", "fleet", "legacy"):
         assert store.get_context(chunk_id)["target"]["id"] == chunk_id
 
+    store.close()
+
+
+def test_hidden_class_audit_fails_on_any_sampled_desktop_leak(tmp_path: Path, monkeypatch) -> None:
+    store = VectorStore(tmp_path / "source-class-audit.db")
+    store.conn.cursor().execute(
+        """
+        INSERT INTO chunks (
+            id, content, metadata, source_file, project, content_type,
+            char_count, conversation_id, position, source_class
+        ) VALUES ('desktop-leak', 'DesktopAggregateLeakNeedle durable sample', '{}',
+                  '/desktop.jsonl', 'brainlayer', 'user_message', 41, 'desktop-conversation', 0, 'desktop')
+        """
+    )
+    real_search = store.search
+
+    def leaking_search(*, query_text, **kwargs):
+        result = real_search(query_text=query_text, **kwargs)
+        if query_text == "DesktopAggregateLeakNeedle":
+            result["ids"][0].append("desktop-leak")
+        return result
+
+    monkeypatch.setattr(store, "search", leaking_search)
+
+    with pytest.raises(RuntimeError, match="desktop.*leak"):
+        _audit_hidden_class_default_visibility(store, "desktop")
     store.close()

--- a/tests/test_source_class_migration.py
+++ b/tests/test_source_class_migration.py
@@ -48,6 +48,13 @@ def _legacy_db(path: Path) -> None:
             "INSERT INTO chunk_fts_rowids(chunk_id, rowid) VALUES (?, ?)",
             [(row[0], position) for position, row in enumerate(conn.execute("SELECT id FROM chunks"), start=1)],
         )
+        conn.execute("CREATE TABLE chunk_vectors (chunk_id TEXT PRIMARY KEY, embedding BLOB)")
+        conn.execute("CREATE TABLE chunk_vectors_binary (chunk_id TEXT PRIMARY KEY, embedding BLOB)")
+        for table in ("chunk_vectors", "chunk_vectors_binary"):
+            conn.executemany(
+                f"INSERT INTO {table}(chunk_id, embedding) VALUES (?, X'00')",
+                [(row[0],) for row in conn.execute("SELECT id FROM chunks")],
+            )
 
 
 def test_migration_backfills_only_unambiguous_rows_and_writes_sha_ledgers(tmp_path: Path) -> None:
@@ -66,6 +73,7 @@ def test_migration_backfills_only_unambiguous_rows_and_writes_sha_ledgers(tmp_pa
         "subagent": 1,
     }
     assert receipt["fts_rows_removed"] == {"chunk_fts_rowids": 1, "chunks_fts": 1}
+    assert receipt["vector_rows_removed"] == {"chunk_vectors": 1, "chunk_vectors_binary": 1}
     with sqlite3.connect(db_path) as conn:
         assert dict(conn.execute("SELECT id, source_class FROM chunks")) == {
             "ambiguous": None,
@@ -88,6 +96,10 @@ def test_migration_backfills_only_unambiguous_rows_and_writes_sha_ledgers(tmp_pa
         assert schema_details["git_sha"] == GIT_SHA
         assert event == (GIT_SHA, "pytest", "success")
         assert conn.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'brain-worker'").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = 'brain-worker'").fetchone()[0] == 0
+        assert (
+            conn.execute("SELECT COUNT(*) FROM chunk_vectors_binary WHERE chunk_id = 'brain-worker'").fetchone()[0] == 0
+        )
 
     second = migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
     assert second["already_applied"] is True
@@ -107,6 +119,34 @@ def test_migration_rejects_non_commit_sha(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="40-character"):
         migration.migrate_source_class(db_path, git_sha="HEAD", actor="pytest")
+
+
+def test_migration_uses_subagent_attribution_and_not_chunk_role_mentions(tmp_path: Path) -> None:
+    db_path = tmp_path / "copy.db"
+    ordinary = tmp_path / ".claude" / "projects" / "-Users-test-Gits-brainlayer" / "s" / "subagents" / "a.jsonl"
+    worker = ordinary.with_name("b.jsonl")
+    ordinary.parent.mkdir(parents=True)
+    ordinary.write_text(json.dumps({"attributionAgent": "general-purpose"}) + "\n")
+    worker.write_text(json.dumps({"attributionAgent": "brain_worker"}) + "\n")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE chunks (id TEXT PRIMARY KEY, content TEXT, source_file TEXT, source TEXT, provenance_class TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO chunks VALUES (?, ?, ?, 'claude_code', NULL)",
+            [
+                ("ordinary", "Discuss the brain-worker and /weave rules.", str(ordinary)),
+                ("worker", "Neutral task text.", str(worker)),
+            ],
+        )
+
+    migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
+
+    with sqlite3.connect(db_path) as conn:
+        assert dict(conn.execute("SELECT id, source_class FROM chunks")) == {
+            "ordinary": "fleet-coordination",
+            "worker": "brain-worker",
+        }
 
 
 def test_migration_rerun_rejects_a_different_code_sha(tmp_path: Path) -> None:

--- a/tests/test_source_class_migration.py
+++ b/tests/test_source_class_migration.py
@@ -43,6 +43,11 @@ def _legacy_db(path: Path) -> None:
             "INSERT INTO chunks_fts(content, chunk_id) VALUES (?, ?)",
             [("visibility token", row[0]) for row in conn.execute("SELECT id FROM chunks")],
         )
+        conn.execute("CREATE TABLE chunk_fts_rowids (chunk_id TEXT PRIMARY KEY, rowid INTEGER NOT NULL)")
+        conn.executemany(
+            "INSERT INTO chunk_fts_rowids(chunk_id, rowid) VALUES (?, ?)",
+            [(row[0], position) for position, row in enumerate(conn.execute("SELECT id FROM chunks"), start=1)],
+        )
 
 
 def test_migration_backfills_only_unambiguous_rows_and_writes_sha_ledgers(tmp_path: Path) -> None:
@@ -60,6 +65,7 @@ def test_migration_backfills_only_unambiguous_rows_and_writes_sha_ledgers(tmp_pa
         "fleet-coordination": 1,
         "subagent": 1,
     }
+    assert receipt["fts_rows_removed"] == {"chunk_fts_rowids": 1, "chunks_fts": 1}
     with sqlite3.connect(db_path) as conn:
         assert dict(conn.execute("SELECT id, source_class FROM chunks")) == {
             "ambiguous": None,
@@ -135,3 +141,42 @@ def test_migration_allows_canonical_database_only_with_supervised_gate(monkeypat
 
     assert receipt["row_count_before"] == receipt["row_count_after"] == 6
     assert receipt["git_sha"] == GIT_SHA
+
+
+def test_idempotent_malformed_receipt_closes_connection(monkeypatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "copy.db"
+    _legacy_db(db_path)
+    migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE schema_migrations SET details = 'not-json' WHERE name = ?",
+            (migration.MIGRATION_NAME,),
+        )
+
+    real_connect = sqlite3.connect
+    tracked: list[object] = []
+
+    class TrackedConnection:
+        def __init__(self, *args, **kwargs) -> None:
+            self.connection = real_connect(*args, **kwargs)
+            self.closed = False
+
+        def __getattr__(self, name):
+            return getattr(self.connection, name)
+
+        def close(self) -> None:
+            self.closed = True
+            self.connection.close()
+
+    def connect(*args, **kwargs):
+        connection = TrackedConnection(*args, **kwargs)
+        tracked.append(connection)
+        return connection
+
+    monkeypatch.setattr(migration.sqlite3, "connect", connect)
+
+    with pytest.raises(json.JSONDecodeError):
+        migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
+
+    assert len(tracked) == 1
+    assert tracked[0].closed is True

--- a/tests/test_source_class_migration.py
+++ b/tests/test_source_class_migration.py
@@ -123,3 +123,15 @@ def test_migration_refuses_canonical_database_even_when_explicit(monkeypatch, tm
 
     with pytest.raises(ValueError, match="canonical"):
         migration.migrate_source_class(canonical, git_sha=GIT_SHA, actor="pytest")
+
+
+def test_migration_allows_canonical_database_only_with_supervised_gate(monkeypatch, tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical.db"
+    _legacy_db(canonical)
+    monkeypatch.setattr(migration, "get_db_path", lambda: canonical)
+    monkeypatch.setenv("BRAINLAYER_OFFLINE_MIGRATOR_GATED_SWAP", "1")
+
+    receipt = migration.migrate_source_class(canonical, git_sha=GIT_SHA, actor="pytest")
+
+    assert receipt["row_count_before"] == receipt["row_count_after"] == 6
+    assert receipt["git_sha"] == GIT_SHA

--- a/tests/test_source_class_migration.py
+++ b/tests/test_source_class_migration.py
@@ -1,0 +1,125 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import brainlayer.source_class_migration as migration
+
+GIT_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _legacy_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, source_file TEXT, source TEXT, provenance_class TEXT)")
+        conn.executemany(
+            "INSERT INTO chunks VALUES (?, ?, ?, ?)",
+            [
+                ("cli", "/Users/test/.codex/sessions/a.jsonl", "codex", None),
+                ("desktop", "/Users/test/.codex/sessions/app.jsonl", "codex", "t3-app-session"),
+                (
+                    "subagent",
+                    "/Users/test/.claude/projects/-Users-test-Gits-domica/s/subagents/a.jsonl",
+                    "claude_code",
+                    None,
+                ),
+                (
+                    "fleet",
+                    "/Users/test/.claude/projects/-Users-test-Gits-brainlayer/s/subagents/a.jsonl",
+                    "claude_code",
+                    None,
+                ),
+                (
+                    "brain-worker",
+                    "/Users/test/.claude/projects/-Users-test-Gits-brainlayer/s/subagents/brain-worker/a.jsonl",
+                    "claude_code",
+                    None,
+                ),
+                ("ambiguous", "/tmp/unattributed.jsonl", "manual", None),
+            ],
+        )
+        conn.execute("CREATE VIRTUAL TABLE chunks_fts USING fts5(content, chunk_id UNINDEXED)")
+        conn.executemany(
+            "INSERT INTO chunks_fts(content, chunk_id) VALUES (?, ?)",
+            [("visibility token", row[0]) for row in conn.execute("SELECT id FROM chunks")],
+        )
+
+
+def test_migration_backfills_only_unambiguous_rows_and_writes_sha_ledgers(tmp_path: Path) -> None:
+    db_path = tmp_path / "copy.db"
+    _legacy_db(db_path)
+
+    receipt = migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
+
+    assert receipt["row_count_before"] == receipt["row_count_after"] == 6
+    assert receipt["distribution"] == {
+        "NULL": 1,
+        "brain-worker": 1,
+        "cli-agent": 1,
+        "desktop": 1,
+        "fleet-coordination": 1,
+        "subagent": 1,
+    }
+    with sqlite3.connect(db_path) as conn:
+        assert dict(conn.execute("SELECT id, source_class FROM chunks")) == {
+            "ambiguous": None,
+            "brain-worker": "brain-worker",
+            "cli": "cli-agent",
+            "desktop": "desktop",
+            "fleet": "fleet-coordination",
+            "subagent": "subagent",
+        }
+        schema_details = json.loads(
+            conn.execute(
+                "SELECT details FROM schema_migrations WHERE name = ?",
+                (migration.MIGRATION_NAME,),
+            ).fetchone()[0]
+        )
+        event = conn.execute(
+            "SELECT commit_hash, actor, status FROM migration_events WHERE id = ?",
+            (migration.MIGRATION_EVENT_ID,),
+        ).fetchone()
+        assert schema_details["git_sha"] == GIT_SHA
+        assert event == (GIT_SHA, "pytest", "success")
+        assert conn.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'brain-worker'").fetchone()[0] == 0
+
+    second = migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
+    assert second["already_applied"] is True
+    with sqlite3.connect(db_path) as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM migration_events WHERE id = ?",
+                (migration.MIGRATION_EVENT_ID,),
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_migration_rejects_non_commit_sha(tmp_path: Path) -> None:
+    db_path = tmp_path / "copy.db"
+    _legacy_db(db_path)
+
+    with pytest.raises(ValueError, match="40-character"):
+        migration.migrate_source_class(db_path, git_sha="HEAD", actor="pytest")
+
+
+def test_migration_rerun_rejects_a_different_code_sha(tmp_path: Path) -> None:
+    db_path = tmp_path / "copy.db"
+    _legacy_db(db_path)
+    migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
+
+    with pytest.raises(RuntimeError, match="ledger SHA mismatch"):
+        migration.migrate_source_class(
+            db_path,
+            git_sha="fedcba9876543210fedcba9876543210fedcba98",
+            actor="pytest",
+        )
+
+
+def test_migration_refuses_canonical_database_even_when_explicit(monkeypatch, tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical.db"
+    _legacy_db(canonical)
+    monkeypatch.setattr(migration, "get_db_path", lambda: canonical)
+
+    with pytest.raises(ValueError, match="canonical"):
+        migration.migrate_source_class(canonical, git_sha=GIT_SHA, actor="pytest")

--- a/tests/test_source_class_migration.py
+++ b/tests/test_source_class_migration.py
@@ -1,8 +1,10 @@
 import json
 import sqlite3
+import struct
 from pathlib import Path
 
 import pytest
+import sqlite_vec
 
 import brainlayer.source_class_migration as migration
 
@@ -147,6 +149,37 @@ def test_migration_uses_subagent_attribution_and_not_chunk_role_mentions(tmp_pat
             "ordinary": "fleet-coordination",
             "worker": "brain-worker",
         }
+
+
+def test_migration_loads_vec0_and_purges_brain_worker_candidates(tmp_path: Path) -> None:
+    db_path = tmp_path / "vec0-copy.db"
+    _legacy_db(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE chunk_vectors")
+        conn.execute("DROP TABLE chunk_vectors_binary")
+        conn.enable_load_extension(True)
+        conn.load_extension(sqlite_vec.loadable_path())
+        conn.enable_load_extension(False)
+        conn.execute("CREATE VIRTUAL TABLE chunk_vectors USING vec0(chunk_id TEXT PRIMARY KEY, embedding FLOAT[1024])")
+        conn.execute(
+            "CREATE VIRTUAL TABLE chunk_vectors_binary USING vec0(chunk_id TEXT PRIMARY KEY, embedding BIT[1024])"
+        )
+        float_embedding = struct.pack("<1024f", *([0.0] * 1024))
+        for chunk_id in ("cli", "brain-worker"):
+            conn.execute("INSERT INTO chunk_vectors(chunk_id, embedding) VALUES (?, ?)", (chunk_id, float_embedding))
+            conn.execute(
+                "INSERT INTO chunk_vectors_binary(chunk_id, embedding) VALUES (?, vec_quantize_binary(?))",
+                (chunk_id, float_embedding),
+            )
+
+    receipt = migration.migrate_source_class(db_path, git_sha=GIT_SHA, actor="pytest")
+
+    assert receipt["vector_rows_removed"] == {"chunk_vectors": 1, "chunk_vectors_binary": 1}
+    with sqlite3.connect(db_path) as conn:
+        conn.enable_load_extension(True)
+        conn.load_extension(sqlite_vec.loadable_path())
+        assert conn.execute("SELECT chunk_id FROM chunk_vectors").fetchall() == [("cli",)]
+        assert conn.execute("SELECT chunk_id FROM chunk_vectors_binary").fetchall() == [("cli",)]
 
 
 def test_migration_rerun_rejects_a_different_code_sha(tmp_path: Path) -> None:

--- a/tests/test_vector_store_schema_flags.py
+++ b/tests/test_vector_store_schema_flags.py
@@ -10,7 +10,7 @@ def test_writer_init_marks_provenance_columns_available(tmp_path, monkeypatch):
     try:
         columns = {row[1] for row in store.conn.cursor().execute("PRAGMA table_info(chunks)")}
 
-        assert {"provenance_class", "superseded_by"}.issubset(columns)
+        assert {"provenance_class", "source_class", "superseded_by"}.issubset(columns)
         assert _optional_chunk_expr(store, "provenance_class") == "provenance_class"
         assert _optional_chunk_expr(store, "superseded_by") == "superseded_by"
     finally:
@@ -19,6 +19,7 @@ def test_writer_init_marks_provenance_columns_available(tmp_path, monkeypatch):
     readonly_store = VectorStore(tmp_path / "brainlayer.db", readonly=True)
     try:
         assert _optional_chunk_expr(readonly_store, "provenance_class") == "provenance_class"
+        assert readonly_store._has_source_class is True
         assert _optional_chunk_expr(readonly_store, "superseded_by") == "superseded_by"
     finally:
         readonly_store.close()

--- a/tests/test_vector_store_upsert_transactions.py
+++ b/tests/test_vector_store_upsert_transactions.py
@@ -180,6 +180,7 @@ def test_t3_upsert_persists_provenance_and_accepts_mirrored_duplicates(isolated_
             "project": None,
             "source": "t3",
             "provenance_class": "t3-thread",
+            "source_class": "desktop",
             "allow_duplicate": True,
         },
         {
@@ -187,6 +188,7 @@ def test_t3_upsert_persists_provenance_and_accepts_mirrored_duplicates(isolated_
             "project": None,
             "source": "t3",
             "provenance_class": "t3-thread",
+            "source_class": "desktop",
             "allow_duplicate": True,
         },
     ]
@@ -195,12 +197,14 @@ def test_t3_upsert_persists_provenance_and_accepts_mirrored_duplicates(isolated_
 
     rows = (
         isolated_store.conn.cursor()
-        .execute("SELECT id, source, provenance_class FROM chunks WHERE id LIKE 't3-thread-%' ORDER BY id")
+        .execute(
+            "SELECT id, source, provenance_class, source_class FROM chunks WHERE id LIKE 't3-thread-%' ORDER BY id"
+        )
         .fetchall()
     )
     assert rows == [
-        ("t3-thread-1", "t3", "t3-thread"),
-        ("t3-thread-2", "t3", "t3-thread"),
+        ("t3-thread-1", "t3", "t3-thread", "desktop"),
+        ("t3-thread-2", "t3", "t3-thread", "desktop"),
     ]
 
 

--- a/tests/test_vector_store_upsert_transactions.py
+++ b/tests/test_vector_store_upsert_transactions.py
@@ -208,6 +208,21 @@ def test_t3_upsert_persists_provenance_and_accepts_mirrored_duplicates(isolated_
     ]
 
 
+def test_repeat_upsert_validates_and_backfills_source_class(isolated_store):
+    first = {**_chunk("replayed"), "source_class": "brain_worker"}
+    replay = {**_chunk("replayed"), "source_class": "desktop"}
+
+    isolated_store.upsert_chunks([first], [_embedding(1)])
+    assert isolated_store.conn.cursor().execute("SELECT source_class FROM chunks WHERE id = 'replayed'").fetchone() == (
+        None,
+    )
+
+    isolated_store.upsert_chunks([replay], [_embedding(1)])
+    assert isolated_store.conn.cursor().execute("SELECT source_class FROM chunks WHERE id = 'replayed'").fetchone() == (
+        "desktop",
+    )
+
+
 def test_busy_sub_batch_retries_without_replaying_committed_sub_batches(isolated_store, monkeypatch):
     monkeypatch.setenv("BRAINLAYER_INDEX_TXN_BATCH", "2")
     insert_attempts: dict[str, int] = {}

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -812,6 +812,30 @@ class TestFullPipeline:
         conn.close()
         assert len(rows) >= 1
 
+    def test_direct_watcher_insert_is_safe_before_source_class_migration(self, tmp_path):
+        db_path = tmp_path / "legacy-without-source-class.db"
+        store = VectorStore(db_path)
+        store.close()
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DROP INDEX IF EXISTS idx_chunks_source_class")
+            conn.execute("ALTER TABLE chunks DROP COLUMN source_class")
+
+        source_file = tmp_path / "projects" / "test-project" / "session.jsonl"
+        entry = _make_jsonl_entry(
+            text="LegacySchemaNeedle direct watcher writes must remain safe before the supervised migration.",
+            entry_type="assistant",
+        )
+        entry["_source_file"] = str(source_file)
+
+        result = create_flush_callback(db_path, arbitrated=False)([entry])
+
+        assert result.inserted == 1
+        with sqlite3.connect(db_path) as conn:
+            assert "source_class" not in {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+            assert conn.execute("SELECT COUNT(*) FROM chunks WHERE content LIKE '%LegacySchemaNeedle%'").fetchone() == (
+                1,
+            )
+
     def test_fts5_searchable_after_insert(self, tmp_path):
         db_path = tmp_path / "test.db"
         VectorStore(db_path).close()

--- a/tests/test_watcher_bridge.py
+++ b/tests/test_watcher_bridge.py
@@ -641,7 +641,7 @@ class TestFlushCallback:
 
 class TestFullPipeline:
     def test_watcher_denylist_blocks_brain_workers_and_allows_ordinary_subagents(self, tmp_path, monkeypatch):
-        """Exercise #666 while naming workflow-path exclusion below as known drift, not policy."""
+        """Exercise #666: only memory-reading workers stay out of the index."""
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.delenv("BRAINLAYER_INGEST_DENYLIST", raising=False)
         db_path = tmp_path / "test.db"
@@ -655,15 +655,6 @@ class TestFullPipeline:
             / "session-123"
             / "subagents"
             / "agent-brain.jsonl",
-            "known-drift-workflow-worker": tmp_path
-            / ".claude"
-            / "projects"
-            / "proj"
-            / "session-123"
-            / "subagents"
-            / "workflows"
-            / "wf_123"
-            / "agent-workflow.jsonl",
         }
         allowed = {
             "codex": tmp_path / ".codex" / "sessions" / "2026" / "07" / "02" / "worker.jsonl",
@@ -683,13 +674,19 @@ class TestFullPipeline:
             / "session-123"
             / "subagents"
             / "agent-general.jsonl",
+            "workflow-subagent": tmp_path
+            / ".claude"
+            / "projects"
+            / "proj"
+            / "session-123"
+            / "subagents"
+            / "workflows"
+            / "wf_123"
+            / "agent-workflow.jsonl",
         }
         for provider, path in denylisted.items():
             path.parent.mkdir(parents=True, exist_ok=True)
-            attribution = {
-                "brain-worker": "brain-worker",
-                "known-drift-workflow-worker": "workflow-subagent",
-            }[provider]
+            attribution = "brain-worker"
             path.write_text(
                 json.dumps(
                     _make_jsonl_entry(
@@ -707,7 +704,13 @@ class TestFullPipeline:
 
         for provider, path in allowed.items():
             path.parent.mkdir(parents=True, exist_ok=True)
-            extra = {"attributionAgent": "general-purpose"} if provider == "claude-subagent" else {}
+            extra = (
+                {"attributionAgent": "workflow-subagent"}
+                if provider == "workflow-subagent"
+                else {"attributionAgent": "general-purpose"}
+                if provider == "claude-subagent"
+                else {}
+            )
             sentinel_provider = provider.replace("-", "").upper()
             path.write_text(
                 json.dumps(
@@ -750,6 +753,9 @@ class TestFullPipeline:
                 )
             for provider, path in allowed.items():
                 sentinel_provider = provider.replace("-", "").upper()
+                expected_source_class = (
+                    "subagent" if provider in {"claude-subagent", "workflow-subagent"} else "cli-agent"
+                )
                 assert (
                     conn.execute("SELECT count(*) FROM chunks WHERE source_file = ?", (str(path),)).fetchone()[0] >= 1
                 )
@@ -760,6 +766,13 @@ class TestFullPipeline:
                     ).fetchone()[0]
                     >= 1
                 ), provider
+                assert {
+                    row[0]
+                    for row in conn.execute(
+                        "SELECT source_class FROM chunks WHERE source_file = ?",
+                        (str(path),),
+                    )
+                } == {expected_source_class}
             assert (
                 conn.execute(
                     "SELECT count(*) FROM chunks_fts WHERE chunks_fts MATCH ?",

--- a/tests/test_watcher_provenance_ingest.py
+++ b/tests/test_watcher_provenance_ingest.py
@@ -49,7 +49,7 @@ def test_direct_session_ingest_stays_default_visible_and_never_operational_or_co
     assert metadata["provenance_effective_visibility"] == "default"
 
 
-def test_cursor_agent_transcript_ingest_is_tagged_and_routed_operational(tmp_path):
+def test_cursor_agent_transcript_ingest_is_tagged_and_default_searchable(tmp_path):
     db_path = tmp_path / "brainlayer.db"
     source_file = (
         tmp_path / "home" / ".cursor" / "projects" / "brainlayer" / "agent-transcripts" / "cursor-gather.jsonl"
@@ -62,13 +62,13 @@ def test_cursor_agent_transcript_ingest_is_tagged_and_routed_operational(tmp_pat
     assert result.inserted == 1
     content_class, provenance_class, metadata, normal_fts_count, operational_fts_count = _single_inserted_row(db_path)
     assert (content_class, provenance_class, normal_fts_count, operational_fts_count) == (
-        "operational",
+        "knowledge",
         "cursor-gather",
-        0,
         1,
+        0,
     )
     assert metadata["provenance_tag"] == "cursor-gather"
-    assert metadata["provenance_effective_visibility"] == "operational"
+    assert metadata["provenance_effective_visibility"] == "default"
 
 
 def test_gemini_session_ingest_is_searchable_by_default(tmp_path):

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -142,6 +142,7 @@ class TestQueueStore:
             created_at="2026-07-08T12:00:00Z",
             conversation_id="session",
             provenance_class="cursor-gather",
+            source_class="cli-agent",
             content_class="operational",
             queue_dir=tmp_path,
         )
@@ -149,6 +150,7 @@ class TestQueueStore:
         item = json.loads(path.read_text())
 
         assert item["provenance_class"] == "cursor-gather"
+        assert item["source_class"] == "cli-agent"
         assert item["content_class"] == "operational"
 
     def test_enqueue_watcher_chunk_omits_empty_provenance_routing_fields(self, tmp_path):
@@ -260,6 +262,7 @@ class TestQueueStore:
             "created_at": "2026-07-08T12:00:00Z",
             "conversation_id": "session-provenance-routing",
             "provenance_class": "cursor-gather",
+            "source_class": "cli-agent",
             "content_class": "operational",
         }
         queue_dir.mkdir()
@@ -270,7 +273,7 @@ class TestQueueStore:
         with sqlite3.connect(db_path) as conn:
             row = conn.execute(
                 """
-                SELECT content_class, provenance_class,
+                SELECT content_class, provenance_class, source_class,
                        (SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = chunks.id),
                        (SELECT COUNT(*) FROM chunks_fts_operational WHERE chunk_id = chunks.id)
                 FROM chunks WHERE id = ?
@@ -279,7 +282,7 @@ class TestQueueStore:
             ).fetchone()
 
         assert drained == 1
-        assert row == ("operational", "cursor-gather", 0, 1)
+        assert row == ("operational", "cursor-gather", "cli-agent", 0, 1)
 
     def test_drain_classifies_legacy_watcher_event_without_routing_fields(self, tmp_path, monkeypatch):
         """Legacy watcher queue files without explicit routing fields still use classifier fallback."""


### PR DESCRIPTION
## Summary

- add the five-value `chunks.source_class` taxonomy with `NULL` for ambiguous historical rows, propagate it through ingest/write paths, and enforce default visibility for CLI agents, desktop sessions, subagents, brain-workers, and fleet coordination
- add the supervised offline migration with exact-code-SHA entries in both ledgers, audited brain-worker FTS removal, idempotency, and the #666 per-class visibility/expansion acceptance coverage
- add the measured [two-host LIVE runbook](https://github.com/EtanHey/brainlayer/blob/99713ebad1b71e6be12afce96a5c571f854f9f17/docs/operations/wave3-3a-two-host-live-runbook.md), with BrainBar v1.5.4 backup-pipeline as Tuesday's primary route and the rehearsal-proven online-backup method only as contingency

## Rehearsal receipt

- migration code/ledger SHA: `be877608ae5ff14de079ccd40949ef14f88aa578`
- real DB copy: 744,335 rows before/after; 198.82s migration; WAL 0 / 29,181,992-byte observed peak / 0
- distribution: NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 97,678; subagent 37,445
- final `PRAGMA quick_check=ok` in 503.49s; both ledgers exact; zero invalid classes and zero brain-worker FTS rows
- exact-row visibility/expansion green for all six buckets; rollback re-copy 0.00s; contingency online-backup replay 26.16s from a `mode=ro` source
- no canonical DB writes or service mutations

## Verification

- focused source-class gate: 198 passed
- scoped pre-push: 313 targeted pytest + 3 MCP registration + 40 isolated eval/hook + Bun + FTS shell green
- broad gate: 3,969 passed / 10 skipped / 62 deselected / 2 xfailed; excludes the two worker-prohibited real-DB files and one separately diagnosed unrelated MPS arbitration no-progress call
- Ruff, format check, runbook `bash -n`, and `git diff --check` green
- local CodeRabbit exact-diff review: three findings fixed and disposition tracked in `docs/operations/wave3-source-class-review-disposition.md`

This PR must not merge before hosted Codex review and lead-routed Claude exact-head pair review. LIVE execution remains Tuesday 20:00+ IDT with Etan present.

— brainlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feadc","ts":"2026-08-10T11:16:06Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default memory search results and production DB migration semantics once `source_class` is populated; mitigated by column-absent compatibility, gated canonical migration, and rehearsal runbooks, but LIVE deploy order (BrainBar v1.5.6 before migrate) is mandatory.
> 
> **Overview**
> Adds a five-value `source_class` on memory chunks and threads it through ingest (watcher, queue, drain, indexer, upsert) with path/provenance-based classification instead of content-keyword recon detection. **Default search** (Python hybrid/KNN/FTS and BrainBar FTS) now hides `desktop` and `brain-worker` rows when the column exists; an internal opt-in can surface desktop but never brain-workers. Brain-worker chunks are dropped at ingest where applicable, and the offline migrator backfills classes, strips brain-worker FTS/vector index rows, and pins exact git SHAs in schema/event ledgers.
> 
> BrainBar consolidates duplicate “active chunk” SQL into `searchableChunkWhereClause` and extends it with `source_class` filtering. Hybrid search gains KNN overfetch for filtered classes, BrainBar fast-profile retry when hidden rows exhaust K, and hybrid-cache entries keyed to per-connection `PRAGMA data_version` so class changes cannot serve stale results.
> 
> Ships `scripts/migrate_source_class.py`, `verify_source_class_visibility.py`, Wave 3 two-host LIVE runbook/review disposition, and broad test/coverage mapping for the new pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 065d602651bc14b096f268482cc125eaca450354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add source_class taxonomy to memory chunks with migration, search filtering, and provenance-driven classification
> - Introduces a five-value `source_class` taxonomy (`desktop`, `brain-worker`, `cli-agent`, `subagent`, `fleet-coordination`) stored in a new `chunks.source_class` column, with schema detection via `_has_source_class` flags across storage components.
> - Updates `classify_provenance` in [agent_provenance.py](https://github.com/EtanHey/brainlayer/pull/700/files#diff-57296bee549fc366c410ccd22072917ab0333369dd41c4fc2917d3b281e6a268) to populate `source_class` on every `ProvenanceDecision`; adds `derive_source_class`, `normalize_source_class`, and `resolve_source_class` helpers.
> - Search (Python and Swift) now excludes `desktop` and `brain-worker` chunks by default, with KNN over-fetching to compensate for hidden rows; opt-in via `include_hidden_source_classes`.
> - Adds [source_class_migration.py](https://github.com/EtanHey/brainlayer/pull/700/files#diff-0e7e0c308ad5e63a89b9505a0f7c1791330570f2a2c49753cf597806ccaf17db) and a [CLI script](https://github.com/EtanHey/brainlayer/pull/700/files#diff-2617b54290ecf95daac4b705cc421a57c110c4037e1e9d439f5cd0133dae29bc) to backfill `source_class` on existing databases and purge `brain-worker` rows from FTS/vector tables.
> - Changes default denylist: `wf_*` workflow paths are no longer blanket-denied; only paths attributed to memory readers (`brain-worker`, `session-miner`, `weave`) are denied by default.
> - Adds [verify_source_class_visibility.py](https://github.com/EtanHey/brainlayer/pull/700/files#diff-e7de2e0ec880bcfe0bb466718a0c09e40356e19f2c245a45e488fb6f0cf334e4) to audit post-migration search visibility.
> - Risk: workflow-agent policy changes from ISOLATE to KEEP, and `brain-worker` chunks are actively excluded from search indexes rather than merely isolated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 065d602.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now applies clearer source-visibility rules, hiding desktop and background-worker records by default while preserving relevant context.
  * Added optional expanded visibility for desktop records.
  * Added tools to classify, migrate, and verify source information in existing data.
  * Smoke tests can limit result counts and save raw responses securely.
* **Bug Fixes**
  * Improved ingestion filtering and preserved source classifications across ingestion paths.
  * Improved filtered search retries and cache invalidation.
* **Documentation**
  * Added live migration, rollback, and migration review documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->