### PR TITLE
chore(release): BrainLayer and BrainBar 1.5.5

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,11 +9,11 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.5.4</string>
+    <string>1.5.5</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.4</string>
+    <string>1.5.5</string>
     <key>BrainLayerReleaseVersion</key>
-    <string>1.5.4</string>
+    <string>1.5.5</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.5.4"
+version = "1.5.5"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"


### PR DESCRIPTION
## Summary

- Bump BrainLayer and BrainBar release metadata from 1.5.4 to 1.5.5.
- Publish the signed/notarized BrainBar recovery carrying deferred-store receipt wording from #693, the core-profile scheduled-backup allowance from #698, and the backup protocol-starvation/fd-reuse fix from #701.
- Carry the already-merged, schema-absent-compatible source-class gate from #700 and #703; it remains dormant until migration adds `source_class`.
- Publish the corresponding Python package through the existing tag-triggered PyPI workflow.
- Update the Homebrew cask and formula to 1.5.5 in lockstep after hosted artifacts exist; the cask already declares `depends_on formula: "brainlayer"`.

## Verification

- Exactly seven literal version substitutions across `pyproject.toml`, `src/brainlayer/__init__.py`, `server.json`, and `brain-bar/bundle/Info.plist`; zero code changes.
- Release version synchronization: 2/2 passed.
- Release/build guard selection: 94 passed; one initial helper-import timeout passed in the authoritative full push gate.
- Full pre-push unit, MCP registration, isolated eval/routing, Bun, and shell gates passed.

## Post-merge release contract

- Tag merged main as `v1.5.5`.
- Require the signed/notarized BrainBar workflow and PyPI publish to pass; no local release build.
- Update/install the Homebrew cask and formula at 1.5.5.
- Verify the installed/running artifact with a fresh held-open socket: initialize, notifications/initialized, tools/list, and one successful brain_recall tools/call.
- Run a real backup and verify `uploaded=true`, `verified=true`, and `backup_log_provenance=real`.
- Then cut metadata-only v1.5.6 through the same release and transport gates.

— brainlayer-worker-ygt7ve (worker) · codex/gpt-5.6-sol
<!-- golem-id: {"seat":"brainlayer-worker-ygt7ve","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feaca","ts":"2026-08-10T17:52:00Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string updates only; no runtime, security, or schema logic is modified in this PR.
> 
> **Overview**
> **Release 1.5.5** — metadata-only version bump from **1.5.4** to **1.5.5** across the Python package (`pyproject.toml`, `src/brainlayer/__init__.py`), MCP registry (`server.json`), and BrainBar app bundle (`brain-bar/bundle/Info.plist`). No application or library code changes in this diff.
> 
> The release packages already-merged work (BrainBar recovery wording, scheduled-backup allowance, backup protocol fixes, dormant `source_class` gate) for signed/notarized BrainBar, PyPI publish, and Homebrew updates per the post-merge contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abab2ea6814bdb6b8dc626d745760213225f1e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump BrainLayer and BrainBar version to 1.5.5
> Updates version strings from 1.5.4 to 1.5.5 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/705/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/705/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/705/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/705/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abab2ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->