### PR TITLE
fix(search): close Wave 3a post-review gates

### DIFF
--- a/docs/operations/wave3-3a-two-host-live-runbook.md
+++ b/docs/operations/wave3-3a-two-host-live-runbook.md
@@ -14,6 +14,7 @@ This runbook is the source-class segment of the Wave 3 maintenance sitting. Exec
 - Final migration rehearsal source: the earlier APFS clone `.tmp-wave3-3a/canonical-pristine.db`, captured 2026-08-10 12:44:04 IDT with 744,335 rows and a clean `PRAGMA quick_check`. Its migrated copy retained exactly 744,335 rows. The 61-row difference from the later online-backup snapshot is therefore between two independently timestamped live snapshots, not a migration row-count discrepancy.
 - Final-code rehearsal migration: 252.02 seconds wall-clock on commit `3964412f8291a083150a424e38df08ece817783d` (`duration_seconds=251.79996774997562`); exact-SHA idempotent rerun: 0.65 seconds.
 - Rehearsal distribution: NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 105,383; subagent 29,740.
+- Shipped-search verifier rerun: code head `065d602651bc14b096f268482cc125eaca450354` against the already-migrated copy, 299.81 seconds under host load; all six visibility/expansion buckets green, 72 sampled desktop tokens with zero leaks, and zero brain-worker rows across all six search indexes.
 - Earlier monitored rehearsal migration WAL: 0 bytes before, 29,181,992-byte observed peak, 0 bytes at close after checkpoints; the final-code rerun was not separately peak-sampled.
 - Rehearsal rollback: restore by APFS re-copy in 0.00 seconds; restored row count 744,335 and `source_class` absent.
 
@@ -122,14 +123,6 @@ test -f "$WAVE3A_DB"
 df -k "$(dirname "$WAVE3A_DB")"
 stat -f '%z' "$WAVE3A_DB"
 stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
-export WAVE3A_ROWS_BEFORE="$("$WAVE3A_PYTHON" - "$WAVE3A_DB" <<'PY'
-import sqlite3, sys
-c = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
-print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
-c.close()
-PY
-)"
-printf '%s\n' "$WAVE3A_ROWS_BEFORE" | tee "$WAVE3A_RUN_DIR/rows-before.txt"
 cat "$HOME/.local/share/brainlayer/pause.sentinel" 2>/dev/null || true
 pgrep -af '[b]rain_digest|[b]rainlayer.*digest' && exit 1 || true
 pgrep -af '[b]rainlayer.backup_daily|[b]ackup-daily.sh' && exit 1 || true
@@ -204,6 +197,20 @@ stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
 
 Stop if the checkpoint reports busy or returns nonzero.
 
+Only now, after the writer inventory is stopped and asserted absent and the checkpoint succeeds, capture the canonical row-count invariant. Use this same ordering independently on M1.
+
+```bash
+set -euo pipefail
+export WAVE3A_ROWS_BEFORE="$("$WAVE3A_PYTHON" - "$WAVE3A_DB" <<'PY'
+import sqlite3, sys
+c = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+print(c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+c.close()
+PY
+)"
+printf '%s\n' "$WAVE3A_ROWS_BEFORE" | tee "$WAVE3A_RUN_DIR/rows-before.txt"
+```
+
 Start one persistent read-only SQLite observer before either backup route. Its connection records `PRAGMA data_version` before the snapshot and again only after BrainBarDaemon is stopped. Any intervening commit makes the rollback snapshot non-authoritative, so the observer fails the gate and migration must not start.
 
 ```bash
@@ -277,10 +284,12 @@ import sqlite3, sys
 p, expected_rows = sys.argv[1], int(sys.argv[2])
 c = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
 rows = c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+quick_check = c.execute("PRAGMA quick_check").fetchone()[0]
 print(rows)
-print(c.execute("PRAGMA quick_check").fetchone()[0])
+print(quick_check)
 c.close()
 assert rows == expected_rows
+assert quick_check == "ok"
 PY
 ```
 
@@ -306,10 +315,12 @@ import sqlite3, sys
 p, expected_rows = sys.argv[1], int(sys.argv[2])
 c = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
 rows = c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+quick_check = c.execute("PRAGMA quick_check").fetchone()[0]
 print(rows)
-print(c.execute("PRAGMA quick_check").fetchone()[0])
+print(quick_check)
 c.close()
 assert rows == expected_rows
+assert quick_check == "ok"
 PY
 ```
 
@@ -374,7 +385,10 @@ receipt = {
     "rows": c.execute("SELECT COUNT(*) FROM chunks").fetchone()[0],
     "distribution": distribution,
     "invalid_classes": c.execute("SELECT COUNT(*) FROM chunks WHERE source_class IS NOT NULL AND source_class NOT IN ('cli-agent','desktop','subagent','brain-worker','fleet-coordination')").fetchone()[0],
-    "brain_worker_fts_rows": c.execute("SELECT COUNT(*) FROM chunk_fts_rowids r JOIN chunks c ON c.id=r.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
+    "brain_worker_fts_mapping_rows": c.execute("SELECT COUNT(*) FROM chunk_fts_rowids r JOIN chunks c ON c.id=r.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
+    "brain_worker_default_fts_rows": c.execute("SELECT COUNT(*) FROM chunks_fts i JOIN chunks c ON c.id=i.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
+    "brain_worker_operational_fts_rows": c.execute("SELECT COUNT(*) FROM chunks_fts_operational i JOIN chunks c ON c.id=i.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
+    "brain_worker_trigram_fts_rows": c.execute("SELECT COUNT(*) FROM chunks_fts_trigram i JOIN chunks c ON c.id=i.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
     "brain_worker_float_vector_rows": c.execute("SELECT COUNT(*) FROM chunk_vectors v JOIN chunks c ON c.id=v.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
     "brain_worker_binary_vector_rows": c.execute("SELECT COUNT(*) FROM chunk_vectors_binary v JOIN chunks c ON c.id=v.chunk_id WHERE c.source_class='brain-worker'").fetchone()[0],
     "schema_sha": schema.get("git_sha"),
@@ -385,7 +399,10 @@ print(json.dumps(receipt, indent=2, sort_keys=True))
 assert receipt["quick_check"] == "ok"
 assert receipt["rows"] == expected_rows
 assert receipt["invalid_classes"] == 0
-assert receipt["brain_worker_fts_rows"] == 0
+assert receipt["brain_worker_fts_mapping_rows"] == 0
+assert receipt["brain_worker_default_fts_rows"] == 0
+assert receipt["brain_worker_operational_fts_rows"] == 0
+assert receipt["brain_worker_trigram_fts_rows"] == 0
 assert receipt["brain_worker_float_vector_rows"] == 0
 assert receipt["brain_worker_binary_vector_rows"] == 0
 assert receipt["schema_sha"] == expected_sha
@@ -395,6 +412,8 @@ stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
 ```
 
 Required visibility probes before restart: one exact stored id from each class plus one NULL row. Exact expansion must work for all six; default search must show cli-agent, subagent, fleet-coordination, and NULL, while hiding desktop and brain-worker. The internal desktop opt-in must reveal desktop but never brain-worker:
+
+The live distribution may differ from the rehearsal counts because classification reads current source JSONL attribution from disk. A distribution delta is a receipt to investigate, not by itself a failure; the taxonomy, row-count, zero-index, and visibility assertions above remain the stop gates.
 
 ```bash
 set -o pipefail
@@ -511,6 +530,6 @@ The PR handoff fills the final-code rerun values here and in the collab append:
 | Distribution | NULL 69,581; brain-worker 84; cli-agent 536,851; desktop 2,696; fleet-coordination 105,383; subagent 29,740 |
 | Ledgers | schema and event rows both pin `3964412f8291a083150a424e38df08ece817783d`; event status `success` |
 | Quick check | `ok` in 712.79 seconds; zero invalid classes; zero brain-worker FTS, float-vector, and binary-vector rows |
-| Class visibility / expansion | six source buckets green against real copied rows; aggregate desktop audit sampled 72 tokens with zero leaked IDs |
+| Class visibility / expansion | rerun with shipped search code at `065d602651bc14b096f268482cc125eaca450354`: six source buckets green against real copied rows; aggregate desktop audit sampled 72 tokens with zero leaked IDs; brain-worker zero across all six indexes |
 | Rollback | APFS re-copy, 0.00 seconds; 744,335 rows; `source_class` absent |
 | Repository gates | focused source-class 251 passed; final search/cache 42 passed; additional search scopes 92 passed / 1 xfailed with the protected production-DB latency probe refused by the test-path guard; Swift Database/KG 119 passed; full Swift reached 850 passed / 10 skipped with 7 unrelated timing failures while another lane held 24 deliberate CPU spinners |

--- a/docs/operations/wave3-3a-two-host-live-runbook.md
+++ b/docs/operations/wave3-3a-two-host-live-runbook.md
@@ -7,6 +7,7 @@ This runbook is the source-class segment of the Wave 3 maintenance sitting. Exec
 ## Pinned artifacts and rehearsal measurements
 
 - Migration/source-class code commit: `3964412f8291a083150a424e38df08ece817783d`.
+- Reviewed execution/verifier code commit: `588ef12bebd82219dd06cb13aaf41307979b39d2`.
 - Required deployed release before either host migrates: BrainLayer + BrainBar **exactly v1.5.6**. v1.5.5 carries the backup-race fix; v1.5.6 adds the Swift default-search source-class gate.
 - Command: `scripts/migrate_source_class.py` from a checkout containing that commit.
 - Rehearsal source: online SQLite backup from canonical opened `mode=ro` into gitignored `.tmp-wave3-3a/` (contingency route, not the LIVE primary route).
@@ -27,7 +28,7 @@ Fill every blank on each host. Do not copy Main values into M1.
 | Operator / Etan go time |  |  |
 | Hostname |  |  |
 | Canonical DB path |  |  |
-| Checked-out commit |  |  |
+| Migration checkout / execution-verifier checkout |  |  |
 | Installed BrainLayer / BrainBar versions (must be exactly 1.5.6) |  |  |
 | Installed CLI path + SHA-256 |  |  |
 | Executing BrainBarDaemon PID / path + SHA-256 |  |  |
@@ -100,24 +101,27 @@ Do not enter host preflight unless all commands pass. Re-run this section indepe
 
 ## 1. Host preflight and writer inventory
 
-From the pinned checkout, set only host-local absolute paths:
+Prepare two clean detached checkouts. The migration checkout pins exactly the code recorded in the ledgers; the execution checkout pins the strengthened verifier/search code reviewed for the shipped release. Never overload one SHA for both purposes.
 
 ```bash
-export WAVE3A_REPO="$PWD"
-export WAVE3A_PYTHON="$WAVE3A_REPO/.venv/bin/python"
+export WAVE3A_MIGRATION_REPO="<absolute clean checkout at 3964412f8291a083150a424e38df08ece817783d>"
+export WAVE3A_EXEC_REPO="<absolute clean checkout at 588ef12bebd82219dd06cb13aaf41307979b39d2>"
+export WAVE3A_PYTHON="$WAVE3A_EXEC_REPO/.venv/bin/python"
 export WAVE3A_CLI="$(command -v brainlayer)"
-export PYTHONPATH="$WAVE3A_REPO/src"
+export PYTHONPATH="$WAVE3A_EXEC_REPO/src"
 export WAVE3A_DB="$($WAVE3A_PYTHON -c 'from brainlayer.paths import get_db_path; print(get_db_path())')"
-export WAVE3A_SHA="3964412f8291a083150a424e38df08ece817783d"
+export WAVE3A_MIGRATION_SHA="3964412f8291a083150a424e38df08ece817783d"
+export WAVE3A_EXEC_SHA="588ef12bebd82219dd06cb13aaf41307979b39d2"
 export WAVE3A_ACTOR="etan+brainlayerCodex"
 export WAVE3A_HOST="$(hostname -s | tr -cd 'A-Za-z0-9_-')"
 export WAVE3A_RUN_DIR="$HOME/.local/share/brainlayer/wave3-live-2026-08-11/$WAVE3A_HOST"
 mkdir -p "$WAVE3A_RUN_DIR"
 test -x "$WAVE3A_PYTHON"
 test -x "$WAVE3A_CLI"
-test "$(git rev-parse "$WAVE3A_SHA")" = "$WAVE3A_SHA"
-test "$(git rev-parse HEAD)" = "$WAVE3A_SHA"
-test -z "$(git status --porcelain)"
+test "$(git -C "$WAVE3A_MIGRATION_REPO" rev-parse HEAD)" = "$WAVE3A_MIGRATION_SHA"
+test "$(git -C "$WAVE3A_EXEC_REPO" rev-parse HEAD)" = "$WAVE3A_EXEC_SHA"
+test -z "$(git -C "$WAVE3A_MIGRATION_REPO" status --porcelain)"
+test -z "$(git -C "$WAVE3A_EXEC_REPO" status --porcelain)"
 test -f "$WAVE3A_DB"
 /usr/libexec/PlistBuddy -c 'Print:CFBundleShortVersionString' /Applications/BrainBar.app/Contents/Info.plist | grep -Fx '1.5.6'
 df -k "$(dirname "$WAVE3A_DB")"
@@ -190,7 +194,7 @@ pgrep -af '[b]rainlayer.*(watch|drain|enrich|p0-counter|jsonl-backup)' && exit 1
 
 ```bash
 set -o pipefail
-/usr/bin/time -p "$WAVE3A_PYTHON" scripts/wal_checkpoint.py --mode TRUNCATE --retry-busy --json \
+/usr/bin/time -p "$WAVE3A_PYTHON" "$WAVE3A_EXEC_REPO/scripts/wal_checkpoint.py" --mode TRUNCATE --retry-busy --json \
   | tee "$WAVE3A_RUN_DIR/checkpoint.json"
 stat -f '%z' "$WAVE3A_DB-wal" 2>/dev/null || true
 ```
@@ -337,7 +341,7 @@ wait "$WAVE3A_FENCE_PID"
 unset WAVE3A_FENCE_PID
 trap - EXIT
 cat "$WAVE3A_FENCE_RESULT"
-"$WAVE3A_PYTHON" scripts/wal_checkpoint.py --mode TRUNCATE --retry-busy --json \
+"$WAVE3A_PYTHON" "$WAVE3A_EXEC_REPO/scripts/wal_checkpoint.py" --mode TRUNCATE --retry-busy --json \
   | tee "$WAVE3A_RUN_DIR/checkpoint-after-backup.json"
 ```
 
@@ -348,9 +352,10 @@ The environment gate is intentionally scoped to this command. Without it the scr
 ```bash
 set -o pipefail
 /usr/bin/time -p env BRAINLAYER_OFFLINE_MIGRATOR_GATED_SWAP=1 \
-  "$WAVE3A_PYTHON" scripts/migrate_source_class.py \
+  PYTHONPATH="$WAVE3A_MIGRATION_REPO/src" \
+  "$WAVE3A_PYTHON" "$WAVE3A_MIGRATION_REPO/scripts/migrate_source_class.py" \
   --db "$WAVE3A_DB" \
-  --git-sha "$WAVE3A_SHA" \
+  --git-sha "$WAVE3A_MIGRATION_SHA" \
   --actor "$WAVE3A_ACTOR" \
   --batch-size 5000 \
   | tee "$WAVE3A_RUN_DIR/source-class-migration.json"
@@ -363,7 +368,7 @@ If additional approved Wave 3 migrations are scheduled for the same maintenance 
 Run this read-only receipt query:
 
 ```bash
-"$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_SHA" "$WAVE3A_ROWS_BEFORE" <<'PY'
+"$WAVE3A_PYTHON" - "$WAVE3A_DB" "$WAVE3A_MIGRATION_SHA" "$WAVE3A_ROWS_BEFORE" <<'PY'
 import json, sqlite3, sys
 import sqlite_vec
 db, expected_sha, expected_rows = sys.argv[1], sys.argv[2], int(sys.argv[3])
@@ -417,7 +422,7 @@ The live distribution may differ from the rehearsal counts because classificatio
 
 ```bash
 set -o pipefail
-"$WAVE3A_PYTHON" scripts/verify_source_class_visibility.py --db "$WAVE3A_DB" \
+"$WAVE3A_PYTHON" "$WAVE3A_EXEC_REPO/scripts/verify_source_class_visibility.py" --db "$WAVE3A_DB" \
   | tee "$WAVE3A_RUN_DIR/source-class-visibility.json"
 ```
 
@@ -472,11 +477,11 @@ with open(sys.argv[2], "w", encoding="utf-8") as handle:
 PY
 source "$WAVE3A_RUN_DIR/live-probes.env"
 QUERY="$WAVE3A_VISIBLE_TOKEN" NUM_RESULTS=100 RAW_OUTPUT_PATH="$WAVE3A_RUN_DIR/real-mcp-visible.raw.jsonl" \
-  DEADLINE_SECS=30 scripts/smoke/firstturn-brainlayer-smoke.sh \
+  DEADLINE_SECS=30 "$WAVE3A_EXEC_REPO/scripts/smoke/firstturn-brainlayer-smoke.sh" \
   | tee "$WAVE3A_RUN_DIR/real-mcp-visible.out"
 grep -F "$WAVE3A_VISIBLE_ID" "$WAVE3A_RUN_DIR/real-mcp-visible.raw.jsonl"
 QUERY="$WAVE3A_DESKTOP_TOKEN" NUM_RESULTS=100 RAW_OUTPUT_PATH="$WAVE3A_RUN_DIR/real-mcp-desktop.raw.jsonl" \
-  DEADLINE_SECS=30 scripts/smoke/firstturn-brainlayer-smoke.sh \
+  DEADLINE_SECS=30 "$WAVE3A_EXEC_REPO/scripts/smoke/firstturn-brainlayer-smoke.sh" \
   | tee "$WAVE3A_RUN_DIR/real-mcp-desktop.out"
 ! grep -F "$WAVE3A_DESKTOP_ID" "$WAVE3A_RUN_DIR/real-mcp-desktop.raw.jsonl"
 "$WAVE3A_CLI" search "source class" -n 3 --text \

--- a/scripts/verify_source_class_visibility.py
+++ b/scripts/verify_source_class_visibility.py
@@ -140,6 +140,34 @@ def _audit_hidden_class_default_visibility(store: VectorStore, source_class: str
     return {"sampled_tokens": len(checked_tokens), "leaked_ids": []}
 
 
+def _brain_worker_index_counts(store: VectorStore) -> dict[str, int]:
+    """Count indexed rows across the complete brain-worker class, not one sample."""
+    tables = {
+        str(row[0])
+        for row in store.conn.cursor().execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")
+    }
+    counts: dict[str, int] = {}
+    for table in (
+        "chunks_fts",
+        "chunks_fts_operational",
+        "chunks_fts_trigram",
+        "chunk_fts_rowids",
+        "chunk_vectors",
+        "chunk_vectors_binary",
+    ):
+        if table not in tables:
+            continue
+        counts[table] = int(
+            store.conn.cursor()
+            .execute(
+                f'SELECT COUNT(*) FROM "{table}" i JOIN chunks c ON c.id = i.chunk_id '
+                "WHERE c.source_class = 'brain-worker'"
+            )
+            .fetchone()[0]
+        )
+    return counts
+
+
 def verify(db_path: Path) -> dict[str, object]:
     store = VectorStore(db_path.expanduser().resolve(), readonly=True)
     try:
@@ -164,26 +192,7 @@ def verify(db_path: Path) -> dict[str, object]:
             raise RuntimeError("no brain-worker row exists for exact-expansion verification")
         brain_worker_id = str(brain_worker_row[0])
         context = store.get_context(brain_worker_id, include_audit=True, include_checkpoints=True)
-        tables = {
-            str(row[0])
-            for row in store.conn.cursor().execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")
-        }
-        index_counts = {}
-        for table in (
-            "chunks_fts",
-            "chunks_fts_operational",
-            "chunks_fts_trigram",
-            "chunk_fts_rowids",
-            "chunk_vectors",
-            "chunk_vectors_binary",
-        ):
-            if table not in tables:
-                continue
-            index_counts[table] = int(
-                store.conn.cursor()
-                .execute(f'SELECT COUNT(*) FROM "{table}" WHERE chunk_id = ?', (brain_worker_id,))
-                .fetchone()[0]
-            )
+        index_counts = _brain_worker_index_counts(store)
         if (context.get("target") or {}).get("id") != brain_worker_id or any(index_counts.values()):
             raise RuntimeError("brain-worker must expand exactly while remaining outside search indexes")
         receipt["brain-worker"] = {

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -806,6 +806,7 @@ class SearchMixin:
         """Return a connection-scoped token plus that connection's data version."""
         for attempt in range(3):
             try:
+                # Resolve the cursor first: _get_read_conn() rotates the token when it creates a replacement connection.
                 cursor = self._read_cursor()
                 row = cursor.execute("PRAGMA data_version").fetchone()
                 if not row:
@@ -1953,7 +1954,7 @@ class SearchMixin:
 
         # ── Cache lookup ─────────────────────────────────────────────────────
         store_key = os.fspath(getattr(self, "db_path", "<unknown-db>"))
-        cache_key = _hybrid_cache_key(
+        base_cache_key = _hybrid_cache_key(
             store_key,
             query_text,
             query_embedding,
@@ -1995,6 +1996,8 @@ class SearchMixin:
         )
         now = time.monotonic()
         reader_state_before_search = self._reader_cache_state()
+        reader_cache_token = reader_state_before_search[0] if reader_state_before_search is not None else None
+        cache_key = base_cache_key + (reader_cache_token,)
         if cache_key in _hybrid_cache:
             cached_result, cached_at, cached_reader_state = _hybrid_cache[cache_key]
             if (

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -1994,13 +1994,13 @@ class SearchMixin:
             include_hidden_source_classes,
         )
         now = time.monotonic()
+        reader_state_before_search = self._reader_cache_state()
         if cache_key in _hybrid_cache:
             cached_result, cached_at, cached_reader_state = _hybrid_cache[cache_key]
-            current_reader_state = self._reader_cache_state()
             if (
                 now - cached_at < _HYBRID_CACHE_TTL
-                and current_reader_state is not None
-                and cached_reader_state == current_reader_state
+                and reader_state_before_search is not None
+                and cached_reader_state == reader_state_before_search
             ):
                 _hybrid_cache.move_to_end(cache_key)  # LRU touch
                 cached_clone = _clone_hybrid_result(cached_result)
@@ -2672,14 +2672,16 @@ class SearchMixin:
         self._queue_retrieval_strengthening(ids)
 
         # ── Cache store ──────────────────────────────────────────────────────
-        _hybrid_cache[cache_key] = (
-            _clone_hybrid_result(result),
-            time.monotonic(),
-            self._reader_cache_state(),
-        )
-        _hybrid_cache.move_to_end(cache_key)
-        if len(_hybrid_cache) > _HYBRID_CACHE_MAX:
-            _hybrid_cache.popitem(last=False)  # evict oldest
+        reader_state_after_search = self._reader_cache_state()
+        if reader_state_before_search is not None and reader_state_after_search == reader_state_before_search:
+            _hybrid_cache[cache_key] = (
+                _clone_hybrid_result(result),
+                time.monotonic(),
+                reader_state_after_search,
+            )
+            _hybrid_cache.move_to_end(cache_key)
+            if len(_hybrid_cache) > _HYBRID_CACHE_MAX:
+                _hybrid_cache.popitem(last=False)  # evict oldest
 
         return result
 

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -2051,6 +2051,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
             conn.enableloadextension(False)
             _configure_reader_pragmas(conn)
             self._local.read_conn = conn
+            self._local.reader_cache_token = object()
         return conn
 
     def _read_cursor(self):
@@ -2996,6 +2997,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 if read_conn is not None:
                     read_conn.close()
                     self._local.read_conn = None
+                    self._local.reader_cache_token = None
             if hasattr(self, "conn"):
                 self.conn.close()
         finally:

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -265,6 +265,35 @@ def test_hybrid_cache_rejects_same_thread_replacement_reader_with_reset_data_ver
     assert "cache-replacement-reader-row" not in second["ids"][0]
 
 
+def test_hybrid_cache_retains_entries_for_multiple_readers_on_same_database(store, monkeypatch):
+    embedding = _embed("pooled reader cache")
+    _insert_chunk(
+        store,
+        chunk_id="cache-pooled-reader-row",
+        content="PooledReaderCacheNeedle",
+        embedding=embedding,
+    )
+    second_reader = VectorStore(store.db_path)
+    try:
+        search_args = {
+            "query_embedding": embedding,
+            "query_text": "PooledReaderCacheNeedle",
+            "n_results": 5,
+        }
+        assert "cache-pooled-reader-row" in store.hybrid_search(**search_args)["ids"][0]
+        assert "cache-pooled-reader-row" in second_reader.hybrid_search(**search_args)["ids"][0]
+        assert len(_hybrid_cache) == 2
+
+        def fail_on_cache_miss(**_kwargs):
+            raise AssertionError("first reader's cache entry was evicted by the second reader")
+
+        monkeypatch.setattr(store, "search", fail_on_cache_miss)
+        monkeypatch.setattr(store, "_binary_search", fail_on_cache_miss)
+        assert "cache-pooled-reader-row" in store.hybrid_search(**search_args)["ids"][0]
+    finally:
+        second_reader.close()
+
+
 class TestBinaryIndexLifecycle:
     def test_binary_table_created(self, store):
         cursor = store.conn.cursor()

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -191,6 +191,47 @@ def test_source_class_knn_count_cache_is_scoped_to_reader_connection(store):
     assert effective_k[-1] == 6
 
 
+def test_hybrid_cache_does_not_stamp_precommit_result_with_postcommit_state(store, monkeypatch):
+    embedding = _embed("cache commit between result and stamp")
+    _insert_chunk(
+        store,
+        chunk_id="cache-interleaved-source-class-row",
+        content="CacheInterleavedSourceClassNeedle",
+        embedding=embedding,
+    )
+
+    committed = False
+
+    def commit_source_class_change(_chunk_ids):
+        nonlocal committed
+        if committed:
+            return
+        writer = apsw.Connection(str(store.db_path))
+        writer.execute(
+            "UPDATE chunks SET source_class = 'desktop' WHERE id = ?",
+            ("cache-interleaved-source-class-row",),
+        )
+        writer.close()
+        committed = True
+
+    monkeypatch.setattr(store, "_queue_retrieval_strengthening", commit_source_class_change)
+    first = store.hybrid_search(
+        query_embedding=embedding,
+        query_text="CacheInterleavedSourceClassNeedle",
+        n_results=5,
+    )
+    assert "cache-interleaved-source-class-row" in first["ids"][0]
+    assert committed
+
+    monkeypatch.setattr(store, "_queue_retrieval_strengthening", lambda _chunk_ids: None)
+    second = store.hybrid_search(
+        query_embedding=embedding,
+        query_text="CacheInterleavedSourceClassNeedle",
+        n_results=5,
+    )
+    assert "cache-interleaved-source-class-row" not in second["ids"][0]
+
+
 class TestBinaryIndexLifecycle:
     def test_binary_table_created(self, store):
         cursor = store.conn.cursor()

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -232,6 +232,39 @@ def test_hybrid_cache_does_not_stamp_precommit_result_with_postcommit_state(stor
     assert "cache-interleaved-source-class-row" not in second["ids"][0]
 
 
+def test_hybrid_cache_rejects_same_thread_replacement_reader_with_reset_data_version(store):
+    embedding = _embed("same thread replacement reader cache")
+    _insert_chunk(
+        store,
+        chunk_id="cache-replacement-reader-row",
+        content="CacheReplacementReaderNeedle",
+        embedding=embedding,
+    )
+
+    first = store.hybrid_search(
+        query_embedding=embedding,
+        query_text="CacheReplacementReaderNeedle",
+        n_results=5,
+    )
+    assert "cache-replacement-reader-row" in first["ids"][0]
+
+    store._local.read_conn.close()
+    store._local.read_conn = None
+    writer = apsw.Connection(str(store.db_path))
+    writer.execute(
+        "UPDATE chunks SET source_class = 'desktop' WHERE id = ?",
+        ("cache-replacement-reader-row",),
+    )
+    writer.close()
+
+    second = store.hybrid_search(
+        query_embedding=embedding,
+        query_text="CacheReplacementReaderNeedle",
+        n_results=5,
+    )
+    assert "cache-replacement-reader-row" not in second["ids"][0]
+
+
 class TestBinaryIndexLifecycle:
     def test_binary_table_created(self, store):
         cursor = store.conn.cursor()

--- a/tests/test_source_class.py
+++ b/tests/test_source_class.py
@@ -10,7 +10,10 @@ from brainlayer.ingest_denylist import BRAINLAYER_INGEST_DENYLIST_ENV, is_denyli
 from brainlayer.pipeline.chunk import Chunk
 from brainlayer.pipeline.classify import ContentType, ContentValue
 from brainlayer.vector_store import VectorStore
-from scripts.verify_source_class_visibility import _audit_hidden_class_default_visibility
+from scripts.verify_source_class_visibility import (
+    _audit_hidden_class_default_visibility,
+    _brain_worker_index_counts,
+)
 
 
 def _claude_subagent(tmp_path: Path, repo: str, name: str = "agent.jsonl") -> Path:
@@ -148,4 +151,31 @@ def test_hidden_class_audit_fails_on_any_sampled_desktop_leak(tmp_path: Path, mo
 
     with pytest.raises(RuntimeError, match="desktop.*leak"):
         _audit_hidden_class_default_visibility(store, "desktop")
+    store.close()
+
+
+def test_brain_worker_index_audit_counts_every_worker_row(tmp_path: Path) -> None:
+    store = VectorStore(tmp_path / "source-class-worker-index-audit.db")
+    cursor = store.conn.cursor()
+    for chunk_id in ("worker-first", "worker-residual"):
+        cursor.execute(
+            """
+            INSERT INTO chunks (
+                id, content, metadata, source_file, project, content_type,
+                char_count, source_class
+            ) VALUES (?, ?, '{}', ?, 'brainlayer', 'assistant_text', 32, 'brain-worker')
+            """,
+            (chunk_id, f"brain worker audit {chunk_id}", f"/{chunk_id}.jsonl"),
+        )
+    cursor.execute("DELETE FROM chunks_fts WHERE chunk_id IN ('worker-first', 'worker-residual')")
+    cursor.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id IN ('worker-first', 'worker-residual')")
+    cursor.execute(
+        "INSERT INTO chunks_fts(content, chunk_id) VALUES (?, ?)",
+        ("residual worker search row", "worker-residual"),
+    )
+
+    counts = _brain_worker_index_counts(store)
+
+    assert counts["chunks_fts"] == 1
+    assert counts["chunk_fts_rowids"] == 0
     store.close()


### PR DESCRIPTION
Closes the exact-head hosted review findings that landed as #700 merged:

- captures and validates hybrid-cache reader state across the whole search, with deterministic interleaving regression
- moves the LIVE row-count invariant after writer quiescence/checkpoint and asserts backup quick-check
- audits every brain-worker row across all six indexes and records the shipped-head visibility rerun

LIVE remains held until v1.5.6 is installed and probed on both hosts.

— brainlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feadc","ts":"2026-08-10T13:12:26Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live search result caching and source-class visibility guarantees used for production migration sign-off; incorrect cache logic could serve stale rankings until TTL, while verifier/runbook gaps affect operational safety rather than steady-state app traffic.
> 
> **Overview**
> Closes post-review gates for Wave 3a by hardening **hybrid search cache correctness**, **LIVE migration verification**, and the **two-host runbook**.
> 
> **Hybrid search cache:** `hybrid_search` now snapshots reader state once at lookup and only writes the LRU entry if that same `(reader_cache_token, data_version)` pair is unchanged after the query—so commits or side effects during search (e.g. retrieval strengthening) cannot stamp pre-commit results with post-commit state. Per-thread readonly connections get a new `reader_cache_token` when recreated, and the cache key includes that token so a replaced reader cannot reuse stale hits. Regression tests cover interleaved commits, same-thread connection replacement, and multi-reader entries on one DB.
> 
> **Wave 3a verification:** `verify_source_class_visibility` audits **all** `brain-worker` rows across six FTS/vector indexes (not a single sample chunk). The runbook splits **migration** vs **execution/verifier** checkouts and SHAs, moves **rows-before** capture to after writer stop + checkpoint, requires **`PRAGMA quick_check = ok`** on backup validation, expands SQL reconcile to assert zero brain-worker rows in each FTS table, and documents the shipped-head visibility rerun.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e09bdeee3f9f4a1974fe0df570012b6aff8387d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `hybrid_search` cache to prevent stale results from concurrent commits and per-reader collisions
> - Scopes `hybrid_search` cache entries per reader thread by appending a `reader_cache_token` to the cache key, so separate readers on the same DB maintain independent entries.
> - Only writes a cache entry when the connection's `data_version` is unchanged before and after the search, preventing pre-commit results from being stamped with post-commit state.
> - Adds a new `_brain_worker_index_counts` helper in [verify_source_class_visibility.py](https://github.com/EtanHey/brainlayer/pull/703/files#diff-e7de2e0ec880bcfe0bb466718a0c09e40356e19f2c245a45e488fb6f0cf334e4) that aggregates brain-worker row counts across all relevant index tables; the verifier now fails if any brain-worker rows exist in any index.
> - Updates the [wave3-3a runbook](https://github.com/EtanHey/brainlayer/pull/703/files#diff-9a1b76c522f84422c1e84d733e972b05376567a36bffed0f5cc14b2889868539) to require separate migration/execution repo checkouts, capture row counts only after WAL checkpoint, and validate per-index brain-worker counts in receipt checks.
> - Behavioral Change: `hybrid_search` cache hits now require both TTL validity and a matching `reader_state` snapshot; previously cached results may not be returned after a concurrent write.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e09bde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->