### PR TITLE
fix(brainbar): keep MCP responsive during backup

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -130,6 +130,7 @@ final class BrainBarServer: @unchecked Sendable {
     private var instanceLock: BrainBarInstanceLock?
     private var daemonHeartbeatTimer: DispatchSourceTimer?
     private var backupToolCallInProgress = false
+    private var deferredDisconnectedAgentIDs = Set<String>()
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
     var onStartRejected: (@Sendable (String) -> Void)?
     /// Maximum EAGAIN retries before disconnecting a stalled client.
@@ -622,7 +623,8 @@ final class BrainBarServer: @unchecked Sendable {
             self.queue.async { [weak self] in
                 guard let self else { return }
                 self.backupToolCallInProgress = false
-                guard self.clients[fd] != nil else { return }
+                self.flushDeferredSubscriberDisconnects()
+                guard self.clients[fd]?.paletteSession === paletteSession else { return }
                 self.sendResponse(fd: fd, response: responseBox.value, useContentLength: useContentLength)
                 self.debugLog("  SENT async response for brain_backup_vacuum_into")
             }
@@ -824,11 +826,23 @@ final class BrainBarServer: @unchecked Sendable {
             brainBus.unsubscribeSynchronously(subscriptionID)
         }
         if let agentID = clients[fd]?.agentID {
-            try? database?.markSubscriberDisconnected(agentID: agentID)
+            if backupToolCallInProgress {
+                deferredDisconnectedAgentIDs.insert(agentID)
+            } else {
+                try? database?.markSubscriberDisconnected(agentID: agentID)
+            }
         }
         clients[fd]?.source.cancel()
         clients.removeValue(forKey: fd)
         NSLog("[BrainBar] Client disconnected (fd: %d)", fd)
+    }
+
+    private func flushDeferredSubscriberDisconnects() {
+        let agentIDs = deferredDisconnectedAgentIDs
+        deferredDisconnectedAgentIDs.removeAll()
+        for agentID in agentIDs {
+            try? database?.markSubscriberDisconnected(agentID: agentID)
+        }
     }
 
     private func cleanup() {
@@ -850,6 +864,7 @@ final class BrainBarServer: @unchecked Sendable {
         // The backup runs off the request queue so protocol traffic stays live.
         // Drain it before closing the shared SQLite connection during shutdown.
         backupToolQueue.sync {}
+        flushDeferredSubscriberDisconnects()
         let writeDatabase = database
         if providedDatabase == nil {
             if let readDatabase, let writeDatabase, readDatabase !== writeDatabase {

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -104,6 +104,10 @@ final class BrainBarServer: @unchecked Sendable {
     private let instanceLockPath: String
     private static let queueKey = DispatchSpecificKey<UUID>()
     private let queue = DispatchQueue(label: BrainBarServer.requestQueueLabel, qos: .userInitiated)
+    private let backupToolQueue = DispatchQueue(
+        label: "com.brainlayer.brainbar.backup-tool",
+        qos: .utility
+    )
     private let daemonHeartbeatQueue = DispatchQueue(
         label: BrainBarServer.daemonHeartbeatQueueLabel,
         qos: .utility
@@ -125,6 +129,7 @@ final class BrainBarServer: @unchecked Sendable {
     private var databaseOpenInProgress = false
     private var instanceLock: BrainBarInstanceLock?
     private var daemonHeartbeatTimer: DispatchSourceTimer?
+    private var backupToolCallInProgress = false
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
     var onStartRejected: (@Sendable (String) -> Void)?
     /// Maximum EAGAIN retries before disconnecting a stalled client.
@@ -164,6 +169,14 @@ final class BrainBarServer: @unchecked Sendable {
         var agentID: String?
         var subscribedTags: Set<String> = []
         var brainBusSubscriptionID: BrainBusEventHub.SubscriptionID?
+    }
+
+    private final class SendableBox<Value>: @unchecked Sendable {
+        let value: Value
+
+        init(_ value: Value) {
+            self.value = value
+        }
     }
 
     init(
@@ -486,6 +499,15 @@ final class BrainBarServer: @unchecked Sendable {
             let method = msg["method"] as? String ?? "<no method>"
             let id = msg["id"]
             debugLog("  MSG fd=\(fd): method=\(method) id=\(String(describing: id))")
+            if parseToolCall(msg)?.name == "brain_backup_vacuum_into" {
+                handleBackupToolCallAsync(
+                    fd: fd,
+                    request: msg,
+                    useContentLength: state.usesContentLengthFraming
+                )
+                debugLog("  DEFERRED response for method=\(method) to backup queue")
+                continue
+            }
             let response = handleMessage(fd: fd, request: msg)
             if !response.isEmpty {
                 sendResponse(fd: fd, response: response, useContentLength: state.usesContentLengthFraming)
@@ -507,6 +529,16 @@ final class BrainBarServer: @unchecked Sendable {
     private func handleMessage(fd: Int32, request: [String: Any]) -> [String: Any] {
         let paletteSession = clients[fd]?.paletteSession
         if let toolCall = parseToolCall(request) {
+            if backupToolCallInProgress, !canHandleDuringBackup(toolCall.name) {
+                return [
+                    "jsonrpc": "2.0",
+                    "id": request["id"] as Any,
+                    "error": [
+                        "code": -32000,
+                        "message": "BrainBar backup snapshot is in progress; retry this tool call shortly.",
+                    ] as [String: Any],
+                ]
+            }
             switch toolCall.name {
             case "brain_subscribe":
                 guard let paletteSession,
@@ -546,6 +578,55 @@ final class BrainBarServer: @unchecked Sendable {
             }
         }
         return router.handle(request, session: paletteSession)
+    }
+
+    private func canHandleDuringBackup(_ toolName: String) -> Bool {
+        if toolName == "expand_palette" { return true }
+        // Production keeps reads on a separate SQLite connection. Do not allow
+        // recall concurrently in injected/single-connection test topologies.
+        return toolName == "brain_recall"
+            && readDatabase != nil
+            && database != nil
+            && readDatabase !== database
+    }
+
+    /// VACUUM INTO can run for minutes on the production database. It must not
+    /// occupy the serial socket queue: initialize, tools/list, and lightweight
+    /// protocol calls are fleet liveness, even while a scheduled backup runs.
+    private func handleBackupToolCallAsync(
+        fd: Int32,
+        request: [String: Any],
+        useContentLength: Bool
+    ) {
+        guard !backupToolCallInProgress else {
+            let response: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": request["id"] as Any,
+                "error": [
+                    "code": -32000,
+                    "message": "A BrainBar backup snapshot is already in progress.",
+                ] as [String: Any],
+            ]
+            sendResponse(fd: fd, response: response, useContentLength: useContentLength)
+            return
+        }
+        guard let paletteSession = clients[fd]?.paletteSession else { return }
+
+        backupToolCallInProgress = true
+        let requestBox = SendableBox(request)
+        backupToolQueue.async { [weak self] in
+            guard let self else { return }
+            let responseBox = SendableBox(
+                self.router.handle(requestBox.value, session: paletteSession)
+            )
+            self.queue.async { [weak self] in
+                guard let self else { return }
+                self.backupToolCallInProgress = false
+                guard self.clients[fd] != nil else { return }
+                self.sendResponse(fd: fd, response: responseBox.value, useContentLength: useContentLength)
+                self.debugLog("  SENT async response for brain_backup_vacuum_into")
+            }
+        }
     }
 
     @discardableResult
@@ -766,6 +847,9 @@ final class BrainBarServer: @unchecked Sendable {
         clients.removeAll()
         if listenFD >= 0 { listenFD = -1 }
         unlink(socketPath)
+        // The backup runs off the request queue so protocol traffic stays live.
+        // Drain it before closing the shared SQLite connection during shutdown.
+        backupToolQueue.sync {}
         let writeDatabase = database
         if providedDatabase == nil {
             if let readDatabase, let writeDatabase, readDatabase !== writeDatabase {

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -133,6 +133,7 @@ final class BrainBarServer: @unchecked Sendable {
     private var deferredDisconnectedAgentIDs = Set<String>()
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
     var onStartRejected: (@Sendable (String) -> Void)?
+    var onDeferredBackupResponseDropped: (@Sendable (_ descriptorWasReused: Bool) -> Void)?
     /// Maximum EAGAIN retries before disconnecting a stalled client.
     /// Each retry sleeps 1ms; 50 retries keeps false-positive disconnects
     /// below the UI budget while still bounding serial-queue stalls.
@@ -624,7 +625,10 @@ final class BrainBarServer: @unchecked Sendable {
                 guard let self else { return }
                 self.backupToolCallInProgress = false
                 self.flushDeferredSubscriberDisconnects()
-                guard self.clients[fd]?.paletteSession === paletteSession else { return }
+                guard self.clients[fd]?.paletteSession === paletteSession else {
+                    self.onDeferredBackupResponseDropped?(self.clients[fd] != nil)
+                    return
+                }
                 self.sendResponse(fd: fd, response: responseBox.value, useContentLength: useContentLength)
                 self.debugLog("  SENT async response for brain_backup_vacuum_into")
             }

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -134,6 +134,8 @@ final class BrainBarServer: @unchecked Sendable {
     var onDatabaseReady: (@Sendable (BrainDatabase) -> Void)?
     var onStartRejected: (@Sendable (String) -> Void)?
     var onDeferredBackupResponseDropped: (@Sendable (_ descriptorWasReused: Bool) -> Void)?
+    var onClientAccepted: (@Sendable (Int32) -> Void)?
+    var onClientDescriptorClosed: (@Sendable (Int32) -> Void)?
     /// Maximum EAGAIN retries before disconnecting a stalled client.
     /// Each retry sleeps 1ms; 50 retries keeps false-positive disconnects
     /// below the UI budget while still bounding serial-queue stalls.
@@ -459,8 +461,9 @@ final class BrainBarServer: @unchecked Sendable {
         readSource.setEventHandler { [weak self] in
             self?.readFromClient(fd: clientFD)
         }
-        readSource.setCancelHandler {
+        readSource.setCancelHandler { [weak self] in
             close(clientFD)
+            self?.onClientDescriptorClosed?(clientFD)
         }
         readSource.resume()
 
@@ -469,6 +472,7 @@ final class BrainBarServer: @unchecked Sendable {
             framing: MCPFraming(),
             paletteSession: router.makePaletteSession()
         )
+        onClientAccepted?(clientFD)
         NSLog("[BrainBar] Client connected (fd: %d)", clientFD)
         debugLog("CLIENT CONNECTED fd=\(clientFD) (total clients: \(clients.count))")
     }

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -424,6 +424,22 @@ final class SocketIntegrationTests: XCTestCase {
         ])
         Thread.sleep(forTimeInterval: 0.05)
 
+        let subscriberFD = try connectClient()
+        try initializeClient(fd: subscriberFD, name: "backup-liveness-subscriber")
+        try sendMCPRequest(on: subscriberFD, request: [
+            "jsonrpc": "2.0", "id": 44, "method": "tools/call",
+            "params": ["name": "expand_palette", "arguments": [:] as [String: Any]],
+        ])
+        _ = try readMCPMessage(fd: subscriberFD)
+        try sendMCPRequest(on: subscriberFD, request: [
+            "jsonrpc": "2.0", "id": 45, "method": "tools/call",
+            "params": [
+                "name": "brain_subscribe",
+                "arguments": ["agent_id": "backup-liveness-agent", "tags": ["agent-message"]],
+            ],
+        ])
+        _ = try readMCPMessage(fd: subscriberFD)
+
         let progressGate = SQLiteProgressGate()
         defer { progressGate.release.signal() }
         sqlite3_progress_handler(
@@ -439,7 +455,6 @@ final class SocketIntegrationTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: targetPath + ".complete") }
 
         let backupFD = try connectClient()
-        defer { close(backupFD) }
         try sendMCPRequest(on: backupFD, request: [
             "jsonrpc": "2.0",
             "id": 40,
@@ -450,6 +465,13 @@ final class SocketIntegrationTests: XCTestCase {
             ],
         ])
         XCTAssertEqual(progressGate.entered.wait(timeout: .now() + 1), .success)
+
+        // Both disconnect paths must leave the request queue live: subscriber
+        // cleanup cannot write on the VACUUM connection, and a reused numeric fd
+        // must not receive the original request's deferred response.
+        close(subscriberFD)
+        close(backupFD)
+        Thread.sleep(forTimeInterval: 0.05)
 
         // Deployment health is a held-open, fresh-socket protocol sequence —
         // initialize + tools/list + a real tool call — not a version/plist probe.
@@ -480,7 +502,8 @@ final class SocketIntegrationTests: XCTestCase {
         }
 
         progressGate.release.signal()
-        _ = try readMCPMessage(fd: backupFD, timeout: 2)
+        let staleResponse = try? readMCPMessage(fd: probeFD, timeout: 0.2)
+        XCTAssertNil(staleResponse, "A reused fd must not receive the disconnected backup client's response")
         if initialize == nil {
             _ = try? readMCPMessage(fd: probeFD, timeout: 1)
         }
@@ -1183,12 +1206,28 @@ final class SocketIntegrationTests: XCTestCase {
     private func waitForSocket(at path: String, timeout: TimeInterval = 3.0) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if FileManager.default.fileExists(atPath: path) {
-                return true
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return false }
+            var addr = sockaddr_un()
+            addr.sun_family = sa_family_t(AF_UNIX)
+            let pathBytes = path.utf8CString
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                ptr.withMemoryRebound(to: CChar.self, capacity: 104) { destination in
+                    pathBytes.withUnsafeBufferPointer { source in
+                        _ = memcpy(destination, source.baseAddress!, source.count)
+                    }
+                }
             }
+            let connected = withUnsafePointer(to: &addr) { addrPointer in
+                addrPointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                    connect(fd, socketAddress, socklen_t(MemoryLayout<sockaddr_un>.size)) == 0
+                }
+            }
+            close(fd)
+            if connected { return true }
             Thread.sleep(forTimeInterval: 0.01)
         }
-        return FileManager.default.fileExists(atPath: path)
+        return false
     }
 
     private func sendMCPRequest(_ request: [String: Any]) throws -> [String: Any] {

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -455,6 +455,7 @@ final class SocketIntegrationTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: targetPath + ".complete") }
 
         let backupFD = try connectClient()
+        defer { close(backupFD) }
         try sendMCPRequest(on: backupFD, request: [
             "jsonrpc": "2.0",
             "id": 40,
@@ -466,11 +467,9 @@ final class SocketIntegrationTests: XCTestCase {
         ])
         XCTAssertEqual(progressGate.entered.wait(timeout: .now() + 1), .success)
 
-        // Both disconnect paths must leave the request queue live: subscriber
-        // cleanup cannot write on the VACUUM connection, and a reused numeric fd
-        // must not receive the original request's deferred response.
+        // Subscriber cleanup cannot write on the VACUUM connection and block
+        // the request queue while the backup is held.
         close(subscriberFD)
-        close(backupFD)
         Thread.sleep(forTimeInterval: 0.05)
 
         // Deployment health is a held-open, fresh-socket protocol sequence —
@@ -502,11 +501,123 @@ final class SocketIntegrationTests: XCTestCase {
         }
 
         progressGate.release.signal()
-        let staleResponse = try? readMCPMessage(fd: probeFD, timeout: 0.2)
-        XCTAssertNil(staleResponse, "A reused fd must not receive the disconnected backup client's response")
-        if initialize == nil {
-            _ = try? readMCPMessage(fd: probeFD, timeout: 1)
+        let backupResponse = try readMCPMessage(fd: backupFD, timeout: 2)
+        XCTAssertEqual(backupResponse["id"] as? Int, 40)
+        XCTAssertNil(backupResponse["error"])
+        XCTAssertNotNil(backupResponse["result"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: targetPath + ".complete"))
+    }
+
+    func testDisconnectedBackupResponseDoesNotLeakToReusedServerDescriptor() throws {
+        // Use the production topology so VACUUM and normal protocol traffic use
+        // separate write/read SQLite connections.
+        server.stop()
+        db.close()
+        setenv("BRAINLAYER_MCP_PROFILE", "core", 1)
+        let databaseReady = DispatchSemaphore(value: 0)
+        let databaseCapture = BrainDatabaseCapture()
+        server = BrainBarServer(
+            socketPath: testSocketPath,
+            dbPath: tempDBPath,
+            enableHybridSearchHelper: false
+        )
+        let reusedDescriptorDrop = DispatchSemaphore(value: 0)
+        server.onDatabaseReady = { database in
+            databaseCapture.set(database)
+            databaseReady.signal()
         }
+        server.onDeferredBackupResponseDropped = { descriptorWasReused in
+            if descriptorWasReused {
+                reusedDescriptorDrop.signal()
+            }
+        }
+        server.start()
+        XCTAssertTrue(waitForSocket(at: testSocketPath), "Server should bind \(testSocketPath)")
+        XCTAssertEqual(databaseReady.wait(timeout: .now() + 1), .success)
+        guard let writeDatabase = databaseCapture.get() else {
+            return XCTFail("Server should expose its ready write database")
+        }
+        // Let the readiness probe's server-side descriptor close before fixing
+        // the allocation order below.
+        Thread.sleep(forTimeInterval: 0.05)
+
+        // Occupy the lowest descriptor holes. The backup client then takes the
+        // next free fd and accept() takes the one after it. Keeping the client fd
+        // allocated with shutdown() while freeing one low spare makes the
+        // replacement client's socket() take the spare and accept() reuse the
+        // disconnected backup client's server-side descriptor deterministically.
+        var spareFDs: [Int32] = []
+        for _ in 0..<8 {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            XCTAssertGreaterThanOrEqual(fd, 0)
+            guard fd >= 0 else { return }
+            spareFDs.append(fd)
+        }
+        defer { spareFDs.forEach { close($0) } }
+
+        let progressGate = SQLiteProgressGate()
+        defer { progressGate.release.signal() }
+        sqlite3_progress_handler(
+            writeDatabase.dbHandle,
+            1,
+            blockSQLiteProgress,
+            Unmanaged.passUnretained(progressGate).toOpaque()
+        )
+        defer { sqlite3_progress_handler(writeDatabase.dbHandle, 0, nil, nil) }
+
+        let targetPath = NSTemporaryDirectory() + "brainbar-reused-fd-backup-\(UUID().uuidString).db"
+        let completionMarkerPath = targetPath + ".complete"
+        defer { try? FileManager.default.removeItem(atPath: targetPath) }
+        defer { try? FileManager.default.removeItem(atPath: completionMarkerPath) }
+
+        let backupFD = try connectClient()
+        defer { close(backupFD) }
+        XCTAssertGreaterThan(backupFD, spareFDs.last ?? -1)
+        try sendMCPRequest(on: backupFD, request: [
+            "jsonrpc": "2.0",
+            "id": 40,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_backup_vacuum_into",
+                "arguments": ["target_path": targetPath],
+            ],
+        ])
+        XCTAssertEqual(progressGate.entered.wait(timeout: .now() + 1), .success)
+
+        XCTAssertEqual(shutdown(backupFD, SHUT_RDWR), 0)
+        Thread.sleep(forTimeInterval: 0.2)
+        let releasedSpareFD = spareFDs.removeFirst()
+        close(releasedSpareFD)
+
+        let probeFD = try connectClient()
+        defer { close(probeFD) }
+        try sendMCPRequest(on: probeFD, request: [
+            "jsonrpc": "2.0", "id": 41, "method": "initialize",
+            "params": ["protocolVersion": "2024-11-05", "capabilities": [:] as [String: Any],
+                       "clientInfo": ["name": "backup-fd-reuse-probe", "version": "1.0"]],
+        ])
+        let initialize = try readMCPMessage(fd: probeFD, timeout: 0.5)
+        XCTAssertNotNil(initialize["result"])
+
+        progressGate.release.signal()
+        let completionDeadline = Date().addingTimeInterval(1)
+        while !FileManager.default.fileExists(atPath: completionMarkerPath), Date() < completionDeadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: completionMarkerPath))
+        XCTAssertEqual(
+            reusedDescriptorDrop.wait(timeout: .now() + 1),
+            .success,
+            "The test must reach the session-identity guard with the descriptor occupied by a replacement client"
+        )
+
+        let unsolicited = try? readMCPMessage(fd: probeFD, timeout: 1)
+        XCTAssertNotEqual(
+            unsolicited?["id"] as? Int,
+            40,
+            "The replacement connection received the disconnected backup client's response"
+        )
+        XCTAssertNil(unsolicited, "The replacement connection must not receive an unsolicited response")
     }
 
     func testBrainBackupVacuumIntoRefusesExistingCompletionMarkerWithoutOverwritingIt() throws {

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -7,6 +7,47 @@ import SQLite3
 import XCTest
 @testable import BrainBar
 
+private final class SQLiteProgressGate: @unchecked Sendable {
+    let entered = DispatchSemaphore(value: 0)
+    let release = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var shouldBlock = true
+
+    func step() -> Int32 {
+        lock.lock()
+        let block = shouldBlock
+        shouldBlock = false
+        lock.unlock()
+        if block {
+            entered.signal()
+            release.wait()
+        }
+        return 0
+    }
+}
+
+private final class BrainDatabaseCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var captured: BrainDatabase?
+
+    func set(_ database: BrainDatabase) {
+        lock.lock()
+        captured = database
+        lock.unlock()
+    }
+
+    func get() -> BrainDatabase? {
+        lock.lock()
+        defer { lock.unlock() }
+        return captured
+    }
+}
+
+private func blockSQLiteProgress(_ context: UnsafeMutableRawPointer?) -> Int32 {
+    guard let context else { return 0 }
+    return Unmanaged<SQLiteProgressGate>.fromOpaque(context).takeUnretainedValue().step()
+}
+
 final class SocketIntegrationTests: XCTestCase {
     let testSocketPath = "/tmp/brainbar-test-\(ProcessInfo.processInfo.processIdentifier).sock"
     var server: BrainBarServer!
@@ -350,6 +391,99 @@ final class SocketIntegrationTests: XCTestCase {
             try queryString("SELECT content FROM chunks WHERE content = 'vacuum over socket'", on: restored),
             "vacuum over socket"
         )
+    }
+
+    func testBlockedBackupVacuumDoesNotStarveFreshSocketProtocolFlow() throws {
+        // Use the production topology: a write connection for VACUUM and an
+        // independent read-only connection for normal recall traffic.
+        server.stop()
+        db.close()
+        setenv("BRAINLAYER_MCP_PROFILE", "core", 1)
+        let databaseReady = DispatchSemaphore(value: 0)
+        let databaseCapture = BrainDatabaseCapture()
+        server = BrainBarServer(
+            socketPath: testSocketPath,
+            dbPath: tempDBPath,
+            enableHybridSearchHelper: false
+        )
+        server.onDatabaseReady = { database in
+            databaseCapture.set(database)
+            databaseReady.signal()
+        }
+        server.start()
+        XCTAssertTrue(waitForSocket(at: testSocketPath), "Server should bind \(testSocketPath)")
+        XCTAssertEqual(databaseReady.wait(timeout: .now() + 1), .success)
+        guard let writeDatabase = databaseCapture.get() else {
+            return XCTFail("Server should expose its ready write database")
+        }
+
+        _ = try sendMCPRequest([
+            "jsonrpc": "2.0", "id": 39, "method": "initialize",
+            "params": ["protocolVersion": "2024-11-05", "capabilities": [:] as [String: Any],
+                       "clientInfo": ["name": "backup-liveness-warmup", "version": "1.0"]],
+        ])
+        Thread.sleep(forTimeInterval: 0.05)
+
+        let progressGate = SQLiteProgressGate()
+        defer { progressGate.release.signal() }
+        sqlite3_progress_handler(
+            writeDatabase.dbHandle,
+            1,
+            blockSQLiteProgress,
+            Unmanaged.passUnretained(progressGate).toOpaque()
+        )
+        defer { sqlite3_progress_handler(writeDatabase.dbHandle, 0, nil, nil) }
+
+        let targetPath = NSTemporaryDirectory() + "brainbar-blocked-backup-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: targetPath) }
+        defer { try? FileManager.default.removeItem(atPath: targetPath + ".complete") }
+
+        let backupFD = try connectClient()
+        defer { close(backupFD) }
+        try sendMCPRequest(on: backupFD, request: [
+            "jsonrpc": "2.0",
+            "id": 40,
+            "method": "tools/call",
+            "params": [
+                "name": "brain_backup_vacuum_into",
+                "arguments": ["target_path": targetPath],
+            ],
+        ])
+        XCTAssertEqual(progressGate.entered.wait(timeout: .now() + 1), .success)
+
+        // Deployment health is a held-open, fresh-socket protocol sequence —
+        // initialize + tools/list + a real tool call — not a version/plist probe.
+        let probeFD = try connectClient()
+        defer { close(probeFD) }
+        try sendMCPRequest(on: probeFD, request: [
+            "jsonrpc": "2.0", "id": 41, "method": "initialize",
+            "params": ["protocolVersion": "2024-11-05", "capabilities": [:] as [String: Any],
+                       "clientInfo": ["name": "backup-liveness-probe", "version": "1.0"]],
+        ])
+        let initialize = try? readMCPMessage(fd: probeFD, timeout: 0.5)
+        XCTAssertNotNil(initialize?["result"])
+
+        if initialize != nil {
+            try sendMCPRequest(on: probeFD, request: [
+                "jsonrpc": "2.0", "id": 42, "method": "tools/list", "params": [:] as [String: Any],
+            ])
+            let tools = try readMCPMessage(fd: probeFD, timeout: 0.5)
+            XCTAssertNotNil((tools["result"] as? [String: Any])?["tools"])
+
+            try sendMCPRequest(on: probeFD, request: [
+                "jsonrpc": "2.0", "id": 43, "method": "tools/call",
+                "params": ["name": "brain_recall", "arguments": ["mode": "stats"]],
+            ])
+            let call = try readMCPMessage(fd: probeFD, timeout: 0.5)
+            XCTAssertNil(call["error"])
+            XCTAssertNotNil(call["result"])
+        }
+
+        progressGate.release.signal()
+        _ = try readMCPMessage(fd: backupFD, timeout: 2)
+        if initialize == nil {
+            _ = try? readMCPMessage(fd: probeFD, timeout: 1)
+        }
     }
 
     func testBrainBackupVacuumIntoRefusesExistingCompletionMarkerWithoutOverwritingIt() throws {

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -43,6 +43,46 @@ private final class BrainDatabaseCapture: @unchecked Sendable {
     }
 }
 
+private final class ClientLifecycleCapture: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var acceptedFDs: [Int32] = []
+    private var closedFDs = Set<Int32>()
+
+    func recordAccepted(_ fd: Int32) {
+        condition.lock()
+        acceptedFDs.append(fd)
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    func recordClosed(_ fd: Int32) {
+        condition.lock()
+        closedFDs.insert(fd)
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    func waitForAccepted(at index: Int, timeout: TimeInterval = 5) -> Int32? {
+        let deadline = Date().addingTimeInterval(timeout)
+        condition.lock()
+        defer { condition.unlock() }
+        while acceptedFDs.count <= index {
+            guard condition.wait(until: deadline) else { return nil }
+        }
+        return acceptedFDs[index]
+    }
+
+    func waitForClosed(_ fd: Int32, timeout: TimeInterval = 5) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        condition.lock()
+        defer { condition.unlock() }
+        while !closedFDs.contains(fd) {
+            guard condition.wait(until: deadline) else { return false }
+        }
+        return true
+    }
+}
+
 private func blockSQLiteProgress(_ context: UnsafeMutableRawPointer?) -> Int32 {
     guard let context else { return 0 }
     return Unmanaged<SQLiteProgressGate>.fromOpaque(context).takeUnretainedValue().step()
@@ -522,6 +562,7 @@ final class SocketIntegrationTests: XCTestCase {
             enableHybridSearchHelper: false
         )
         let reusedDescriptorDrop = DispatchSemaphore(value: 0)
+        let clientLifecycle = ClientLifecycleCapture()
         server.onDatabaseReady = { database in
             databaseCapture.set(database)
             databaseReady.signal()
@@ -531,29 +572,35 @@ final class SocketIntegrationTests: XCTestCase {
                 reusedDescriptorDrop.signal()
             }
         }
+        server.onClientAccepted = { clientLifecycle.recordAccepted($0) }
+        server.onClientDescriptorClosed = { clientLifecycle.recordClosed($0) }
         server.start()
         XCTAssertTrue(waitForSocket(at: testSocketPath), "Server should bind \(testSocketPath)")
         XCTAssertEqual(databaseReady.wait(timeout: .now() + 1), .success)
         guard let writeDatabase = databaseCapture.get() else {
             return XCTFail("Server should expose its ready write database")
         }
-        // Let the readiness probe's server-side descriptor close before fixing
-        // the allocation order below.
-        Thread.sleep(forTimeInterval: 0.05)
-
-        // Occupy the lowest descriptor holes. The backup client then takes the
-        // next free fd and accept() takes the one after it. Keeping the client fd
-        // allocated with shutdown() while freeing one low spare makes the
-        // replacement client's socket() take the spare and accept() reuse the
-        // disconnected backup client's server-side descriptor deterministically.
-        var spareFDs: [Int32] = []
-        for _ in 0..<8 {
-            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-            XCTAssertGreaterThanOrEqual(fd, 0)
-            guard fd >= 0 else { return }
-            spareFDs.append(fd)
+        guard let readinessProbeServerFD = clientLifecycle.waitForAccepted(at: 0) else {
+            return XCTFail("Server should observe the readiness probe connection")
         }
-        defer { spareFDs.forEach { close($0) } }
+        XCTAssertTrue(
+            clientLifecycle.waitForClosed(readinessProbeServerFD),
+            "Readiness probe must be fully disconnected before descriptor allocation starts"
+        )
+
+        // Hold one known-low descriptor to release for the replacement client's
+        // socket(). Other holes are filled explicitly after the backup server
+        // descriptor closes, so concurrent fd churn cannot invalidate a fixed
+        // spare-count assumption.
+        let replacementClientHoleFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(replacementClientHoleFD, 0)
+        guard replacementClientHoleFD >= 0 else { return }
+        var replacementClientHoleIsOpen = true
+        defer {
+            if replacementClientHoleIsOpen {
+                close(replacementClientHoleFD)
+            }
+        }
 
         let progressGate = SQLiteProgressGate()
         defer { progressGate.release.signal() }
@@ -572,7 +619,10 @@ final class SocketIntegrationTests: XCTestCase {
 
         let backupFD = try connectClient()
         defer { close(backupFD) }
-        XCTAssertGreaterThan(backupFD, spareFDs.last ?? -1)
+        XCTAssertGreaterThan(backupFD, replacementClientHoleFD)
+        guard let backupServerFD = clientLifecycle.waitForAccepted(at: 1) else {
+            return XCTFail("Server should accept the backup connection")
+        }
         try sendMCPRequest(on: backupFD, request: [
             "jsonrpc": "2.0",
             "id": 40,
@@ -585,12 +635,46 @@ final class SocketIntegrationTests: XCTestCase {
         XCTAssertEqual(progressGate.entered.wait(timeout: .now() + 1), .success)
 
         XCTAssertEqual(shutdown(backupFD, SHUT_RDWR), 0)
-        Thread.sleep(forTimeInterval: 0.2)
-        let releasedSpareFD = spareFDs.removeFirst()
-        close(releasedSpareFD)
+        XCTAssertTrue(
+            clientLifecycle.waitForClosed(backupServerFD),
+            "Backup server descriptor must close before constructing its replacement"
+        )
+
+        // socket() always returns the lowest free descriptor. Fill every free
+        // hole below the known backup server fd, briefly acquire the target to
+        // prove it is free, then release only the target and the one low client
+        // hole. The probe's socket() consumes the low hole; accept() must consume
+        // the target.
+        var fillerFDs: [Int32] = []
+        defer { fillerFDs.forEach { close($0) } }
+        while true {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            XCTAssertGreaterThanOrEqual(fd, 0)
+            guard fd >= 0 else { return }
+            if fd == backupServerFD {
+                close(fd)
+                break
+            }
+            XCTAssertLessThan(fd, backupServerFD, "Backup server descriptor should be the next target hole")
+            guard fd < backupServerFD else {
+                close(fd)
+                return
+            }
+            fillerFDs.append(fd)
+        }
+        close(replacementClientHoleFD)
+        replacementClientHoleIsOpen = false
 
         let probeFD = try connectClient()
         defer { close(probeFD) }
+        guard let probeServerFD = clientLifecycle.waitForAccepted(at: 2) else {
+            return XCTFail("Server should accept the replacement connection")
+        }
+        XCTAssertEqual(
+            probeServerFD,
+            backupServerFD,
+            "Replacement connection must reuse the disconnected backup server descriptor"
+        )
         try sendMCPRequest(on: probeFD, request: [
             "jsonrpc": "2.0", "id": 41, "method": "initialize",
             "params": ["protocolVersion": "2024-11-05", "capabilities": [:] as [String: Any],
@@ -600,13 +684,13 @@ final class SocketIntegrationTests: XCTestCase {
         XCTAssertNotNil(initialize["result"])
 
         progressGate.release.signal()
-        let completionDeadline = Date().addingTimeInterval(1)
+        let completionDeadline = Date().addingTimeInterval(5)
         while !FileManager.default.fileExists(atPath: completionMarkerPath), Date() < completionDeadline {
             Thread.sleep(forTimeInterval: 0.01)
         }
         XCTAssertTrue(FileManager.default.fileExists(atPath: completionMarkerPath))
         XCTAssertEqual(
-            reusedDescriptorDrop.wait(timeout: .now() + 1),
+            reusedDescriptorDrop.wait(timeout: .now() + 5),
             .success,
             "The test must reach the session-identity guard with the descriptor occupied by a replacement client"
         )

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -133,7 +133,7 @@ def migrate_legacy_mcp_configs(
 
 
 def verify_mcp_transport(*, bridge_command: str | None = None, timeout_seconds: float = 10.0) -> int:
-    """Require a real initialize + tools/list exchange through the installed stdio bridge."""
+    """Require initialize + tools/list + one successful tool call on one fresh bridge."""
     resolved_bridge = bridge_command or get_current_mcp_bridge_bin()
     if not resolved_bridge:
         raise FileNotFoundError("brainlayer-mcp-stdio-bridge was not found on PATH")
@@ -200,6 +200,30 @@ def verify_mcp_transport(*, bridge_command: str | None = None, timeout_seconds: 
         tools = tools_result.get("tools") if isinstance(tools_result, dict) else None
         if not isinstance(tools, list) or not tools:
             raise RuntimeError("MCP tools/list response missing tools")
+        tool_names = {
+            tool.get("name") for tool in tools if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+        }
+        if "brain_recall" in tool_names:
+            smoke_tool = "brain_recall"
+            smoke_arguments = {"mode": "stats"}
+        elif "expand_palette" in tool_names:
+            smoke_tool = "expand_palette"
+            smoke_arguments: dict[str, object] = {}
+        else:
+            raise RuntimeError("MCP tools/list has no safe deployment smoke tool")
+        send(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": smoke_tool, "arguments": smoke_arguments},
+            },
+        )
+        call_response = receive(process, 3)
+        call_result = call_response.get("result") if call_response else None
+        if not isinstance(call_result, dict) or call_result.get("isError") is True:
+            raise RuntimeError(f"MCP deployment tool call failed: {smoke_tool}")
         return len(tools)
     finally:
         process.terminate()

--- a/tests/benchmarks/test_wave5_contract_bench.py
+++ b/tests/benchmarks/test_wave5_contract_bench.py
@@ -224,12 +224,15 @@ def _assert_existing_state_after_rejection(ledger: Ledger, event: OccurrenceEven
     assert ledger.weave_accumulation(through=cross_day_repeat.occurred_at.date()) == ()
 
 
-def test_wave5_options_register_for_root_suite_without_collection() -> None:
+def test_wave5_options_register_for_root_suite_without_collection(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "help-cache"
     result = subprocess.run(
         [
             sys.executable,
             "-m",
             "pytest",
+            "-o",
+            f"cache_dir={cache_dir}",
             "--help",
             "--wave5-ledger-factory=tests.benchmarks.wave5_contract:OccurrenceLedger",
             "--wave5-candidate-producer=tests.benchmarks.wave5_contract:oracle_candidate_producer",
@@ -245,12 +248,15 @@ def test_wave5_options_register_for_root_suite_without_collection() -> None:
     assert "--wave5-candidate-producer=MODULE:ATTRIBUTE" in result.stdout
 
 
-def test_external_ledger_factory_option_reaches_contract() -> None:
+def test_external_ledger_factory_option_reaches_contract(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "ledger-cache"
     result = subprocess.run(
         [
             sys.executable,
             "-m",
             "pytest",
+            "-o",
+            f"cache_dir={cache_dir}",
             str(Path(__file__)),
             "-q",
             "-k",
@@ -266,14 +272,20 @@ def test_external_ledger_factory_option_reaches_contract() -> None:
 
     assert result.returncode == 1
     assert "external ledger factory selected" in result.stdout
+    assert "test_occurrence_identity_includes_semantic_fingerprint_and_scope" in (
+        cache_dir / "v" / "cache" / "lastfailed"
+    ).read_text()
 
 
-def test_external_candidate_producer_option_reaches_promotion_benchmark() -> None:
+def test_external_candidate_producer_option_reaches_promotion_benchmark(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "candidate-cache"
     result = subprocess.run(
         [
             sys.executable,
             "-m",
             "pytest",
+            "-o",
+            f"cache_dir={cache_dir}",
             str(Path(__file__)),
             "-q",
             "-k",
@@ -289,6 +301,9 @@ def test_external_candidate_producer_option_reaches_promotion_benchmark() -> Non
 
     assert result.returncode == 1
     assert "external candidate producer selected" in result.stdout
+    assert "test_candidate_producer_meets_promotion_thresholds_and_false_positive_budget" in (
+        cache_dir / "v" / "cache" / "lastfailed"
+    ).read_text()
 
 
 def test_occurrence_identity_includes_semantic_fingerprint_and_scope(

--- a/tests/benchmarks/test_wave5_contract_bench.py
+++ b/tests/benchmarks/test_wave5_contract_bench.py
@@ -272,9 +272,10 @@ def test_external_ledger_factory_option_reaches_contract(tmp_path: Path) -> None
 
     assert result.returncode == 1
     assert "external ledger factory selected" in result.stdout
-    assert "test_occurrence_identity_includes_semantic_fingerprint_and_scope" in (
-        cache_dir / "v" / "cache" / "lastfailed"
-    ).read_text()
+    assert (
+        "test_occurrence_identity_includes_semantic_fingerprint_and_scope"
+        in (cache_dir / "v" / "cache" / "lastfailed").read_text()
+    )
 
 
 def test_external_candidate_producer_option_reaches_promotion_benchmark(tmp_path: Path) -> None:
@@ -301,9 +302,10 @@ def test_external_candidate_producer_option_reaches_promotion_benchmark(tmp_path
 
     assert result.returncode == 1
     assert "external candidate producer selected" in result.stdout
-    assert "test_candidate_producer_meets_promotion_thresholds_and_false_positive_budget" in (
-        cache_dir / "v" / "cache" / "lastfailed"
-    ).read_text()
+    assert (
+        "test_candidate_producer_meets_promotion_thresholds_and_false_positive_budget"
+        in (cache_dir / "v" / "cache" / "lastfailed").read_text()
+    )
 
 
 def test_occurrence_identity_includes_semantic_fingerprint_and_scope(

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -319,26 +319,33 @@ def test_setup_mcp_migration_preserves_symlink_and_updates_target(tmp_path: Path
     }
 
 
-def test_verify_mcp_transport_requires_initialize_and_tools_list(tmp_path: Path) -> None:
+def test_verify_mcp_transport_requires_initialize_tools_list_and_tool_call(tmp_path: Path) -> None:
     from brainlayer.setup import verify_mcp_transport
 
     bridge = tmp_path / "fake-bridge"
+    call_marker = tmp_path / "tool-call-seen"
     bridge.write_text(
-        """#!/usr/bin/env python3
+        f"""#!/usr/bin/env python3
 import json
+from pathlib import Path
 import sys
 for line in sys.stdin:
     request = json.loads(line)
     if request.get("id") == 1:
-        print(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-06-18"}}), flush=True)
+        print(json.dumps({{"jsonrpc": "2.0", "id": 1, "result": {{"protocolVersion": "2025-06-18"}}}}), flush=True)
     elif request.get("id") == 2:
-        print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "brain_search"}]}}), flush=True)
+        print(json.dumps({{"jsonrpc": "2.0", "id": 2, "result": {{"tools": [{{"name": "brain_recall"}}]}}}}), flush=True)
+    elif request.get("id") == 3 and request.get("method") == "tools/call":
+        assert request.get("params") == {{"name": "brain_recall", "arguments": {{"mode": "stats"}}}}
+        Path({str(call_marker)!r}).write_text("seen")
+        print(json.dumps({{"jsonrpc": "2.0", "id": 3, "result": {{"content": [{{"type": "text", "text": "expanded"}}]}}}}), flush=True)
 """,
         encoding="utf-8",
     )
     bridge.chmod(0o755)
 
     assert verify_mcp_transport(bridge_command=str(bridge), timeout_seconds=2) == 1
+    assert call_marker.read_text() == "seen"
 
 
 def test_verify_mcp_transport_waits_for_initialize_response_before_next_message(tmp_path: Path) -> None:
@@ -361,7 +368,13 @@ if initialized.get("method") != "notifications/initialized":
 tools = json.loads(sys.stdin.readline())
 if tools.get("id") != 2:
     raise SystemExit(14)
-print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "brain_search"}]}}), flush=True)
+print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "brain_recall"}]}}), flush=True)
+call = json.loads(sys.stdin.readline())
+if call.get("id") != 3 or call.get("method") != "tools/call":
+    raise SystemExit(15)
+if call.get("params") != {"name": "brain_recall", "arguments": {"mode": "stats"}}:
+    raise SystemExit(16)
+print(json.dumps({"jsonrpc": "2.0", "id": 3, "result": {"content": [{"type": "text", "text": "expanded"}]}}), flush=True)
 """,
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary
- move the multi-minute backup VACUUM off BrainBar serial protocol queue
- keep fresh-socket initialize, tools/list, and read-only brain_recall live during backup
- make the installed transport verifier require initialize, list, and a successful real tool call

## Root cause
v1.5.4 made brain_backup_vacuum_into reachable on the core profile, but MCPRouter.handle still executed it synchronously on BrainBarServer request queue. A real three-minute VACUUM therefore starved every later initialize request.

## Verification
- RED: SQLite-paused VACUUM caused fresh-socket initialize to miss the 0.5s budget before the fix
- Swift package: 858 tests, 10 skipped, 0 failures
- Python backup/install: 96 passed
- pre-push: 3920 passed, 10 skipped, 61 deselected, 2 xfailed
- pair review: ACCEPT at exact head 4dbe2dc6

— brainlayer-worker-ygt7ve (worker) · codex/gpt-5.6-sol
<!-- golem-id: {"seat":"brainlayer-worker-ygt7ve","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feaca","ts":"2026-08-10T11:25:38Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-running backup concurrency, subscriber disconnect timing, and fd-reuse response routing on the MCP server; shutdown can block until an in-flight backup completes.
> 
> **Overview**
> Fixes MCP starvation when **`brain_backup_vacuum_into`** ran synchronously on BrainBar’s serial request queue during multi-minute VACUUM work.
> 
> **`brain_backup_vacuum_into`** now runs on a dedicated **`backupToolQueue`** so **`initialize`**, **`tools/list`**, and other socket traffic stay responsive. While a backup is active, most **`tools/call`** requests get a **`-32000`** retry error; **`expand_palette`** and read-only **`brain_recall`** (separate write/read SQLite connections) still work. Subscriber disconnect cleanup is **deferred** until the backup finishes, and async backup replies are **dropped** if the client disconnects and the server fd is reused—guarded by palette session identity. Shutdown **drains** the backup queue before closing the database.
> 
> Socket integration tests cover liveness under a paused VACUUM and prevention of backup responses leaking to a reused descriptor. **`verify_mcp_transport`** now requires **`initialize`**, **`tools/list`**, and one successful **`tools/call`** smoke check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eeca22df9c1a8c380263bd1f02407bf79add55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep BrainBar MCP server responsive during `brain_backup_vacuum_into` calls
> - Runs `brain_backup_vacuum_into` on a dedicated `backupToolQueue` so the main socket request queue remains responsive during long backups.
> - Rejects most tool calls with a JSON-RPC `-32000` error during backup; allows `expand_palette` always and `brain_recall` if a separate read-only DB connection exists.
> - Defers `markSubscriberDisconnected` writes during backup and flushes them after the backup completes or during shutdown.
> - Drops the backup response if the originating client has disconnected, with an observable `onDeferredBackupResponseDropped` callback to prevent delivery to a reused descriptor.
> - Extends `verify_mcp_transport` in [setup.py](https://github.com/EtanHey/brainlayer/pull/701/files#diff-774188ad41f49470ff3c8e53644d81dc923136e10591c3fa1cbf5de30a51eaee) to require a successful tool call (not just initialize + tools/list) before considering the bridge healthy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0eeca22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Backups now run asynchronously, keeping socket communication responsive during backup operations.
  - Concurrent backup requests are prevented, and incompatible actions are safely deferred until backups finish.
  - Client connections are handled more reliably when disconnecting or reconnecting during a backup.

- **Bug Fixes**
  - Prevented backup responses from being delivered to disconnected or replacement clients.
  - Improved shutdown behavior by completing active backups before closing database connections.
  - Installation checks now confirm that a real MCP tool call succeeds after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->