### PR TITLE
feat(setup): exclude runtime data from Spotlight

### DIFF
--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -82,23 +82,33 @@ condition fails, keep services stopped and investigate; do not move the tree.
 
 ### 4. Stage, mark, and restore each canonical tree
 
-For each of the four roots, perform a same-filesystem rename to its exact staging path, recreate the
-canonical root, create `.metadata_never_index`, then move every child (including dotfiles) back.
-Never copy across filesystems and never create the marker after children return.
+For each of the four roots, perform a same-filesystem rename to its exact staging path, create
+`.metadata_never_index` inside the staged tree, then atomically rename the same tree back to its
+canonical path. This preserves the root's mode, ownership, ACLs, extended attributes, and children;
+the marker is already present before the canonical path becomes visible again. Never copy the tree.
 
 Example for the data root; repeat with the exact runtime/log/counter pairs listed above:
 
 ```bash
 mv /Users/etanheyman/.local/share/brainlayer \
   /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging
-mkdir /Users/etanheyman/.local/share/brainlayer
-touch /Users/etanheyman/.local/share/brainlayer/.metadata_never_index
-find /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging \
-  -mindepth 1 -maxdepth 1 -exec mv {} /Users/etanheyman/.local/share/brainlayer/ \;
+touch /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging/.metadata_never_index
+mv /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging \
+  /Users/etanheyman/.local/share/brainlayer
 ```
 
 Before each `mv`, resolve and print both paths, assert the source is the expected canonical root,
 assert the staging target does not exist, and confirm both parents are on the same filesystem.
+Apply this recovery state machine before continuing any root:
+
+- canonical exists, staging absent: expected; continue;
+- canonical missing, staging exists: restore with an atomic staging-to-canonical rename, verify the
+  tree, and restart this root's preflight from the beginning;
+- both exist: duplicate/conflict; stop without moving or merging either tree;
+- both absent: data is missing; stop and investigate.
+
+This same state machine is the recovery procedure if the shell or machine stops between either
+rename. Never infer completion from the presence of only one path without inspecting it.
 
 ### 5. Re-run setup and verify paths before restart
 
@@ -118,8 +128,8 @@ it points into a marked ancestor before restart.
 Bootstrap the recorded launchd plist set, then verify each expected label is loaded and each daemon
 has a live PID. Do not restore a label that was deliberately disabled before the window.
 
-Keep the now-empty staging directories until every verification below passes. Afterward, verify
-each is empty and remove only those four exact directories.
+Confirm none of the four staging paths remains after its atomic rename back. If one remains, stop
+and investigate before restarting writers.
 
 Run a real request through a fresh installed MCP client session (not an in-process Python test):
 
@@ -143,15 +153,22 @@ First establish that Spotlight is enabled for the containing volume:
 mdutil -s /
 ```
 
-Then create a unique plain-text probe beneath the marked data root. Record these outputs:
+Then create a unique, non-clobbering plain-text probe beneath the marked data root. Record these
+outputs and retain the two printed variable values with the evidence:
 
 ```bash
-mdimport -t -d1 /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt
-mdimport -i /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt
+spotlight_probe_path="$(mktemp /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt.XXXXXX)"
+spotlight_probe_name="$(basename "$spotlight_probe_path")"
+printf 'BrainLayer Spotlight exclusion live probe %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  > "$spotlight_probe_path"
+printf 'probe_path=%s\nprobe_name=%s\n' "$spotlight_probe_path" "$spotlight_probe_name"
+mdimport -t -d1 "$spotlight_probe_path"
+mdimport -i "$spotlight_probe_path"
 mdls -name kMDItemFSName -name kMDItemContentType \
-  /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt
+  "$spotlight_probe_path"
 mdfind -onlyin /Users/etanheyman/.local/share/brainlayer \
-  'kMDItemFSName == "spotlight-exclusion-live-probe.txt"cd'
+  "kMDItemFSName == '$spotlight_probe_name'cd"
+rm -- "$spotlight_probe_path"
 ```
 
 Pass criteria: `mdutil` shows the containing volume is indexed; `mdimport -t` identifies the normal
@@ -165,11 +182,12 @@ the whole volume.
 
 ## Rollback
 
-Rollback is allowed only before writers restart. Keep all processes stopped. For each root, move
-every restored child except `.metadata_never_index` back into its still-present staging directory,
-remove only the exact marker, remove the now-empty canonical directory, and rename staging back to
-the canonical name. Verify DB/WAL/SHM and queue counts before bootstrapping only the preflight label
-set. If either tree contains an unexpected duplicate, stop; never overwrite or merge it.
+Rollback is allowed only before writers restart. Keep all processes stopped. For each root, first
+apply the same four-state recovery table above: restore staging to canonical when only staging
+exists, and stop on both-exist or both-absent states. Once canonical exists and staging is absent,
+atomically rename canonical to staging, remove only `.metadata_never_index`, then atomically rename
+the same tree back to canonical. This preserves the original root metadata. Verify DB/WAL/SHM and
+queue counts before bootstrapping only the preflight label set. Never overwrite or merge paths.
 
 ## Completion record
 

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -104,15 +104,21 @@ set -euo pipefail
 brainlayer_data_root="${HOME:?}/.local/share/brainlayer"
 brainlayer_stage_root="${HOME:?}/.local/share/brainlayer.spotlight-migration-staging"
 test -d "$brainlayer_data_root"
-test ! -e "$brainlayer_stage_root"
+test ! -L "$brainlayer_data_root"
+brainlayer_expected_root="$(cd "${HOME:?}/.local/share" && pwd -P)/brainlayer"
+test "$(realpath "$brainlayer_data_root")" = "$brainlayer_expected_root"
+test ! -e "$brainlayer_stage_root" && test ! -L "$brainlayer_stage_root"
 mv "$brainlayer_data_root" "$brainlayer_stage_root"
 touch "$brainlayer_stage_root/.metadata_never_index"
 test -f "$brainlayer_stage_root/.metadata_never_index"
 mv "$brainlayer_stage_root" "$brainlayer_data_root"
 ```
 
-Before each `mv`, resolve and print both paths, assert the source is the expected canonical root,
-assert the staging target does not exist, and confirm both parents are on the same filesystem.
+Before each `mv`, resolve and print both paths, reject symbolic links (including dangling staging
+links), assert the resolved source is the preflight-recorded canonical root, assert the staging
+target does not exist, and confirm both parents are on the same filesystem. `test -d` alone is not
+sufficient because it accepts a directory symlink and the subsequent `touch` could write through
+that link.
 Apply this recovery state machine before continuing any root:
 
 - canonical exists, staging absent: expected; continue;

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -38,7 +38,12 @@ configuration and user-facing exports.
 3. Confirm no staging path below exists. If one exists, stop and inspect it; never overwrite it.
 4. Record `brainlayer status --json`, `brainlayer doctor --json`, DB/WAL/SHM sizes, queue count, and
    loaded `com.brainlayer.*` labels. Resolve and record the active DB parent from `BRAINLAYER_DB`;
-   when it differs from `$HOME/.local/share/brainlayer`, add it as a fifth migration root.
+   when it differs from `$HOME/.local/share/brainlayer`, add it as a fifth migration root only
+   after validating that it is a dedicated BrainLayer-owned directory. Its basename must contain
+   `brainlayer`, and it must not be `/`, `$HOME`, a mount root, an ancestor of the canonical data
+   root, overlap another migration root, or contain unrelated data. If it fails any check, stop:
+   never mark or rename that parent. Relocate the override DB and configuration into a dedicated
+   directory in a separate approved migration before using this runbook.
 5. Keep the terminal open until restart and the real store/search probe both pass.
 
 Staging paths:
@@ -84,8 +89,9 @@ condition fails, keep services stopped and investigate; do not move the tree.
 
 ### 4. Stage, mark, and restore each canonical tree
 
-For each of the four canonical roots, plus the active `BRAINLAYER_DB` parent when it is distinct,
-perform a same-filesystem rename to its exact staging path, create
+For each of the four canonical roots, plus the active `BRAINLAYER_DB` parent when it is distinct
+and passed the dedicated-directory validation above, perform a same-filesystem rename to its exact
+staging path, create
 `.metadata_never_index` inside the staged tree, then atomically rename the same tree back to its
 canonical path. This preserves the root's mode, ownership, ACLs, extended attributes, and children;
 the marker is already present before the canonical path becomes visible again. Never copy the tree.
@@ -158,11 +164,20 @@ brainlayer doctor --json
 
 ### 7. Spotlight evidence
 
-First establish that Spotlight is enabled for the containing volume:
+First establish that Spotlight is enabled for the containing volume of every migration root. For
+each canonical root and the validated distinct override root, resolve the filesystem mount point,
+record the root-to-volume mapping, and query that mount point directly:
 
 ```bash
-mdutil -s /
+brainlayer_probe_root="${HOME:?}/.local/share/brainlayer"
+brainlayer_probe_volume="$(df -P "$brainlayer_probe_root" | awk 'END {print $NF}')"
+printf 'root=%s\nvolume=%s\n' "$brainlayer_probe_root" "$brainlayer_probe_volume"
+mdutil -s "$brainlayer_probe_volume"
 ```
+
+Repeat this check for every migrated root. Do not infer an override root's Spotlight state from
+`mdutil -s /`: an override may reside on another volume. Every containing volume must report that
+indexing is enabled before the exclusion probe can be interpreted.
 
 Then create a unique, non-clobbering plain-text probe beneath the marked data root. Record these
 outputs and retain the two printed variable values with the evidence:

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -37,7 +37,8 @@ configuration and user-facing exports.
 2. Confirm the current time is inside the approved window and no backup or release job overlaps it.
 3. Confirm no staging path below exists. If one exists, stop and inspect it; never overwrite it.
 4. Record `brainlayer status --json`, `brainlayer doctor --json`, DB/WAL/SHM sizes, queue count, and
-   loaded `com.brainlayer.*` labels.
+   loaded `com.brainlayer.*` labels. Resolve and record the active DB parent from `BRAINLAYER_DB`;
+   when it differs from `$HOME/.local/share/brainlayer`, add it as a fifth migration root.
 5. Keep the terminal open until restart and the real store/search probe both pass.
 
 Staging paths:
@@ -47,6 +48,7 @@ $HOME/.local/share/brainlayer.spotlight-migration-staging
 $HOME/.brainlayer.spotlight-migration-staging
 $HOME/Library/Logs/brainlayer.spotlight-migration-staging
 $HOME/.brainlayer-p0-counter.spotlight-migration-staging
+<active-BRAINLAYER_DB-parent>.spotlight-migration-staging  # only when outside the canonical root
 ```
 
 ## Execute in one stop window
@@ -82,12 +84,14 @@ condition fails, keep services stopped and investigate; do not move the tree.
 
 ### 4. Stage, mark, and restore each canonical tree
 
-For each of the four roots, perform a same-filesystem rename to its exact staging path, create
+For each of the four canonical roots, plus the active `BRAINLAYER_DB` parent when it is distinct,
+perform a same-filesystem rename to its exact staging path, create
 `.metadata_never_index` inside the staged tree, then atomically rename the same tree back to its
 canonical path. This preserves the root's mode, ownership, ACLs, extended attributes, and children;
 the marker is already present before the canonical path becomes visible again. Never copy the tree.
 
-Example for the data root; repeat with the exact runtime/log/counter pairs listed above:
+Example for the canonical data root; repeat with the exact runtime/log/counter pairs listed above
+and the recorded override parent/staging pair when applicable:
 
 ```bash
 set -euo pipefail
@@ -125,18 +129,18 @@ brainlayer doctor --json
 ```
 
 Doctor may still report daemon liveness while services are intentionally stopped, but it must not
-report `spotlight_indexing_enabled`. Confirm all four marker files exist and the canonical DB, WAL,
-SHM, queue, prompt, scratch, vector, and log paths still resolve to their pre-stop locations. No
-symlink or environment rewrite is expected for the marker design; if an override is present, verify
-it points into a marked ancestor before restart.
+report `spotlight_indexing_enabled`. Confirm all four canonical marker files and the conditional
+override marker exist, and that the DB, WAL, SHM, queue, prompt, scratch, vector, and log paths still
+resolve to their pre-stop locations. No symlink or environment rewrite is expected for the marker
+design; if an override is present, verify it points into a marked ancestor before restart.
 
 ### 6. Restart exactly the labels recorded in preflight
 
 Bootstrap the recorded launchd plist set, then verify each expected label is loaded and each daemon
 has a live PID. Do not restore a label that was deliberately disabled before the window.
 
-Confirm none of the four staging paths remains after its atomic rename back. If one remains, stop
-and investigate before restarting writers.
+Confirm none of the four canonical staging paths, or the conditional override staging path, remains
+after its atomic rename back. If one remains, stop and investigate before restarting writers.
 
 Run a real request through a fresh installed MCP client session (not an in-process Python test):
 
@@ -180,8 +184,9 @@ rm -- "$spotlight_probe_path"
 
 Pass criteria: `mdutil` shows the containing volume is indexed; `mdimport -t` identifies the normal
 importer; the real `mdimport -i` leaves both `mdls` attributes null; `mdfind` returns no probe path.
-Repeat the real import/`mdls`/`mdfind` check once under each of the other three marked roots. Remove
-only the four exact probe files after saving evidence.
+Repeat the real import/`mdls`/`mdfind` check once under each of the other three canonical marked
+roots and under the active override parent when distinct. Remove only the exact probe files after
+saving evidence.
 
 If a marker-backed root receives metadata, keep BrainLayer stopped and add that exact root through
 System Settings → Spotlight → Search Privacy, then repeat the probe. Do not disable Spotlight for
@@ -189,7 +194,8 @@ the whole volume.
 
 ## Rollback
 
-Rollback is allowed only before writers restart. Keep all processes stopped. For each root, first
+Rollback is allowed only before writers restart. Keep all processes stopped. For each canonical
+root and the conditional override root, first
 apply the same four-state recovery table above: restore staging to canonical when only staging
 exists, and stop on both-exist or both-absent states. Once canonical exists and staging is absent,
 atomically rename canonical to staging, remove only `.metadata_never_index`, then atomically rename
@@ -199,5 +205,6 @@ queue counts before bootstrapping only the preflight label set. Never overwrite 
 ## Completion record
 
 Append the exact installed version/head, pre/post DB and WAL sizes, restored labels, real
-store/search output, doctor output, and all four Spotlight probe results to the maintenance source
-task. Only the live-window operator adds the separate live-migration completion marker.
+store/search output, doctor output, all four canonical Spotlight probe results, and the conditional
+override probe result to the maintenance source task. Only the live-window operator adds the
+separate live-migration completion marker.

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -1,0 +1,178 @@
+# Spotlight Exclusion Migration Runbook
+
+Status: **READY — execute only in the lead-scheduled writer-stop window.** This runbook was written
+for the canonical Etan workstation paths. It must not run during the 03:17 backup window. Prefer the
+Tuesday 20:00 combined stop window so this migration and the other scheduled maintenance operation
+share one writer stop.
+
+## Why `.metadata_never_index`
+
+BrainLayer uses a marker in each high-churn root. On macOS 26.5.1 (25F80), a disposable recursive
+`mdimport -i` probe gave a file below `excluded.noindex` normal `kMDItemFSName` and
+`kMDItemContentType` attributes. The equivalent file below a directory containing
+`.metadata_never_index` retained null attributes. `mdimport -t` is useful importer evidence but not
+an exclusion verdict: its manual says test imports return attributes without writing the Spotlight
+index.
+
+[Apple's documented Search Privacy UI](https://support.apple.com/guide/mac-help/mchl1bb43b84/mac)
+remains the fallback if a post-migration marker probe fails. It is not the primary mechanism
+because setup must work unattended.
+
+## Complete high-churn inventory
+
+| Excluded root | Covered paths |
+| --- | --- |
+| `/Users/etanheyman/.local/share/brainlayer` | `brainlayer.db`, `brainlayer.db-wal`, `brainlayer.db-shm`; sqlite-vec data and future vector sidecars; `chromadb`, `chromadb.backup`, `style`, `storage`, `experiments`; `enrichment_checkpoints.db`, `reembed_bgem3_checkpoint.json`, `enrichment-scratch`; `prompts`; `offsets.json`, watcher/drain/T3/health state, pause sentinel, pending-store files; `backups`, `jsonl-backups`; `logs` |
+| `/Users/etanheyman/.brainlayer` | `queue`; `quarantine` including stale-queue quarantine; `logs` including drain logs; runtime repository state |
+| `/Users/etanheyman/Library/Logs/brainlayer` | launchd stdout/stderr and BrainBar runtime logs |
+| `/Users/etanheyman/.brainlayer-p0-counter` | longitudinal counter logs |
+
+`/tmp` locks, sockets, and pidfiles are already outside Spotlight's normal user-content scope.
+`~/.config/brainlayer` and `~/.brainlayer-brain` are deliberately not excluded: they are low-churn
+configuration and user-facing exports.
+
+## Preconditions
+
+1. Confirm the merged release containing this runbook is installed.
+2. Confirm the current time is inside the approved window and not near 03:17.
+3. Confirm no staging path below exists. If one exists, stop and inspect it; never overwrite it.
+4. Record `brainlayer status --json`, `brainlayer doctor --json`, DB/WAL/SHM sizes, queue count, and
+   loaded `com.brainlayer.*` labels.
+5. Keep the terminal open until restart and the real store/search probe both pass.
+
+Staging paths:
+
+```text
+/Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging
+/Users/etanheyman/.brainlayer.spotlight-migration-staging
+/Users/etanheyman/Library/Logs/brainlayer.spotlight-migration-staging
+/Users/etanheyman/.brainlayer-p0-counter.spotlight-migration-staging
+```
+
+## Execute in one stop window
+
+### 1. Reduce the live WAL before the stop
+
+This first checkpoint is deliberately non-destructive and may report busy. Do not proceed to moves
+from this result alone.
+
+```bash
+brainlayer wal-checkpoint --mode PASSIVE --json
+```
+
+### 2. Stop every writer, scheduler, and self-healer
+
+Disable/kick out the installed `com.brainlayer.*` labels as a group, including BrainBar daemon,
+watch, drain, hotlane, enrichment, index, T3 ingest, maintenance, repair, decay, WAL checkpoint,
+backup jobs, watchdogs, and the P0 counter. Record the exact loaded-label list before stopping it so
+only that list is restored. Verify with both `launchctl print` and `pgrep -fal` that no BrainLayer
+Python, BrainBar daemon, watcher, drain, hotlane, or enrichment process remains.
+
+Do not let a watchdog restart a writer between this step and the final checkpoint.
+
+### 3. Checkpoint after writers are stopped
+
+```bash
+brainlayer wal-checkpoint --mode TRUNCATE --retry-busy --json
+```
+
+Require `busy: false`, a zero-byte or absent `brainlayer.db-wal`, and no process holding
+`brainlayer.db`, `brainlayer.db-wal`, or `brainlayer.db-shm` (`lsof` must return no writer). If any
+condition fails, keep services stopped and investigate; do not move the tree.
+
+### 4. Stage, mark, and restore each canonical tree
+
+For each of the four roots, perform a same-filesystem rename to its exact staging path, recreate the
+canonical root, create `.metadata_never_index`, then move every child (including dotfiles) back.
+Never copy across filesystems and never create the marker after children return.
+
+Example for the data root; repeat with the exact runtime/log/counter pairs listed above:
+
+```bash
+mv /Users/etanheyman/.local/share/brainlayer \
+  /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging
+mkdir /Users/etanheyman/.local/share/brainlayer
+touch /Users/etanheyman/.local/share/brainlayer/.metadata_never_index
+find /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging \
+  -mindepth 1 -maxdepth 1 -exec mv {} /Users/etanheyman/.local/share/brainlayer/ \;
+```
+
+Before each `mv`, resolve and print both paths, assert the source is the expected canonical root,
+assert the staging target does not exist, and confirm both parents are on the same filesystem.
+
+### 5. Re-run setup and verify paths before restart
+
+```bash
+brainlayer setup --no-launchd
+brainlayer doctor --json
+```
+
+Doctor may still report daemon liveness while services are intentionally stopped, but it must not
+report `spotlight_indexing_enabled`. Confirm all four marker files exist and the canonical DB, WAL,
+SHM, queue, prompt, scratch, vector, and log paths still resolve to their pre-stop locations. No
+symlink or environment rewrite is expected for the marker design; if an override is present, verify
+it points into a marked ancestor before restart.
+
+### 6. Restart exactly the labels recorded in preflight
+
+Bootstrap the recorded launchd plist set, then verify each expected label is loaded and each daemon
+has a live PID. Do not restore a label that was deliberately disabled before the window.
+
+Keep the now-empty staging directories until every verification below passes. Afterward, verify
+each is empty and remove only those four exact directories.
+
+Run a real request through a fresh installed MCP client session (not an in-process Python test):
+
+```text
+brain_store(content="spotlight migration live probe", project="brainlayer-maintenance")
+brain_search(query="spotlight migration live probe", project="brainlayer-maintenance")
+```
+
+Then run the CLI status gates:
+
+```bash
+brainlayer status --json
+brainlayer doctor --json
+```
+
+### 7. Spotlight evidence
+
+First establish that Spotlight is enabled for the containing volume:
+
+```bash
+mdutil -s /
+```
+
+Then create a unique plain-text probe beneath the marked data root. Record these outputs:
+
+```bash
+mdimport -t -d1 /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt
+mdimport -i /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt
+mdls -name kMDItemFSName -name kMDItemContentType \
+  /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt
+mdfind -onlyin /Users/etanheyman/.local/share/brainlayer \
+  'kMDItemFSName == "spotlight-exclusion-live-probe.txt"cd'
+```
+
+Pass criteria: `mdutil` shows the containing volume is indexed; `mdimport -t` identifies the normal
+importer; the real `mdimport -i` leaves both `mdls` attributes null; `mdfind` returns no probe path.
+Repeat the real import/`mdls`/`mdfind` check once under each of the other three marked roots. Remove
+only the four exact probe files after saving evidence.
+
+If a marker-backed root receives metadata, keep BrainLayer stopped and add that exact root through
+System Settings → Spotlight → Search Privacy, then repeat the probe. Do not disable Spotlight for
+the whole volume.
+
+## Rollback
+
+Rollback is allowed only before writers restart. Keep all processes stopped. For each root, move
+every restored child except `.metadata_never_index` back into its still-present staging directory,
+remove only the exact marker, remove the now-empty canonical directory, and rename staging back to
+the canonical name. Verify DB/WAL/SHM and queue counts before bootstrapping only the preflight label
+set. If either tree contains an unexpected duplicate, stop; never overwrite or merge it.
+
+## Completion record
+
+Append the exact installed version/head, pre/post DB and WAL sizes, restored labels, real
+store/search output, doctor output, and all four Spotlight probe results to the maintenance source
+task. Only the live-window operator adds the separate live-migration completion marker.

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -191,8 +191,14 @@ record the root-to-volume mapping, and query that mount point directly:
 
 ```bash
 brainlayer_probe_root="${HOME:?}/.local/share/brainlayer"
-brainlayer_probe_volume="$(stat -f %m "$brainlayer_probe_root")"
-printf 'root=%s\nvolume=%s\n' "$brainlayer_probe_root" "$brainlayer_probe_volume"
+brainlayer_probe_device="$(df -P "$brainlayer_probe_root" | awk 'NR == 2 { print $1 }')"
+brainlayer_probe_volume="$(
+  diskutil info -plist "$brainlayer_probe_device" |
+    plutil -extract MountPoint raw -
+)"
+test -n "$brainlayer_probe_device" && test -n "$brainlayer_probe_volume"
+printf 'root=%s\ndevice=%s\nvolume=%s\n' \
+  "$brainlayer_probe_root" "$brainlayer_probe_device" "$brainlayer_probe_volume"
 mdutil -s "$brainlayer_probe_volume"
 ```
 

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -1,9 +1,8 @@
 # Spotlight Exclusion Migration Runbook
 
-Status: **READY — execute only in the lead-scheduled writer-stop window.** This runbook was written
-for the canonical Etan workstation paths. It must not run during the 03:17 backup window. Prefer the
-Tuesday 20:00 combined stop window so this migration and the other scheduled maintenance operation
-share one writer stop.
+Status: **READY — execute only in an approved writer-stop window.** Never overlap this operation
+with a backup, release, or another write-heavy maintenance job. Exact workstation scheduling and
+operator coordination belong in the restricted maintenance record, not this repository.
 
 ## Why `.metadata_never_index`
 
@@ -22,10 +21,10 @@ because setup must work unattended.
 
 | Excluded root | Covered paths |
 | --- | --- |
-| `/Users/etanheyman/.local/share/brainlayer` | `brainlayer.db`, `brainlayer.db-wal`, `brainlayer.db-shm`; sqlite-vec data and future vector sidecars; `chromadb`, `chromadb.backup`, `style`, `storage`, `experiments`; `enrichment_checkpoints.db`, `reembed_bgem3_checkpoint.json`, `enrichment-scratch`; `prompts`; `offsets.json`, watcher/drain/T3/health state, pause sentinel, pending-store files; `backups`, `jsonl-backups`; `logs` |
-| `/Users/etanheyman/.brainlayer` | `queue`; `quarantine` including stale-queue quarantine; `logs` including drain logs; runtime repository state |
-| `/Users/etanheyman/Library/Logs/brainlayer` | launchd stdout/stderr and BrainBar runtime logs |
-| `/Users/etanheyman/.brainlayer-p0-counter` | longitudinal counter logs |
+| `$HOME/.local/share/brainlayer` | `brainlayer.db`, `brainlayer.db-wal`, `brainlayer.db-shm`; sqlite-vec data and future vector sidecars; `chromadb`, `chromadb.backup`, `style`, `storage`, `experiments`; `enrichment_checkpoints.db`, `reembed_bgem3_checkpoint.json`, `enrichment-scratch`; `prompts`; `offsets.json`, watcher/drain/T3/health state, pause sentinel, pending-store files; `backups`, `jsonl-backups`; `logs` |
+| `$HOME/.brainlayer` | `queue`; `quarantine` including stale-queue quarantine; `logs` including drain logs; runtime repository state |
+| `$HOME/Library/Logs/brainlayer` | launchd stdout/stderr and BrainBar runtime logs |
+| `$HOME/.brainlayer-p0-counter` | longitudinal counter logs |
 
 `/tmp` locks, sockets, and pidfiles are already outside Spotlight's normal user-content scope.
 `~/.config/brainlayer` and `~/.brainlayer-brain` are deliberately not excluded: they are low-churn
@@ -34,7 +33,7 @@ configuration and user-facing exports.
 ## Preconditions
 
 1. Confirm the merged release containing this runbook is installed.
-2. Confirm the current time is inside the approved window and not near 03:17.
+2. Confirm the current time is inside the approved window and no backup or release job overlaps it.
 3. Confirm no staging path below exists. If one exists, stop and inspect it; never overwrite it.
 4. Record `brainlayer status --json`, `brainlayer doctor --json`, DB/WAL/SHM sizes, queue count, and
    loaded `com.brainlayer.*` labels.
@@ -43,10 +42,10 @@ configuration and user-facing exports.
 Staging paths:
 
 ```text
-/Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging
-/Users/etanheyman/.brainlayer.spotlight-migration-staging
-/Users/etanheyman/Library/Logs/brainlayer.spotlight-migration-staging
-/Users/etanheyman/.brainlayer-p0-counter.spotlight-migration-staging
+$HOME/.local/share/brainlayer.spotlight-migration-staging
+$HOME/.brainlayer.spotlight-migration-staging
+$HOME/Library/Logs/brainlayer.spotlight-migration-staging
+$HOME/.brainlayer-p0-counter.spotlight-migration-staging
 ```
 
 ## Execute in one stop window
@@ -90,11 +89,15 @@ the marker is already present before the canonical path becomes visible again. N
 Example for the data root; repeat with the exact runtime/log/counter pairs listed above:
 
 ```bash
-mv /Users/etanheyman/.local/share/brainlayer \
-  /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging
-touch /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging/.metadata_never_index
-mv /Users/etanheyman/.local/share/brainlayer.spotlight-migration-staging \
-  /Users/etanheyman/.local/share/brainlayer
+set -euo pipefail
+brainlayer_data_root="${HOME:?}/.local/share/brainlayer"
+brainlayer_stage_root="${HOME:?}/.local/share/brainlayer.spotlight-migration-staging"
+test -d "$brainlayer_data_root"
+test ! -e "$brainlayer_stage_root"
+mv "$brainlayer_data_root" "$brainlayer_stage_root"
+touch "$brainlayer_stage_root/.metadata_never_index"
+test -f "$brainlayer_stage_root/.metadata_never_index"
+mv "$brainlayer_stage_root" "$brainlayer_data_root"
 ```
 
 Before each `mv`, resolve and print both paths, assert the source is the expected canonical root,
@@ -157,7 +160,7 @@ Then create a unique, non-clobbering plain-text probe beneath the marked data ro
 outputs and retain the two printed variable values with the evidence:
 
 ```bash
-spotlight_probe_path="$(mktemp /Users/etanheyman/.local/share/brainlayer/spotlight-exclusion-live-probe.txt.XXXXXX)"
+spotlight_probe_path="$(mktemp "${HOME:?}/.local/share/brainlayer/spotlight-exclusion-live-probe.txt.XXXXXX")"
 spotlight_probe_name="$(basename "$spotlight_probe_path")"
 printf 'BrainLayer Spotlight exclusion live probe %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   > "$spotlight_probe_path"
@@ -166,7 +169,7 @@ mdimport -t -d1 "$spotlight_probe_path"
 mdimport -i "$spotlight_probe_path"
 mdls -name kMDItemFSName -name kMDItemContentType \
   "$spotlight_probe_path"
-mdfind -onlyin /Users/etanheyman/.local/share/brainlayer \
+mdfind -onlyin "${HOME:?}/.local/share/brainlayer" \
   "kMDItemFSName == '$spotlight_probe_name'cd"
 rm -- "$spotlight_probe_path"
 ```

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -44,7 +44,9 @@ configuration and user-facing exports.
    root, overlap another migration root, or contain unrelated data. If it fails any check, stop:
    never mark or rename that parent. Relocate the override DB and configuration into a dedicated
    directory in a separate approved migration before using this runbook.
-5. Keep the terminal open until restart and the real store/search probe both pass.
+5. For every migration root, provisionally record whether the root and `.metadata_never_index`
+   already exist. The authoritative rollback baseline is refreshed after all writers are stopped.
+6. Keep the terminal open until restart and the real store/search probe both pass.
 
 Staging paths:
 
@@ -77,15 +79,33 @@ Python, BrainBar daemon, watcher, drain, hotlane, or enrichment process remains.
 
 Do not let a watchdog restart a writer between this step and the final checkpoint.
 
+After confirming all processes are stopped, re-record whether every root and its marker exist.
+This writer-stop snapshot is the authoritative rollback baseline. If either state changed from the
+provisional preflight inventory, explain and record the change before proceeding; never infer that
+the migration created a marker observed before the first rename.
+
 ### 3. Checkpoint after writers are stopped
 
 ```bash
 brainlayer wal-checkpoint --mode TRUNCATE --retry-busy --json
 ```
 
-Require `busy: false`, a zero-byte or absent `brainlayer.db-wal`, and no process holding
-`brainlayer.db`, `brainlayer.db-wal`, or `brainlayer.db-shm` (`lsof` must return no writer). If any
-condition fails, keep services stopped and investigate; do not move the tree.
+Require `busy: false`. Set `brainlayer_active_db` to the absolute active DB path recorded during
+preflight—not a hardcoded canonical path—and require its WAL to be zero-byte or absent. Check the
+active DB plus its actual `-wal` and `-shm` sidecars; every existing file must have no `lsof`
+holder:
+
+```bash
+brainlayer_active_db="<preflight-resolved-active-db>"
+test "${brainlayer_active_db#/}" != "$brainlayer_active_db"
+test ! -s "${brainlayer_active_db}-wal"
+for brainlayer_db_file in \
+  "$brainlayer_active_db" "${brainlayer_active_db}-wal" "${brainlayer_active_db}-shm"; do
+  test ! -e "$brainlayer_db_file" || ! lsof -- "$brainlayer_db_file"
+done
+```
+
+If any condition fails, keep services stopped and investigate; do not move any tree.
 
 ### 4. Stage, mark, and restore each canonical tree
 
@@ -106,19 +126,32 @@ brainlayer_stage_root="${HOME:?}/.local/share/brainlayer.spotlight-migration-sta
 test -d "$brainlayer_data_root"
 test ! -L "$brainlayer_data_root"
 brainlayer_expected_root="$(cd "${HOME:?}/.local/share" && pwd -P)/brainlayer"
+brainlayer_expected_stage="$(cd "${HOME:?}/.local/share" && pwd -P)/brainlayer.spotlight-migration-staging"
 test "$(realpath "$brainlayer_data_root")" = "$brainlayer_expected_root"
 test ! -e "$brainlayer_stage_root" && test ! -L "$brainlayer_stage_root"
+test "$(stat -f %d "$(dirname "$brainlayer_data_root")")" = \
+  "$(stat -f %d "$(dirname "$brainlayer_stage_root")")"
 mv "$brainlayer_data_root" "$brainlayer_stage_root"
+test -d "$brainlayer_stage_root" && test ! -L "$brainlayer_stage_root"
+test "$(realpath "$brainlayer_stage_root")" = "$brainlayer_expected_stage"
 touch "$brainlayer_stage_root/.metadata_never_index"
 test -f "$brainlayer_stage_root/.metadata_never_index"
+test ! -e "$brainlayer_data_root" && test ! -L "$brainlayer_data_root"
+test "$(stat -f %d "$(dirname "$brainlayer_stage_root")")" = \
+  "$(stat -f %d "$(dirname "$brainlayer_data_root")")"
 mv "$brainlayer_stage_root" "$brainlayer_data_root"
+test -d "$brainlayer_data_root" && test ! -L "$brainlayer_data_root"
+test "$(realpath "$brainlayer_data_root")" = "$brainlayer_expected_root"
+test -f "$brainlayer_data_root/.metadata_never_index"
+test ! -e "$brainlayer_stage_root" && test ! -L "$brainlayer_stage_root"
 ```
 
-Before each `mv`, resolve and print both paths, reject symbolic links (including dangling staging
-links), assert the resolved source is the preflight-recorded canonical root, assert the staging
-target does not exist, and confirm both parents are on the same filesystem. `test -d` alone is not
-sufficient because it accepts a directory symlink and the subsequent `touch` could write through
-that link.
+Before each `mv`, resolve and print both paths, reject symbolic links (including dangling target
+links), and confirm both parents are on the same filesystem. For the first move, assert the source
+resolves to the preflight-recorded canonical root and staging is absent. For the restore move,
+assert the source resolves to the exact staging root and canonical is absent. `test -d` alone is
+not sufficient because it accepts a directory symlink and the subsequent `touch` could write
+through that link.
 Apply this recovery state machine before continuing any root:
 
 - canonical exists, staging absent: expected; continue;
@@ -135,6 +168,10 @@ rename. Never infer completion from the presence of only one path without inspec
 
 ### 5. Re-run setup and verify paths before restart
 
+Confirm none of the four canonical staging paths, or the conditional override staging path,
+remains. Apply the recovery state machine before running setup if any staging path exists; setup
+must never create a fresh canonical tree beside staged data.
+
 ```bash
 brainlayer setup --no-launchd
 brainlayer doctor --json
@@ -146,29 +183,7 @@ override marker exist, and that the DB, WAL, SHM, queue, prompt, scratch, vector
 resolve to their pre-stop locations. No symlink or environment rewrite is expected for the marker
 design; if an override is present, verify it points into a marked ancestor before restart.
 
-### 6. Restart exactly the labels recorded in preflight
-
-Bootstrap the recorded launchd plist set, then verify each expected label is loaded and each daemon
-has a live PID. Do not restore a label that was deliberately disabled before the window.
-
-Confirm none of the four canonical staging paths, or the conditional override staging path, remains
-after its atomic rename back. If one remains, stop and investigate before restarting writers.
-
-Run a real request through a fresh installed MCP client session (not an in-process Python test):
-
-```text
-brain_store(content="spotlight migration live probe", project="brainlayer-maintenance")
-brain_search(query="spotlight migration live probe", project="brainlayer-maintenance")
-```
-
-Then run the CLI status gates:
-
-```bash
-brainlayer status --json
-brainlayer doctor --json
-```
-
-### 7. Spotlight evidence
+### 6. Spotlight evidence while writers remain stopped
 
 First establish that Spotlight is enabled for the containing volume of every migration root. For
 each canonical root and the validated distinct override root, resolve the filesystem mount point,
@@ -213,15 +228,45 @@ If a marker-backed root receives metadata, keep BrainLayer stopped and add that 
 System Settings → Spotlight → Search Privacy, then repeat the probe. Do not disable Spotlight for
 the whole volume.
 
+### 7. Restart exactly the labels recorded in preflight
+
+Only after every root passes Step 6, bootstrap the recorded launchd plist set, then verify each
+expected label is loaded and each daemon has a live PID. Do not restore a label that was
+deliberately disabled before the window.
+
+Run a real request through a fresh installed MCP client session (not an in-process Python test):
+
+```text
+brain_store(content="spotlight migration live probe", project="brainlayer-maintenance")
+brain_search(query="spotlight migration live probe", project="brainlayer-maintenance")
+```
+
+Then run the CLI status gates:
+
+```bash
+brainlayer status --json
+brainlayer doctor --json
+```
+
 ## Rollback
 
-Rollback is allowed only before writers restart. Keep all processes stopped. For each canonical
-root and the conditional override root, first
-apply the same four-state recovery table above: restore staging to canonical when only staging
-exists, and stop on both-exist or both-absent states. Once canonical exists and staging is absent,
-atomically rename canonical to staging, remove only `.metadata_never_index`, then atomically rename
-the same tree back to canonical. This preserves the original root metadata. Verify DB/WAL/SHM and
-queue counts before bootstrapping only the preflight label set. Never overwrite or merge paths.
+Rollback is allowed only before writers restart. Keep all processes stopped. For each root that
+existed in the writer-stop baseline, restore staging to canonical when only staging exists, stop on
+both-exist, and treat both-absent as data loss. Once canonical exists and staging is absent,
+atomically rename canonical to staging. Consult the writer-stop marker record and remove
+`.metadata_never_index` only when this execution created it; preserve every marker that was already
+present. Then atomically rename the same tree back to canonical. This preserves the original root
+metadata.
+
+For an optional root recorded as absent at writer-stop, both-absent is the successfully restored
+state and must stay absent. If the migration created its canonical tree, require staging to be
+absent and prove the tree contains only the marker plus known setup-created empty directories.
+Remove only the exact execution-created marker file, then remove those known empty directories and
+the root with exact, non-recursive `rmdir` operations; stop on any unexpected or nonempty entry.
+Never apply the forward absent/absent rule during rollback.
+
+Verify DB/WAL/SHM and queue counts before bootstrapping only the preflight label set. Never
+overwrite or merge paths.
 
 ## Completion record
 

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -191,7 +191,7 @@ record the root-to-volume mapping, and query that mount point directly:
 
 ```bash
 brainlayer_probe_root="${HOME:?}/.local/share/brainlayer"
-brainlayer_probe_volume="$(df -P "$brainlayer_probe_root" | awk 'END {print $NF}')"
+brainlayer_probe_volume="$(stat -f %m "$brainlayer_probe_root")"
 printf 'root=%s\nvolume=%s\n' "$brainlayer_probe_root" "$brainlayer_probe_volume"
 mdutil -s "$brainlayer_probe_volume"
 ```

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -6,12 +6,12 @@ operator coordination belong in the restricted maintenance record, not this repo
 
 ## Why `.metadata_never_index`
 
-BrainLayer uses a marker in each high-churn root. On macOS 26.5.1 (25F80), a disposable recursive
-`mdimport -i` probe gave a file below `excluded.noindex` normal `kMDItemFSName` and
-`kMDItemContentType` attributes. The equivalent file below a directory containing
-`.metadata_never_index` retained null attributes. `mdimport -t` is useful importer evidence but not
+BrainLayer uses a marker in each high-churn root. `mdimport -t` is useful importer evidence but not
 an exclusion verdict: its manual says test imports return attributes without writing the Spotlight
-index.
+index. A mandatory macOS 26.5.1 (25F80) pair-review probe showed why negative results alone are
+insufficient: after a real `mdimport -i`, both marker-backed files and an unmarked control had null
+`mdls` attributes and no `mdfind` result on that workstation. Step 6 therefore requires an
+unmarked same-volume positive control to be indexed before a marker-backed negative is accepted.
 
 [Apple's documented Search Privacy UI](https://support.apple.com/guide/mac-help/mchl1bb43b84/mac)
 remains the fallback if a post-migration marker probe fails. It is not the primary mechanism
@@ -71,11 +71,65 @@ brainlayer wal-checkpoint --mode PASSIVE --json
 
 ### 2. Stop every writer, scheduler, and self-healer
 
-Disable/kick out the installed `com.brainlayer.*` labels as a group, including BrainBar daemon,
-watch, drain, hotlane, enrichment, index, T3 ingest, maintenance, repair, decay, WAL checkpoint,
-backup jobs, watchdogs, and the P0 counter. Record the exact loaded-label list before stopping it so
-only that list is restored. Verify with both `launchctl print` and `pgrep -fal` that no BrainLayer
-Python, BrainBar daemon, watcher, drain, hotlane, or enrichment process remains.
+Use the same complete writer fence as the Wave 3a live runbook. The broader inventory pattern is
+intentional: `com.mcplayer.brainlayer-proxy` is a write-capable bridge even though its label does
+not begin with `com.brainlayer`. `com.mcplayer.bus` may remain loaded because it is the event bus,
+not the BrainLayer MCP proxy or a DB writer. Set `spotlight_run_dir` to the restricted maintenance
+evidence directory, then record the exact active set and stop only labels that were active:
+
+```bash
+set -euo pipefail
+spotlight_run_dir="<absolute restricted maintenance evidence directory>"
+test "${spotlight_run_dir#/}" != "$spotlight_run_dir"
+mkdir -p "$spotlight_run_dir"
+launchctl list | awk '$3 ~ /^(com\.brainlayer\.|com\.mcplayer\.)/ {print $3}' | sort \
+  > "$spotlight_run_dir/active-labels.before"
+: > "$spotlight_run_dir/stopped-labels"
+
+spotlight_stop_labels=(
+  com.brainlayer.tier0-watchdog
+  com.brainlayer.throughput-watchdog
+  com.brainlayer.health-check
+  com.brainlayer.backup-daily
+  com.brainlayer.jsonl-backup
+  com.brainlayer.maintenance-nightly
+  com.brainlayer.maintenance-weekly
+  com.brainlayer.wal-checkpoint
+  com.brainlayer.repair-fts
+  com.brainlayer.decay
+  com.brainlayer.p0-counter
+  com.brainlayer.index
+  com.brainlayer.watch
+  com.brainlayer.drain
+  com.brainlayer.hotlane-brainbar
+  com.brainlayer.enrichment
+  com.brainlayer.brainbar
+  com.brainlayer.gemini-loopback
+  com.mcplayer.brainlayer-proxy
+  com.brainlayer.brainbar-daemon
+  com.brainlayer.t3-ingest
+)
+for label in "${spotlight_stop_labels[@]}"; do
+  if grep -Fxq "$label" "$spotlight_run_dir/active-labels.before"; then
+    launchctl bootout "gui/$(id -u)/$label"
+    printf '%s\n' "$label" >> "$spotlight_run_dir/stopped-labels"
+  fi
+done
+
+launchctl list | awk '$3 ~ /^(com\.brainlayer\.|com\.mcplayer\.)/ {print $3}' | sort \
+  > "$spotlight_run_dir/active-labels.after-stop"
+for label in "${spotlight_stop_labels[@]}"; do
+  ! grep -Fxq "$label" "$spotlight_run_dir/active-labels.after-stop"
+done
+! lsof -nP -iTCP:48123 -sTCP:LISTEN
+pgrep -fal '[b]rainlayer|[B]rainBar' > "$spotlight_run_dir/processes.after-stop" || true
+test ! -s "$spotlight_run_dir/processes.after-stop"
+```
+
+The stop and absence assertions deliberately share the single `spotlight_stop_labels` list; never
+maintain a shorter assertion list. Verify with `launchctl`, the TCP assertion, and the captured
+process inventory that no BrainLayer Python, BrainBar daemon, watcher, drain, hotlane, enrichment,
+T3 ingest, or proxy process remains.
 
 Do not let a watchdog restart a writer between this step and the final checkpoint.
 
@@ -206,29 +260,85 @@ Repeat this check for every migrated root. Do not infer an override root's Spotl
 `mdutil -s /`: an override may reside on another volume. Every containing volume must report that
 indexing is enabled before the exclusion probe can be interpreted.
 
-Then create a unique, non-clobbering plain-text probe beneath the marked data root. Record these
-outputs and retain the two printed variable values with the evidence:
+Then create two unique plain-text probes on the same volume in the same command: the exclusion
+probe beneath the marked root and a positive control in an unmarked sibling directory. The control
+is mandatory. If Spotlight cannot find the control, the result is inconclusive even when it cannot
+find the excluded probe; keep writers stopped and do not declare the marker effective.
 
 ```bash
+set -euo pipefail
 spotlight_probe_path="$(mktemp "${HOME:?}/.local/share/brainlayer/spotlight-exclusion-live-probe.txt.XXXXXX")"
 spotlight_probe_name="$(basename "$spotlight_probe_path")"
+# For an override on another volume, replace this with a preflight-verified searchable,
+# non-hidden directory on that same volume.
+spotlight_positive_control_parent="${HOME:?}/Documents"
+test -d "$spotlight_positive_control_parent" && test ! -L "$spotlight_positive_control_parent"
+spotlight_positive_control_root="$(mktemp -d "$spotlight_positive_control_parent/brainlayer-spotlight-positive-control.XXXXXX")"
+spotlight_positive_control_path="$(mktemp "$spotlight_positive_control_root/spotlight-index-positive-control.txt.XXXXXX")"
+spotlight_positive_control_name="$(basename "$spotlight_positive_control_path")"
+cleanup_spotlight_probes() {
+  rm -f -- "$spotlight_probe_path" "$spotlight_positive_control_path"
+  rmdir "$spotlight_positive_control_root" 2>/dev/null || true
+}
+trap cleanup_spotlight_probes EXIT
+test "$(stat -f %d "$spotlight_probe_path")" = "$(stat -f %d "$spotlight_positive_control_path")"
+
+# A marker on any control ancestor would invalidate the positive control.
+spotlight_control_ancestor="$spotlight_positive_control_root"
+while :; do
+  test ! -e "$spotlight_control_ancestor/.metadata_never_index"
+  spotlight_control_parent="$(dirname "$spotlight_control_ancestor")"
+  test "$spotlight_control_parent" != "$spotlight_control_ancestor" || break
+  spotlight_control_ancestor="$spotlight_control_parent"
+done
+
 printf 'BrainLayer Spotlight exclusion live probe %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   > "$spotlight_probe_path"
-printf 'probe_path=%s\nprobe_name=%s\n' "$spotlight_probe_path" "$spotlight_probe_name"
+cp "$spotlight_probe_path" "$spotlight_positive_control_path"
+printf 'probe_path=%s\nprobe_name=%s\ncontrol_path=%s\ncontrol_name=%s\n' \
+  "$spotlight_probe_path" "$spotlight_probe_name" \
+  "$spotlight_positive_control_path" "$spotlight_positive_control_name"
 mdimport -t -d1 "$spotlight_probe_path"
-mdimport -i "$spotlight_probe_path"
+mdimport -t -d1 "$spotlight_positive_control_path"
+mdimport -i "$spotlight_probe_path" "$spotlight_positive_control_path"
+
+spotlight_control_found=0
+for _ in $(jot 30); do
+  if test "$(mdls -raw -name kMDItemFSName "$spotlight_positive_control_path")" = \
+      "$spotlight_positive_control_name" \
+    && test "$(mdls -raw -name kMDItemContentType "$spotlight_positive_control_path")" != '(null)' \
+    && mdfind -onlyin "$spotlight_positive_control_root" \
+      "kMDItemFSName == '$spotlight_positive_control_name'cd" \
+      | grep -Fxq "$spotlight_positive_control_path"; then
+    spotlight_control_found=1
+    break
+  fi
+  sleep 1
+done
+if test "$spotlight_control_found" -ne 1; then
+  printf '%s\n' 'SPOTLIGHT PROBE INCONCLUSIVE: the unmarked positive control was not indexed' >&2
+  exit 1
+fi
+
 mdls -name kMDItemFSName -name kMDItemContentType \
   "$spotlight_probe_path"
-mdfind -onlyin "${HOME:?}/.local/share/brainlayer" \
-  "kMDItemFSName == '$spotlight_probe_name'cd"
-rm -- "$spotlight_probe_path"
+test "$(mdls -raw -name kMDItemFSName "$spotlight_probe_path")" = '(null)'
+test "$(mdls -raw -name kMDItemContentType "$spotlight_probe_path")" = '(null)'
+! mdfind -onlyin "${HOME:?}/.local/share/brainlayer" \
+  "kMDItemFSName == '$spotlight_probe_name'cd" | grep -Fxq "$spotlight_probe_path"
+rm -- "$spotlight_probe_path" "$spotlight_positive_control_path"
+rmdir "$spotlight_positive_control_root"
+trap - EXIT
 ```
 
 Pass criteria: `mdutil` shows the containing volume is indexed; `mdimport -t` identifies the normal
-importer; the real `mdimport -i` leaves both `mdls` attributes null; `mdfind` returns no probe path.
+importer for both files; after the same real `mdimport -i`, the unmarked positive control has
+non-null metadata and is returned at its exact path by `mdfind`, while the marked-root probe leaves
+both `mdls` attributes null and is not returned at its exact path by `mdfind`.
 Repeat the real import/`mdls`/`mdfind` check once under each of the other three canonical marked
-roots and under the active override parent when distinct. Remove only the exact probe files after
-saving evidence.
+roots and under the active override parent when distinct. Create the control beside each tested
+root and prove it is on the same containing volume. Remove only the exact probe files and empty
+control directories after saving evidence.
 
 If a marker-backed root receives metadata, keep BrainLayer stopped and add that exact root through
 System Settings → Spotlight → Search Privacy, then repeat the probe. Do not disable Spotlight for

--- a/docs/operations/spotlight-exclusion-migration.md
+++ b/docs/operations/spotlight-exclusion-migration.md
@@ -22,6 +22,7 @@ because setup must work unattended.
 | Excluded root | Covered paths |
 | --- | --- |
 | `$HOME/.local/share/brainlayer` | `brainlayer.db`, `brainlayer.db-wal`, `brainlayer.db-shm`; sqlite-vec data and future vector sidecars; `chromadb`, `chromadb.backup`, `style`, `storage`, `experiments`; `enrichment_checkpoints.db`, `reembed_bgem3_checkpoint.json`, `enrichment-scratch`; `prompts`; `offsets.json`, watcher/drain/T3/health state, pause sentinel, pending-store files; `backups`, `jsonl-backups`; `logs` |
+| active `BRAINLAYER_DB` parent, when outside the canonical root | overridden DB, WAL, SHM, and adjacent vector sidecars; setup marks both this parent and the canonical root |
 | `$HOME/.brainlayer` | `queue`; `quarantine` including stale-queue quarantine; `logs` including drain logs; runtime repository state |
 | `$HOME/Library/Logs/brainlayer` | launchd stdout/stderr and BrainBar runtime logs |
 | `$HOME/.brainlayer-p0-counter` | longitudinal counter logs |
@@ -108,7 +109,10 @@ Apply this recovery state machine before continuing any root:
 - canonical missing, staging exists: restore with an atomic staging-to-canonical rename, verify the
   tree, and restart this root's preflight from the beginning;
 - both exist: duplicate/conflict; stop without moving or merging either tree;
-- both absent: data is missing; stop and investigate.
+- both absent: for the canonical/override data root, stop because data is missing. For an optional
+  runtime/log/counter root, first prove from the preflight label and path inventory that it was never
+  created and never held data; record that evidence, create the exact canonical directory with mode
+  `0700`, create and verify `.metadata_never_index`, and do not perform a staging rename for it.
 
 This same state machine is the recovery procedure if the shell or machine stops between either
 rename. Never infer completion from the presence of only one path without inspecting it.

--- a/docs/plans/2026-08-10-spotlight-exclusion-design.md
+++ b/docs/plans/2026-08-10-spotlight-exclusion-design.md
@@ -8,11 +8,18 @@ of the existing production tree is deliberately deferred to a coordinated writer
 
 ## Mechanism
 
-Use a `.metadata_never_index` marker in each high-churn root. A disposable probe on macOS 26.5.1
-(25F80) showed that a marker-bearing directory refused metadata import, while a `.noindex`
-directory still received `kMDItemFSName` and `kMDItemContentType` after recursive `mdimport -i`.
-`mdimport -t` is retained as importer evidence only: its own manual says test imports do not write
-the Spotlight index, so `mdls`/`mdfind` after `mdimport -i` are the exclusion verdict.
+Use a `.metadata_never_index` marker in each high-churn root. `mdimport -t` is importer evidence
+only: its manual says test imports do not write the Spotlight index, so a live verdict must compare
+`mdls`/`mdfind` after a real `mdimport -i` against an unmarked positive control on the same volume.
+
+The mandatory pair review at exact head `e3659579` invalidated the earlier uncontrolled mechanism
+claim. Its macOS 26.5.1 (25F80) transcript recorded indexing enabled, a normal RichText importer
+returning 29 attributes for the test import, and then null `mdls` plus zero `mdfind` results after a
+real import for *all* cases—including the unmarked control in both `$HOME` and `~/Documents`.
+Therefore a missing excluded-file result alone is vacuous on that workstation. The runbook now
+fails closed unless an identical unmarked control, imported in the same command, receives non-null
+metadata and is returned at its exact path by `mdfind`. The source transcript and verdict are under
+`DONE_SPOTLIGHT_REVIEW` in the Wave 25 collaboration record.
 
 The marker approach preserves existing canonical paths and needs no environment rewiring on fresh
 installs. [Apple documents Search Privacy](https://support.apple.com/guide/mac-help/mchl1bb43b84/mac)
@@ -48,7 +55,9 @@ Configuration and user-facing exports remain searchable: `~/.config/brainlayer` 
 This PR does not touch `~/.local/share/brainlayer` or any live writer. The runbook requires one
 coordinated stop window: checkpoint WAL, stop all writers, move the data/runtime trees to staging,
 create marker-bearing targets, move data back without crossing filesystems, restore configured
-paths, restart, then prove exclusion with `mdimport`, `mdls`, `mdfind`, and `mdutil` volume status.
+paths, restart, then prove exclusion with a same-volume positive control plus `mdimport`, `mdls`,
+`mdfind`, and `mdutil` volume status. An unindexed positive control makes the result inconclusive
+and stops the window.
 Rollback keeps the stopped trees intact and reverses the move before writers restart.
 
 ## Tests

--- a/docs/plans/2026-08-10-spotlight-exclusion-design.md
+++ b/docs/plans/2026-08-10-spotlight-exclusion-design.md
@@ -1,0 +1,61 @@
+# Spotlight Exclusion Setup Design
+
+## Goal
+
+BrainLayer setup must exclude every high-churn runtime tree from Spotlight before it creates
+runtime children. Doctor must warn when the active database directory is not excluded. Migration
+of the existing production tree is deliberately deferred to a coordinated writer-stop window.
+
+## Mechanism
+
+Use a `.metadata_never_index` marker in each high-churn root. A disposable probe on macOS 26.5.1
+(25F80) showed that a marker-bearing directory refused metadata import, while a `.noindex`
+directory still received `kMDItemFSName` and `kMDItemContentType` after recursive `mdimport -i`.
+`mdimport -t` is retained as importer evidence only: its own manual says test imports do not write
+the Spotlight index, so `mdls`/`mdfind` after `mdimport -i` are the exclusion verdict.
+
+The marker approach preserves existing canonical paths and needs no environment rewiring on fresh
+installs. [Apple documents Search Privacy](https://support.apple.com/guide/mac-help/mchl1bb43b84/mac)
+as the supported UI fallback, but that is manual and therefore cannot satisfy unattended setup.
+
+## Excluded layout
+
+Setup creates each root first, writes its marker atomically, then creates its children:
+
+- `~/.local/share/brainlayer`: canonical SQLite DB, `-wal`/`-shm`, sqlite-vec tables and any vector
+  sidecars, legacy Chroma/vector and experiment directories, enrichment checkpoints/scratch, prompt cache,
+  watcher/drain state, backup staging, and data-root logs.
+- `~/.brainlayer`: durable drain queue, queue quarantine, and drain runtime logs.
+- `~/Library/Logs/brainlayer`: launchd and BrainBar runtime logs.
+- `~/.brainlayer-p0-counter`: longitudinal counter logs.
+
+Configuration and user-facing exports remain searchable: `~/.config/brainlayer` and
+`~/.brainlayer-brain` are intentionally not excluded.
+
+## Components
+
+- `brainlayer.paths` owns the marker name plus pure exclusion detection by walking a path and its
+  ancestors.
+- `brainlayer.setup` owns idempotent layout creation. Defaults cover all four roots; injected roots
+  make tests hermetic. It preflights every root and refuses a legacy nonempty, unmarked tree before
+  making any marker, directing that machine to the coordinated migration runbook.
+- `brainlayer setup` calls layout creation before writing configuration or installing launchd.
+- `brainlayer doctor` adds a warning-only `spotlight_indexing_enabled` issue for an unexcluded active
+  DB directory on Darwin. The warning never changes the existing fatal/exit-code contract.
+
+## Migration boundary
+
+This PR does not touch `~/.local/share/brainlayer` or any live writer. The runbook requires one
+coordinated stop window: checkpoint WAL, stop all writers, move the data/runtime trees to staging,
+create marker-bearing targets, move data back without crossing filesystems, restore configured
+paths, restart, then prove exclusion with `mdimport`, `mdls`, `mdfind`, and `mdutil` volume status.
+Rollback keeps the stopped trees intact and reverses the move before writers restart.
+
+## Tests
+
+- Layout creation makes every root and marker, enumerates expected high-churn children, is
+  idempotent, and fails without partial mutation when any legacy root needs migration.
+- Exclusion detection accepts a marker on the directory or an ancestor and rejects an unmarked
+  path.
+- Doctor emits exactly the warning for an unexcluded DB directory and omits it for a marked one.
+- CLI setup invokes layout creation before env-file creation.

--- a/docs/plans/2026-08-10-spotlight-exclusion.md
+++ b/docs/plans/2026-08-10-spotlight-exclusion.md
@@ -1,0 +1,69 @@
+# Spotlight Exclusion Setup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make BrainLayer setup create Spotlight-excluded runtime trees and make doctor warn about legacy unexcluded database directories.
+
+**Architecture:** A small path helper recognizes `.metadata_never_index` on a directory or ancestor. Setup creates marker-bearing high-churn roots before children, and doctor performs a warning-only Darwin check against the active DB directory.
+
+**Tech Stack:** Python 3.11+, pathlib, Typer, pytest, macOS Spotlight command-line tools.
+
+---
+
+### Task 1: Path exclusion contract
+
+**Files:**
+- Modify: `src/brainlayer/paths.py`
+- Modify: `tests/test_paths.py`
+
+1. Add failing tests for marker-on-self, marker-on-ancestor, and unmarked paths.
+2. Run `pytest tests/test_paths.py -q` and confirm failure because the helper is absent.
+3. Add `SPOTLIGHT_EXCLUSION_MARKER` and `is_spotlight_excluded(path)`.
+4. Re-run `pytest tests/test_paths.py -q` and confirm green.
+
+### Task 2: Setup layout
+
+**Files:**
+- Modify: `src/brainlayer/setup.py`
+- Modify: `src/brainlayer/cli/__init__.py`
+- Modify: `tests/test_installable_build.py`
+
+1. Add failing tests that inject four roots, assert markers precede child creation, assert the full
+   high-churn child set, assert idempotence, and assert CLI ordering.
+2. Run the focused tests and confirm the missing layout function/order causes RED.
+3. Implement `ensure_spotlight_excluded_layout()` and call it first from `brainlayer setup`.
+4. Re-run the focused tests and confirm GREEN.
+
+### Task 3: Doctor warning
+
+**Files:**
+- Modify: `src/brainlayer/doctor.py`
+- Modify: `tests/test_doctor.py`
+
+1. Add failing doctor tests for marked and unmarked DB directories with the check explicitly enabled.
+2. Run those tests and confirm RED because the warning does not exist.
+3. Add a Darwin-defaulted config flag and warning-only issue with remediation details.
+4. Re-run the focused tests and confirm GREEN.
+
+### Task 4: Migration runbook and evidence
+
+**Files:**
+- Create: `docs/operations/spotlight-exclusion-migration.md`
+- Modify after merge: `docs.local/tasks/2026-08-10-spotlight-exclusion-setup.md`
+
+1. Write the checkpoint/stop/move/mark/restore/restart/verify/rollback runbook.
+2. Include the untruncated path inventory and disposable macOS probe commands.
+3. Run the commands only against disposable probe directories; never touch canonical runtime data.
+4. Mark the runbook READY in the source task, reserving the live-migration marker for its window.
+
+### Task 5: Verification and PR loop
+
+**Files:** all changed files.
+
+1. Run focused pytest, Ruff, and the full repository test command.
+2. Run local CodeRabbit review with a bounded timeout.
+3. Commit with the required agent trailer, push, and open a ready PR with a signed body.
+4. Append the PR and exact head to the collab, then route `READY_FOR_REVIEW_SPOTLIGHT` to the lead.
+5. Address review findings, re-run verification, confirm CI and exact head, and merge.
+6. Append merged evidence plus `DONE_SPOTLIGHT_EXCL` to the source task and a one-line DONE pointer to the lead.
+

--- a/docs/plans/2026-08-10-spotlight-exclusion.md
+++ b/docs/plans/2026-08-10-spotlight-exclusion.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Path exclusion contract
+## Task 1: Path exclusion contract
 
 **Files:**
 - Modify: `src/brainlayer/paths.py`
@@ -21,7 +21,7 @@
 3. Add `SPOTLIGHT_EXCLUSION_MARKER` and `is_spotlight_excluded(path)`.
 4. Re-run `pytest tests/test_paths.py -q` and confirm green.
 
-### Task 2: Setup layout
+## Task 2: Setup layout
 
 **Files:**
 - Modify: `src/brainlayer/setup.py`
@@ -34,7 +34,7 @@
 3. Implement `ensure_spotlight_excluded_layout()` and call it first from `brainlayer setup`.
 4. Re-run the focused tests and confirm GREEN.
 
-### Task 3: Doctor warning
+## Task 3: Doctor warning
 
 **Files:**
 - Modify: `src/brainlayer/doctor.py`
@@ -45,7 +45,7 @@
 3. Add a Darwin-defaulted config flag and warning-only issue with remediation details.
 4. Re-run the focused tests and confirm GREEN.
 
-### Task 4: Migration runbook and evidence
+## Task 4: Migration runbook and evidence
 
 **Files:**
 - Create: `docs/operations/spotlight-exclusion-migration.md`
@@ -56,7 +56,7 @@
 3. Run the commands only against disposable probe directories; never touch canonical runtime data.
 4. Mark the runbook READY in the source task, reserving the live-migration marker for its window.
 
-### Task 5: Verification and PR loop
+## Task 5: Verification and PR loop
 
 **Files:** all changed files.
 
@@ -66,4 +66,3 @@
 4. Append the PR and exact head to the collab, then route `READY_FOR_REVIEW_SPOTLIGHT` to the lead.
 5. Address review findings, re-run verification, confirm CI and exact head, and merge.
 6. Append merged evidence plus `DONE_SPOTLIGHT_EXCL` to the source task and a one-line DONE pointer to the lead.
-

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -100,7 +100,7 @@ case "$BRAINLAYER_INSTALL_ACTION" in
             fi
             PYTHONPATH="$BRAINLAYER_PREFLIGHT_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}" \
                 "$BRAINLAYER_PREFLIGHT_PYTHON" -c \
-                'from brainlayer.spotlight import ensure_spotlight_excluded_layout; ensure_spotlight_excluded_layout()'
+                'import os; from pathlib import Path; from brainlayer.config import configured_brainlayer_env_value; from brainlayer.spotlight import ensure_spotlight_excluded_layout; env_file = Path(os.environ["BRAINLAYER_ENV_FILE"]) if os.environ.get("BRAINLAYER_ENV_FILE") else None; configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", env_file); kwargs = {"resolve_db_path_fn": lambda: Path(configured_db).expanduser()} if configured_db else {}; ensure_spotlight_excluded_layout(**kwargs)'
         fi
         ;;
 esac

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -82,6 +82,28 @@ if [ ! -x "$BRAINLAYER_BIN" ]; then
     exit 1
 fi
 
+case "${1:-all}" in
+    remove|unload)
+        ;;
+    *)
+        if [ "$(uname -s)" = "Darwin" ]; then
+            if [ -d "$BRAINLAYER_DIR/src/brainlayer" ]; then
+                BRAINLAYER_PREFLIGHT_PYTHONPATH="$BRAINLAYER_DIR/src"
+            else
+                BRAINLAYER_PREFLIGHT_PYTHONPATH="$BRAINLAYER_DIR"
+            fi
+            if [ -x "$PYTHON_BIN" ]; then
+                BRAINLAYER_PREFLIGHT_PYTHON="$PYTHON_BIN"
+            else
+                BRAINLAYER_PREFLIGHT_PYTHON="$(command -v python3)"
+            fi
+            PYTHONPATH="$BRAINLAYER_PREFLIGHT_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}" \
+                "$BRAINLAYER_PREFLIGHT_PYTHON" -c \
+                'from brainlayer.spotlight import ensure_spotlight_excluded_layout; ensure_spotlight_excluded_layout()'
+        fi
+        ;;
+esac
+
 mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$LOG_DIR/brainlayer" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
 mkdir -p "$HOME/.brainlayer/logs" "$HOME/.brainlayer/queue"
 

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -83,6 +83,19 @@ if [ ! -x "$BRAINLAYER_BIN" ]; then
 fi
 
 BRAINLAYER_INSTALL_ACTION="${1:-all}"
+launchd_install_usage() {
+    echo "Usage: $0 [index|t3-ingest|watch|enrich|enrichment|decay|drain|hotlane|hotlane-brainbar|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|tier0|tier0-watchdog|throughput-watchdog|p0-counter|all|remove]"
+}
+
+case "$BRAINLAYER_INSTALL_ACTION" in
+    index|t3-ingest|watch|enrich|enrichment|decay|drain|hotlane|hotlane-brainbar|repair-fts|load|unload|checkpoint|backup|jsonl|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|tier0|tier0-watchdog|throughput-watchdog|p0-counter|all|remove)
+        ;;
+    *)
+        launchd_install_usage
+        exit 1
+        ;;
+esac
+
 case "$BRAINLAYER_INSTALL_ACTION" in
     remove|unload)
         ;;
@@ -100,7 +113,7 @@ case "$BRAINLAYER_INSTALL_ACTION" in
             fi
             PYTHONPATH="$BRAINLAYER_PREFLIGHT_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}" \
                 "$BRAINLAYER_PREFLIGHT_PYTHON" -c \
-                'import os; from pathlib import Path; from brainlayer.config import configured_brainlayer_env_value; from brainlayer.spotlight import ensure_spotlight_excluded_layout; env_file = Path(os.environ["BRAINLAYER_ENV_FILE"]) if os.environ.get("BRAINLAYER_ENV_FILE") else None; configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", env_file); kwargs = {"resolve_db_path_fn": lambda: Path(configured_db).expanduser()} if configured_db else {}; ensure_spotlight_excluded_layout(**kwargs)'
+                'import os; from pathlib import Path; from brainlayer.spotlight import ensure_spotlight_excluded_layout; env_file = Path(os.environ["BRAINLAYER_ENV_FILE"]) if os.environ.get("BRAINLAYER_ENV_FILE") else None; ensure_spotlight_excluded_layout(env_file=env_file)'
         fi
         mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$LOG_DIR/brainlayer" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
         mkdir -p "$HOME/.brainlayer/logs" "$HOME/.brainlayer/queue"
@@ -757,7 +770,7 @@ case "${1:-all}" in
         rm -f "$HOTLANE_BRAINBAR_DST"
         ;;
     *)
-        echo "Usage: $0 [index|t3-ingest|watch|enrich|enrichment|decay|drain|hotlane|repair-fts|load [name]|unload [name]|checkpoint|backup|jsonl-backup|maintenance|maintenance-nightly|maintenance-weekly|health-check|tier0-watchdog|throughput-watchdog|p0-counter|all|remove]"
+        launchd_install_usage
         exit 1
         ;;
 esac

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -82,7 +82,8 @@ if [ ! -x "$BRAINLAYER_BIN" ]; then
     exit 1
 fi
 
-case "${1:-all}" in
+BRAINLAYER_INSTALL_ACTION="${1:-all}"
+case "$BRAINLAYER_INSTALL_ACTION" in
     remove|unload)
         ;;
     *)

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -102,11 +102,10 @@ case "$BRAINLAYER_INSTALL_ACTION" in
                 "$BRAINLAYER_PREFLIGHT_PYTHON" -c \
                 'import os; from pathlib import Path; from brainlayer.config import configured_brainlayer_env_value; from brainlayer.spotlight import ensure_spotlight_excluded_layout; env_file = Path(os.environ["BRAINLAYER_ENV_FILE"]) if os.environ.get("BRAINLAYER_ENV_FILE") else None; configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", env_file); kwargs = {"resolve_db_path_fn": lambda: Path(configured_db).expanduser()} if configured_db else {}; ensure_spotlight_excluded_layout(**kwargs)'
         fi
+        mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$LOG_DIR/brainlayer" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
+        mkdir -p "$HOME/.brainlayer/logs" "$HOME/.brainlayer/queue"
         ;;
 esac
-
-mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$LOG_DIR/brainlayer" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
-mkdir -p "$HOME/.brainlayer/logs" "$HOME/.brainlayer/queue"
 
 install_env_runner() {
     local src="$SCRIPT_DIR/brainlayer-env-run.sh"

--- a/scripts/launchd/install.sh
+++ b/scripts/launchd/install.sh
@@ -97,7 +97,7 @@ case "$BRAINLAYER_INSTALL_ACTION" in
 esac
 
 case "$BRAINLAYER_INSTALL_ACTION" in
-    remove|unload)
+    remove|unload|load)
         ;;
     *)
         if [ "$(uname -s)" = "Darwin" ]; then
@@ -113,7 +113,19 @@ case "$BRAINLAYER_INSTALL_ACTION" in
             fi
             PYTHONPATH="$BRAINLAYER_PREFLIGHT_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}" \
                 "$BRAINLAYER_PREFLIGHT_PYTHON" -c \
-                'import os; from pathlib import Path; from brainlayer.spotlight import ensure_spotlight_excluded_layout; env_file = Path(os.environ["BRAINLAYER_ENV_FILE"]) if os.environ.get("BRAINLAYER_ENV_FILE") else None; ensure_spotlight_excluded_layout(env_file=env_file)'
+                '
+import os
+from pathlib import Path
+from brainlayer.spotlight import ensure_spotlight_excluded_layout
+
+env_file = Path(os.environ["BRAINLAYER_ENV_FILE"]) if os.environ.get("BRAINLAYER_ENV_FILE") else None
+try:
+    ensure_spotlight_excluded_layout(env_file=env_file)
+except RuntimeError as exc:
+    raise SystemExit(
+        f"ERROR: {exc}; run docs/operations/spotlight-exclusion-migration.md before installing launchd jobs"
+    ) from None
+'
         fi
         mkdir -p "$LAUNCH_DIR" "$LOG_DIR" "$LOG_DIR/brainlayer" "$BRAINLAYER_LOG_DIR" "$BRAINLAYER_LIB_DIR"
         mkdir -p "$HOME/.brainlayer/logs" "$HOME/.brainlayer/queue"

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -486,9 +486,9 @@ def init(
     from .wizard import run_wizard
 
     try:
-        if sys.platform == "darwin":
-            ensure_spotlight_excluded_layout()
         config = run_wizard()
+        if sys.platform == "darwin":
+            ensure_spotlight_excluded_layout(env_file=config.gemini_env_file)
         if should_install_launchd:
             install_launchd_agents("all", env_file=config.gemini_env_file)
     except (
@@ -547,13 +547,13 @@ def setup(
     )
 
     try:
-        if sys.platform == "darwin":
-            ensure_spotlight_excluded_layout()
         resolved_env_file = ensure_brainlayer_env(
             env_file,
             google_api_key_op_ref=google_api_key_op_ref,
             overwrite_google_key=overwrite_google_key,
         )
+        if sys.platform == "darwin":
+            ensure_spotlight_excluded_layout(env_file=resolved_env_file)
         if launchd:
             install_launchd(target, env_file=resolved_env_file)
         migrated_configs = migrate_legacy_mcp_configs() if migrate_mcp else []

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -534,9 +534,16 @@ def setup(
     """Create brainlayer.env and optionally bootstrap launchd agents."""
     import subprocess
 
-    from ..setup import ensure_brainlayer_env, install_launchd, migrate_legacy_mcp_configs, verify_mcp_transport
+    from ..setup import (
+        ensure_brainlayer_env,
+        ensure_spotlight_excluded_layout,
+        install_launchd,
+        migrate_legacy_mcp_configs,
+        verify_mcp_transport,
+    )
 
     try:
+        ensure_spotlight_excluded_layout()
         resolved_env_file = ensure_brainlayer_env(
             env_file,
             google_api_key_op_ref=google_api_key_op_ref,

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -481,10 +481,13 @@ def init(
     """Interactive setup wizard — detects your environment and configures BrainLayer."""
     import subprocess
 
+    from ..setup import ensure_spotlight_excluded_layout
     from ..setup import install_launchd as install_launchd_agents
     from .wizard import run_wizard
 
     try:
+        if sys.platform == "darwin":
+            ensure_spotlight_excluded_layout()
         config = run_wizard()
         if should_install_launchd:
             install_launchd_agents("all", env_file=config.gemini_env_file)
@@ -493,6 +496,7 @@ def init(
         FileExistsError,
         PermissionError,
         TimeoutError,
+        RuntimeError,
         ValueError,
         subprocess.CalledProcessError,
     ) as exc:
@@ -543,7 +547,8 @@ def setup(
     )
 
     try:
-        ensure_spotlight_excluded_layout()
+        if sys.platform == "darwin":
+            ensure_spotlight_excluded_layout()
         resolved_env_file = ensure_brainlayer_env(
             env_file,
             google_api_key_op_ref=google_api_key_op_ref,

--- a/src/brainlayer/cli/__init__.py
+++ b/src/brainlayer/cli/__init__.py
@@ -483,12 +483,12 @@ def init(
 
     from ..setup import ensure_spotlight_excluded_layout
     from ..setup import install_launchd as install_launchd_agents
-    from .wizard import run_wizard
+    from .wizard import get_default_env_file, run_wizard
 
     try:
-        config = run_wizard()
         if sys.platform == "darwin":
-            ensure_spotlight_excluded_layout(env_file=config.gemini_env_file)
+            ensure_spotlight_excluded_layout(env_file=get_default_env_file())
+        config = run_wizard()
         if should_install_launchd:
             install_launchd_agents("all", env_file=config.gemini_env_file)
     except (
@@ -538,6 +538,7 @@ def setup(
     """Create brainlayer.env and optionally bootstrap launchd agents."""
     import subprocess
 
+    from ..config import get_user_env_path
     from ..setup import (
         ensure_brainlayer_env,
         ensure_spotlight_excluded_layout,
@@ -547,13 +548,13 @@ def setup(
     )
 
     try:
+        if sys.platform == "darwin":
+            ensure_spotlight_excluded_layout(env_file=env_file or get_user_env_path())
         resolved_env_file = ensure_brainlayer_env(
             env_file,
             google_api_key_op_ref=google_api_key_op_ref,
             overwrite_google_key=overwrite_google_key,
         )
-        if sys.platform == "darwin":
-            ensure_spotlight_excluded_layout(env_file=resolved_env_file)
         if launchd:
             install_launchd(target, env_file=resolved_env_file)
         migrated_configs = migrate_legacy_mcp_configs() if migrate_mcp else []

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -119,9 +119,11 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
     target = env_path or get_user_env_path()
     try:
         lines = target.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return None
     except (OSError, UnicodeDecodeError) as exc:
         logger.warning("Could not read BrainLayer env file %s: %s", target, exc)
-        return None
+        raise RuntimeError(f"Could not read BrainLayer env file {target}: {exc}") from exc
 
     selected: str | None = None
     for line in lines:

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 _OP_READ_PREFIX = "$(op read "
+_brainlayer_db_config_error: str | None = None
 
 
 def get_user_env_path() -> Path:
@@ -143,6 +144,11 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
     return selected
 
 
+def get_brainlayer_db_config_error() -> str | None:
+    """Return the runtime DB env validation error that triggered canonical fallback."""
+    return _brainlayer_db_config_error
+
+
 def load_brainlayer_env(
     env_path: Path | None = None,
     *,
@@ -154,37 +160,57 @@ def load_brainlayer_env(
     .env files are deliberately ignored; pass repo_env_path only to document
     that it is not part of the loader contract.
     """
+    global _brainlayer_db_config_error
+
     del repo_env_path
 
     target = env_path or get_user_env_path()
+    record_db_error = env_path is None or target == get_user_env_path()
     if not target.exists():
+        if record_db_error:
+            _brainlayer_db_config_error = None
         return {}
 
     try:
         lines = target.read_text(encoding="utf-8").splitlines()
     except OSError as exc:
         logger.warning("Could not read BrainLayer env file %s: %s", target, exc)
+        if record_db_error:
+            _brainlayer_db_config_error = f"Could not read BrainLayer env file {target}: {exc}"
         return {}
     except UnicodeDecodeError as exc:
         logger.warning("Could not decode BrainLayer env file %s: %s", target, exc)
+        if record_db_error:
+            _brainlayer_db_config_error = f"Could not decode BrainLayer env file {target}: {exc}"
         return {}
 
     loaded: dict[str, str] = {}
     if "BRAINLAYER_DB" not in os.environ:
-        configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", target)
-        direct_db_values = []
-        for line in lines:
-            assignment = _split_env_assignment(line)
-            if assignment is None or assignment[0] != "BRAINLAYER_DB":
-                continue
-            value = _parse_env_value(assignment[1])
-            if value is not None:
-                direct_db_values.append(value)
-        if any(value != configured_db for value in direct_db_values):
-            raise RuntimeError(f"BRAINLAYER_DB must parse identically for launchd and direct CLI use in {target}")
-        if configured_db is not None:
-            os.environ["BRAINLAYER_DB"] = configured_db
-            loaded["BRAINLAYER_DB"] = configured_db
+        try:
+            configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", target)
+            direct_db_values = []
+            for line in lines:
+                assignment = _split_env_assignment(line)
+                if assignment is None or assignment[0] != "BRAINLAYER_DB":
+                    continue
+                value = _parse_env_value(assignment[1])
+                if value is not None:
+                    direct_db_values.append(value)
+            if any(value != configured_db for value in direct_db_values):
+                raise RuntimeError(f"BRAINLAYER_DB must parse identically for launchd and direct CLI use in {target}")
+        except RuntimeError as exc:
+            if record_db_error:
+                _brainlayer_db_config_error = str(exc)
+            logger.error("Invalid BRAINLAYER_DB configuration; falling back to the canonical database: %s", exc)
+        else:
+            if record_db_error:
+                _brainlayer_db_config_error = None
+            if configured_db is not None:
+                os.environ["BRAINLAYER_DB"] = configured_db
+                loaded["BRAINLAYER_DB"] = configured_db
+    else:
+        if record_db_error:
+            _brainlayer_db_config_error = None
 
     for line in lines:
         assignment = _split_env_assignment(line)

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -170,11 +170,29 @@ def load_brainlayer_env(
         return {}
 
     loaded: dict[str, str] = {}
+    if "BRAINLAYER_DB" not in os.environ:
+        configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", target)
+        direct_db_values = []
+        for line in lines:
+            assignment = _split_env_assignment(line)
+            if assignment is None or assignment[0] != "BRAINLAYER_DB":
+                continue
+            value = _parse_env_value(assignment[1])
+            if value is not None:
+                direct_db_values.append(value)
+        if any(value != configured_db for value in direct_db_values):
+            raise RuntimeError(f"BRAINLAYER_DB must parse identically for launchd and direct CLI use in {target}")
+        if configured_db is not None:
+            os.environ["BRAINLAYER_DB"] = configured_db
+            loaded["BRAINLAYER_DB"] = configured_db
+
     for line in lines:
         assignment = _split_env_assignment(line)
         if assignment is None:
             continue
         key, raw_value = assignment
+        if key == "BRAINLAYER_DB":
+            continue
         if key in os.environ:
             continue
         value = _parse_env_value(raw_value)

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -115,7 +115,7 @@ def _resolve_op_read_value(value_text: str) -> str | None:
 
 
 def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> str | None:
-    """Return the final valid assignment from the selected BrainLayer env file."""
+    """Return one unambiguous launchd-compatible assignment from the selected env file."""
     target = env_path or get_user_env_path()
     try:
         lines = target.read_text(encoding="utf-8").splitlines()
@@ -132,7 +132,10 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
             raise RuntimeError(f"{name} must not use an op command substitution in {target}")
         if "$(" in assignment[1] or "`" in assignment[1]:
             continue
-        selected = _parse_launchd_env_value(assignment[1])
+        value = _parse_launchd_env_value(assignment[1])
+        if selected is not None:
+            raise RuntimeError(f"duplicate valid {name} assignments in {target}")
+        selected = value
     return selected
 
 

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -128,6 +128,8 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
         assignment = _split_launchd_env_assignment(line)
         if assignment is None or assignment[0] != name:
             continue
+        if _OP_READ_PREFIX in assignment[1]:
+            raise RuntimeError(f"{name} must not use an op command substitution in {target}")
         if "$(" in assignment[1] or "`" in assignment[1]:
             continue
         selected = _parse_launchd_env_value(assignment[1])

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -135,6 +135,8 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
         if "$(" in assignment[1] or "`" in assignment[1]:
             continue
         value = _parse_launchd_env_value(assignment[1])
+        if _parse_env_value(assignment[1]) != value:
+            raise RuntimeError(f"{name} must parse identically for launchd and direct CLI use in {target}")
         if selected is not None:
             raise RuntimeError(f"duplicate valid {name} assignments in {target}")
         selected = value

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -52,6 +52,14 @@ def _parse_env_assignment(line: str) -> tuple[str, str] | None:
     return (key, value) if value is not None else None
 
 
+def _parse_launchd_env_value(raw_value: str) -> str:
+    """Match brainlayer-env-run.sh: trim and remove one pair of matching quotes."""
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
 def _resolve_op_read_value(value_text: str) -> str | None:
     """Resolve exactly quoted $(op read 'op://...') values without a shell."""
     try:
@@ -107,9 +115,7 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
             continue
         if "$(" in assignment[1] or "`" in assignment[1]:
             continue
-        value = _parse_env_value(assignment[1])
-        if value is not None:
-            selected = value
+        selected = _parse_launchd_env_value(assignment[1])
     return selected
 
 

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -96,13 +96,16 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
     target = env_path or get_user_env_path()
     try:
         lines = target.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError):
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Could not read BrainLayer env file %s: %s", target, exc)
         return None
 
     selected: str | None = None
     for line in lines:
         assignment = _split_env_assignment(line)
         if assignment is None or assignment[0] != name:
+            continue
+        if "$(" in assignment[1] or "`" in assignment[1]:
             continue
         value = _parse_env_value(assignment[1])
         if value is not None:

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 _OP_READ_PREFIX = "$(op read "
-_PROCESS_ENV_AT_IMPORT = dict(os.environ)
 
 
 def get_user_env_path() -> Path:
@@ -93,24 +92,22 @@ def _resolve_op_read_value(value_text: str) -> str | None:
 
 
 def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> str | None:
-    """Return one configured value with original process-env precedence."""
-    if name in _PROCESS_ENV_AT_IMPORT:
-        return _PROCESS_ENV_AT_IMPORT[name]
-
+    """Return the final valid assignment from the selected BrainLayer env file."""
     target = env_path or get_user_env_path()
     try:
         lines = target.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
         return None
 
+    selected: str | None = None
     for line in lines:
         assignment = _split_env_assignment(line)
         if assignment is None or assignment[0] != name:
             continue
         value = _parse_env_value(assignment[1])
         if value is not None:
-            return value
-    return None
+            selected = value
+    return selected
 
 
 def load_brainlayer_env(

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -60,6 +60,21 @@ def _parse_launchd_env_value(raw_value: str) -> str:
     return value
 
 
+def _split_launchd_env_assignment(line: str) -> tuple[str, str] | None:
+    """Match brainlayer-env-run.sh's deliberately simple assignment grammar."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped.removeprefix("export ")
+
+    key, raw_value = stripped.split("=", 1)
+    key = key.rstrip()
+    if not key or not key.replace("_", "").isalnum() or key[0].isdigit():
+        return None
+    return key, raw_value.lstrip()
+
+
 def _resolve_op_read_value(value_text: str) -> str | None:
     """Resolve exactly quoted $(op read 'op://...') values without a shell."""
     try:
@@ -110,7 +125,7 @@ def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> 
 
     selected: str | None = None
     for line in lines:
-        assignment = _split_env_assignment(line)
+        assignment = _split_launchd_env_assignment(line)
         if assignment is None or assignment[0] != name:
             continue
         if "$(" in assignment[1] or "`" in assignment[1]:

--- a/src/brainlayer/config.py
+++ b/src/brainlayer/config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 _OP_READ_PREFIX = "$(op read "
+_PROCESS_ENV_AT_IMPORT = dict(os.environ)
 
 
 def get_user_env_path() -> Path:
@@ -89,6 +90,27 @@ def _resolve_op_read_value(value_text: str) -> str | None:
         logger.warning("Could not resolve 1Password env reference %s: op read exited %s", args[2], result.returncode)
         return None
     return result.stdout.rstrip("\n")
+
+
+def configured_brainlayer_env_value(name: str, env_path: Path | None = None) -> str | None:
+    """Return one configured value with original process-env precedence."""
+    if name in _PROCESS_ENV_AT_IMPORT:
+        return _PROCESS_ENV_AT_IMPORT[name]
+
+    target = env_path or get_user_env_path()
+    try:
+        lines = target.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    for line in lines:
+        assignment = _split_env_assignment(line)
+        if assignment is None or assignment[0] != name:
+            continue
+        value = _parse_env_value(assignment[1])
+        if value is not None:
+            return value
+    return None
 
 
 def load_brainlayer_env(

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -74,8 +74,17 @@ class DoctorIssue:
 
 
 def _spotlight_exclusion_issue(db_path: Path) -> DoctorIssue | None:
-    data_dir = db_path.expanduser().parent.resolve(strict=False)
-    if is_spotlight_excluded(data_dir):
+    try:
+        data_dir = db_path.expanduser().parent.resolve(strict=False)
+        excluded = is_spotlight_excluded(data_dir)
+    except (OSError, RuntimeError) as exc:
+        return DoctorIssue(
+            "spotlight_exclusion_check_failed",
+            "warning",
+            "Could not verify Spotlight exclusion for the BrainLayer data directory",
+            {"db_path": str(db_path), "error": str(exc)},
+        )
+    if excluded:
         return None
     return DoctorIssue(
         "spotlight_indexing_enabled",

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .alarm import BrainLayerAlarm, build_alarm, emit_alarm
+from .config import get_brainlayer_db_config_error
 from .deploy_drift import DEFAULT_DEPLOY_DRIFT_LABELS, default_deploy_provenance_dir, detect_deploy_drift
 from .drain_liveness import (
     DEFAULT_DRAIN_LIVENESS_STALE_SECONDS,
@@ -457,6 +458,15 @@ def run_doctor(
 
     def warning(code: str, message: str, **details: Any) -> None:
         result.issues.append(DoctorIssue(code, "warning", message, details))
+
+    db_config_error = get_brainlayer_db_config_error()
+    if db_config_error is not None:
+        fatal(
+            "brainlayer_db_config_invalid",
+            "BRAINLAYER_DB configuration is invalid; runtime fell back to the canonical database",
+            error=db_config_error,
+            remediation="fix BRAINLAYER_DB in ~/.config/brainlayer/brainlayer.env, then rerun doctor",
+        )
 
     if config.version_check_enabled:
         _check_brainbar_version_consistency(

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -43,7 +44,7 @@ from .launchd_primitive import (
     is_launchd_label_loaded,
     verify_launchd_label_loaded,
 )
-from .paths import get_db_path
+from .paths import SPOTLIGHT_EXCLUSION_MARKER, get_db_path, is_spotlight_excluded
 from .search_repo import clear_hybrid_search_cache
 from .vector_store import VectorStore
 
@@ -72,6 +73,25 @@ class DoctorIssue:
     details: dict[str, Any] = field(default_factory=dict)
 
 
+def _spotlight_exclusion_issue(db_path: Path) -> DoctorIssue | None:
+    data_dir = db_path.expanduser().parent.resolve(strict=False)
+    if is_spotlight_excluded(data_dir):
+        return None
+    return DoctorIssue(
+        "spotlight_indexing_enabled",
+        "warning",
+        "BrainLayer data directory is not excluded from Spotlight indexing",
+        {
+            "data_dir": str(data_dir),
+            "marker": SPOTLIGHT_EXCLUSION_MARKER,
+            "remediation": (
+                "run `brainlayer setup` for a fresh or empty layout; "
+                "for existing data, follow the Spotlight exclusion migration runbook"
+            ),
+        },
+    )
+
+
 @dataclass
 class DoctorConfig:
     db_path: Path = field(default_factory=get_db_path)
@@ -98,6 +118,7 @@ class DoctorConfig:
     version_check_enabled: bool = True
     version_check_required: bool = False
     version_check_path: Path = field(default_factory=default_version_check_path)
+    spotlight_check_enabled: bool = field(default_factory=lambda: sys.platform == "darwin")
 
 
 @dataclass
@@ -435,6 +456,11 @@ def run_doctor(
             version_check_required=config.version_check_required,
             command_runner=command_runner,
         )
+
+    if config.spotlight_check_enabled:
+        spotlight_issue = _spotlight_exclusion_issue(config.db_path)
+        if spotlight_issue is not None:
+            result.issues.append(spotlight_issue)
 
     store: VectorStore | None = None
     try:

--- a/src/brainlayer/paths.py
+++ b/src/brainlayer/paths.py
@@ -50,6 +50,11 @@ def resolve_db_path() -> Path:
     if env:
         return _guard_test_runtime_path(Path(env), source="BRAINLAYER_DB")
 
+    return get_canonical_db_path()
+
+
+def get_canonical_db_path() -> Path:
+    """Return the canonical database path without creating its parent."""
     return _guard_test_runtime_path(_CANONICAL_DB_PATH, source="canonical database path")
 
 

--- a/src/brainlayer/paths.py
+++ b/src/brainlayer/paths.py
@@ -9,6 +9,13 @@ import os
 from pathlib import Path
 
 _CANONICAL_DB_PATH = Path.home() / ".local" / "share" / "brainlayer" / "brainlayer.db"
+SPOTLIGHT_EXCLUSION_MARKER = ".metadata_never_index"
+
+
+def is_spotlight_excluded(path: Path) -> bool:
+    """Return whether *path* is beneath a marker-backed Spotlight exclusion."""
+    resolved = path.expanduser().resolve(strict=False)
+    return any((directory / SPOTLIGHT_EXCLUSION_MARKER).is_file() for directory in (resolved, *resolved.parents))
 
 
 def _guard_test_runtime_path(path: Path, *, source: str) -> Path:

--- a/src/brainlayer/paths.py
+++ b/src/brainlayer/paths.py
@@ -54,10 +54,10 @@ def resolve_db_path() -> Path:
 
 
 def get_db_path() -> Path:
-    """Resolve the BrainLayer database path and ensure its parent exists."""
+    """Resolve the DB path, creating only the canonical path's parent."""
     db_path = resolve_db_path()
-
-    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if not os.environ.get("BRAINLAYER_DB"):
+        db_path.parent.mkdir(parents=True, exist_ok=True)
     return db_path
 
 

--- a/src/brainlayer/paths.py
+++ b/src/brainlayer/paths.py
@@ -44,19 +44,22 @@ def _guard_test_runtime_path(path: Path, *, source: str) -> Path:
     return path
 
 
-def get_db_path() -> Path:
-    """Resolve the BrainLayer database path.
-
-    Checks BRAINLAYER_DB env var first, then uses the canonical path.
-    """
+def resolve_db_path() -> Path:
+    """Resolve the BrainLayer database path without creating its parent."""
     env = os.environ.get("BRAINLAYER_DB")
     if env:
         return _guard_test_runtime_path(Path(env), source="BRAINLAYER_DB")
 
-    db_path = _guard_test_runtime_path(_CANONICAL_DB_PATH, source="canonical database path")
+    return _guard_test_runtime_path(_CANONICAL_DB_PATH, source="canonical database path")
+
+
+def get_db_path() -> Path:
+    """Resolve the BrainLayer database path and ensure its parent exists."""
+    db_path = resolve_db_path()
+
     db_path.parent.mkdir(parents=True, exist_ok=True)
     return db_path
 
 
-# Convenience: pre-resolved default for import
-DEFAULT_DB_PATH = get_db_path()
+# Convenience: pre-resolved default without import-time filesystem mutation.
+DEFAULT_DB_PATH = resolve_db_path()

--- a/src/brainlayer/paths.py
+++ b/src/brainlayer/paths.py
@@ -48,7 +48,7 @@ def resolve_db_path() -> Path:
     """Resolve the BrainLayer database path without creating its parent."""
     env = os.environ.get("BRAINLAYER_DB")
     if env:
-        return _guard_test_runtime_path(Path(env), source="BRAINLAYER_DB")
+        return _guard_test_runtime_path(Path(env).expanduser(), source="BRAINLAYER_DB")
 
     return get_canonical_db_path()
 

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -13,54 +13,11 @@ from importlib import resources
 from pathlib import Path
 
 from .cli.wizard import DEFAULT_BRAINLAYER_CONFIG, write_gemini_env_file
-from .paths import SPOTLIGHT_EXCLUSION_MARKER, get_canonical_db_path, resolve_db_path
+from .paths import get_canonical_db_path, resolve_db_path
+from .spotlight import ensure_spotlight_excluded_layout as _ensure_spotlight_excluded_layout
 
 DEFAULT_GOOGLE_API_KEY_OP_REF = "op://Private/Google AI/Gemini API key"
 DEFAULT_MCP_PROTOCOL_VERSION = "2025-06-18"
-
-_DATA_CHILDREN = (
-    "backups",
-    "chromadb",
-    "chromadb.backup",
-    "enrichment-scratch",
-    "experiments",
-    "jsonl-backups",
-    "logs",
-    "prompts",
-    "style",
-    "storage",
-)
-_RUNTIME_CHILDREN = ("logs", "quarantine", "queue")
-
-
-def _validate_override_data_root(active_root: Path, canonical_root: Path) -> None:
-    active = active_root.expanduser().resolve(strict=False)
-    canonical = canonical_root.expanduser().resolve(strict=False)
-    if active == canonical:
-        return
-    unsafe_location = active == Path.home().resolve() or active == Path(active.anchor) or os.path.ismount(active)
-    if unsafe_location or active in canonical.parents or "brainlayer" not in active.name.casefold():
-        raise RuntimeError(f"BRAINLAYER_DB must be inside a dedicated BrainLayer directory; unsafe parent: {active}")
-
-
-def _validate_disjoint_roots(roots: tuple[Path, ...]) -> None:
-    resolved = tuple(root.expanduser().resolve(strict=False) for root in roots)
-    for index, root in enumerate(resolved):
-        for other in resolved[:index]:
-            if root == other or root in other.parents or other in root.parents:
-                raise RuntimeError(f"Spotlight exclusion roots must not overlap: {other} and {root}")
-
-
-def _ensure_spotlight_excluded_root(root: Path, children: tuple[str, ...] = ()) -> Path:
-    resolved = root.expanduser()
-    resolved.mkdir(parents=True, exist_ok=True)
-    marker = resolved / SPOTLIGHT_EXCLUSION_MARKER
-    if not marker.is_file() and next(resolved.iterdir(), None) is not None:
-        raise RuntimeError(f"existing runtime tree {resolved} requires the Spotlight exclusion migration runbook")
-    marker.touch(exist_ok=True)
-    for child in children:
-        (resolved / child).mkdir(parents=True, exist_ok=True)
-    return resolved
 
 
 def ensure_spotlight_excluded_layout(
@@ -71,36 +28,16 @@ def ensure_spotlight_excluded_layout(
     counter_dir: Path | None = None,
 ) -> tuple[Path, ...]:
     """Create marker-backed roots for every high-churn BrainLayer runtime path."""
-    if data_dir is not None:
-        data_roots = (data_dir,)
-    else:
-        active_data_root = resolve_db_path().parent
-        canonical_data_root = get_canonical_db_path().parent
-        _validate_override_data_root(active_data_root, canonical_data_root)
-        data_roots = tuple(dict.fromkeys((active_data_root, canonical_data_root)))
-    requested_roots = (
-        *data_roots,
-        runtime_dir or Path.home() / ".brainlayer",
-        launchd_log_dir or Path.home() / "Library" / "Logs" / "brainlayer",
-        counter_dir or Path.home() / ".brainlayer-p0-counter",
+    return _ensure_spotlight_excluded_layout(
+        data_dir=data_dir,
+        runtime_dir=runtime_dir,
+        launchd_log_dir=launchd_log_dir,
+        counter_dir=counter_dir,
+        resolve_db_path_fn=resolve_db_path,
+        get_canonical_db_path_fn=get_canonical_db_path,
+        home_fn=Path.home,
+        ismount_fn=os.path.ismount,
     )
-    _validate_disjoint_roots(requested_roots)
-    resolved_roots = tuple(root.expanduser() for root in requested_roots)
-    for root in resolved_roots:
-        if root.is_symlink() or (root.exists() and not root.is_dir()):
-            raise RuntimeError(f"runtime root {root} must be a directory")
-        marker = root / SPOTLIGHT_EXCLUSION_MARKER
-        if root.is_dir() and not marker.is_file() and next(root.iterdir(), None) is not None:
-            raise RuntimeError(f"existing runtime tree {root} requires the Spotlight exclusion migration runbook")
-
-    data_root_count = len(data_roots)
-    roots = (
-        *(_ensure_spotlight_excluded_root(root, _DATA_CHILDREN) for root in resolved_roots[:data_root_count]),
-        _ensure_spotlight_excluded_root(resolved_roots[data_root_count], _RUNTIME_CHILDREN),
-        _ensure_spotlight_excluded_root(resolved_roots[data_root_count + 1]),
-        _ensure_spotlight_excluded_root(resolved_roots[data_root_count + 2]),
-    )
-    return roots
 
 
 def get_default_env_file() -> Path:

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -38,8 +38,17 @@ def _validate_override_data_root(active_root: Path, canonical_root: Path) -> Non
     canonical = canonical_root.expanduser().resolve(strict=False)
     if active == canonical:
         return
-    if active in canonical.parents or "brainlayer" not in active.name.casefold():
+    unsafe_location = active == Path.home().resolve() or active == Path(active.anchor) or os.path.ismount(active)
+    if unsafe_location or active in canonical.parents or "brainlayer" not in active.name.casefold():
         raise RuntimeError(f"BRAINLAYER_DB must be inside a dedicated BrainLayer directory; unsafe parent: {active}")
+
+
+def _validate_disjoint_roots(roots: tuple[Path, ...]) -> None:
+    resolved = tuple(root.expanduser().resolve(strict=False) for root in roots)
+    for index, root in enumerate(resolved):
+        for other in resolved[:index]:
+            if root == other or root in other.parents or other in root.parents:
+                raise RuntimeError(f"Spotlight exclusion roots must not overlap: {other} and {root}")
 
 
 def _ensure_spotlight_excluded_root(root: Path, children: tuple[str, ...] = ()) -> Path:
@@ -75,9 +84,10 @@ def ensure_spotlight_excluded_layout(
         launchd_log_dir or Path.home() / "Library" / "Logs" / "brainlayer",
         counter_dir or Path.home() / ".brainlayer-p0-counter",
     )
+    _validate_disjoint_roots(requested_roots)
     resolved_roots = tuple(root.expanduser() for root in requested_roots)
     for root in resolved_roots:
-        if (root.exists() or root.is_symlink()) and not root.is_dir():
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
             raise RuntimeError(f"runtime root {root} must be a directory")
         marker = root / SPOTLIGHT_EXCLUSION_MARKER
         if root.is_dir() and not marker.is_file() and next(root.iterdir(), None) is not None:

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -33,6 +33,15 @@ _DATA_CHILDREN = (
 _RUNTIME_CHILDREN = ("logs", "quarantine", "queue")
 
 
+def _validate_override_data_root(active_root: Path, canonical_root: Path) -> None:
+    active = active_root.expanduser().resolve(strict=False)
+    canonical = canonical_root.expanduser().resolve(strict=False)
+    if active == canonical:
+        return
+    if active in canonical.parents or "brainlayer" not in active.name.casefold():
+        raise RuntimeError(f"BRAINLAYER_DB must be inside a dedicated BrainLayer directory; unsafe parent: {active}")
+
+
 def _ensure_spotlight_excluded_root(root: Path, children: tuple[str, ...] = ()) -> Path:
     resolved = root.expanduser()
     resolved.mkdir(parents=True, exist_ok=True)
@@ -58,6 +67,7 @@ def ensure_spotlight_excluded_layout(
     else:
         active_data_root = resolve_db_path().parent
         canonical_data_root = get_canonical_db_path().parent
+        _validate_override_data_root(active_data_root, canonical_data_root)
         data_roots = tuple(dict.fromkeys((active_data_root, canonical_data_root)))
     requested_roots = (
         *data_roots,

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -13,9 +13,67 @@ from importlib import resources
 from pathlib import Path
 
 from .cli.wizard import DEFAULT_BRAINLAYER_CONFIG, write_gemini_env_file
+from .paths import SPOTLIGHT_EXCLUSION_MARKER, get_db_path
 
 DEFAULT_GOOGLE_API_KEY_OP_REF = "op://Private/Google AI/Gemini API key"
 DEFAULT_MCP_PROTOCOL_VERSION = "2025-06-18"
+
+_DATA_CHILDREN = (
+    "backups",
+    "chromadb",
+    "chromadb.backup",
+    "enrichment-scratch",
+    "experiments",
+    "jsonl-backups",
+    "logs",
+    "prompts",
+    "style",
+    "storage",
+)
+_RUNTIME_CHILDREN = ("logs", "quarantine", "queue")
+
+
+def _ensure_spotlight_excluded_root(root: Path, children: tuple[str, ...] = ()) -> Path:
+    resolved = root.expanduser()
+    resolved.mkdir(parents=True, exist_ok=True)
+    marker = resolved / SPOTLIGHT_EXCLUSION_MARKER
+    if not marker.is_file() and next(resolved.iterdir(), None) is not None:
+        raise RuntimeError(f"existing runtime tree {resolved} requires the Spotlight exclusion migration runbook")
+    marker.touch(exist_ok=True)
+    for child in children:
+        (resolved / child).mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def ensure_spotlight_excluded_layout(
+    *,
+    data_dir: Path | None = None,
+    runtime_dir: Path | None = None,
+    launchd_log_dir: Path | None = None,
+    counter_dir: Path | None = None,
+) -> tuple[Path, Path, Path, Path]:
+    """Create marker-backed roots for every high-churn BrainLayer runtime path."""
+    requested_roots = (
+        data_dir or get_db_path().parent,
+        runtime_dir or Path.home() / ".brainlayer",
+        launchd_log_dir or Path.home() / "Library" / "Logs" / "brainlayer",
+        counter_dir or Path.home() / ".brainlayer-p0-counter",
+    )
+    resolved_roots = tuple(root.expanduser() for root in requested_roots)
+    for root in resolved_roots:
+        if (root.exists() or root.is_symlink()) and not root.is_dir():
+            raise RuntimeError(f"runtime root {root} must be a directory")
+        marker = root / SPOTLIGHT_EXCLUSION_MARKER
+        if root.is_dir() and not marker.is_file() and next(root.iterdir(), None) is not None:
+            raise RuntimeError(f"existing runtime tree {root} requires the Spotlight exclusion migration runbook")
+
+    roots = (
+        _ensure_spotlight_excluded_root(resolved_roots[0], _DATA_CHILDREN),
+        _ensure_spotlight_excluded_root(resolved_roots[1], _RUNTIME_CHILDREN),
+        _ensure_spotlight_excluded_root(resolved_roots[2]),
+        _ensure_spotlight_excluded_root(resolved_roots[3]),
+    )
+    return roots
 
 
 def get_default_env_file() -> Path:

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -29,18 +29,13 @@ def ensure_spotlight_excluded_layout(
     counter_dir: Path | None = None,
 ) -> tuple[Path, ...]:
     """Create marker-backed roots for every high-churn BrainLayer runtime path."""
-    resolve_db_path_fn = resolve_db_path
-    if data_dir is None and env_file is not None:
-        from .config import configured_brainlayer_env_value
-
-        configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
-        resolve_db_path_fn = (lambda: Path(configured_db).expanduser()) if configured_db else get_canonical_db_path
     return _ensure_spotlight_excluded_layout(
         data_dir=data_dir,
+        env_file=env_file,
         runtime_dir=runtime_dir,
         launchd_log_dir=launchd_log_dir,
         counter_dir=counter_dir,
-        resolve_db_path_fn=resolve_db_path_fn,
+        resolve_db_path_fn=resolve_db_path,
         get_canonical_db_path_fn=get_canonical_db_path,
         home_fn=Path.home,
         ismount_fn=os.path.ismount,

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -13,7 +13,7 @@ from importlib import resources
 from pathlib import Path
 
 from .cli.wizard import DEFAULT_BRAINLAYER_CONFIG, write_gemini_env_file
-from .paths import SPOTLIGHT_EXCLUSION_MARKER, get_db_path
+from .paths import SPOTLIGHT_EXCLUSION_MARKER, resolve_db_path
 
 DEFAULT_GOOGLE_API_KEY_OP_REF = "op://Private/Google AI/Gemini API key"
 DEFAULT_MCP_PROTOCOL_VERSION = "2025-06-18"
@@ -54,7 +54,7 @@ def ensure_spotlight_excluded_layout(
 ) -> tuple[Path, Path, Path, Path]:
     """Create marker-backed roots for every high-churn BrainLayer runtime path."""
     requested_roots = (
-        data_dir or get_db_path().parent,
+        data_dir or resolve_db_path().parent,
         runtime_dir or Path.home() / ".brainlayer",
         launchd_log_dir or Path.home() / "Library" / "Logs" / "brainlayer",
         counter_dir or Path.home() / ".brainlayer-p0-counter",

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -23,17 +23,24 @@ DEFAULT_MCP_PROTOCOL_VERSION = "2025-06-18"
 def ensure_spotlight_excluded_layout(
     *,
     data_dir: Path | None = None,
+    env_file: Path | None = None,
     runtime_dir: Path | None = None,
     launchd_log_dir: Path | None = None,
     counter_dir: Path | None = None,
 ) -> tuple[Path, ...]:
     """Create marker-backed roots for every high-churn BrainLayer runtime path."""
+    resolve_db_path_fn = resolve_db_path
+    if data_dir is None and env_file is not None:
+        from .config import configured_brainlayer_env_value
+
+        configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
+        resolve_db_path_fn = (lambda: Path(configured_db).expanduser()) if configured_db else get_canonical_db_path
     return _ensure_spotlight_excluded_layout(
         data_dir=data_dir,
         runtime_dir=runtime_dir,
         launchd_log_dir=launchd_log_dir,
         counter_dir=counter_dir,
-        resolve_db_path_fn=resolve_db_path,
+        resolve_db_path_fn=resolve_db_path_fn,
         get_canonical_db_path_fn=get_canonical_db_path,
         home_fn=Path.home,
         ismount_fn=os.path.ismount,

--- a/src/brainlayer/setup.py
+++ b/src/brainlayer/setup.py
@@ -13,7 +13,7 @@ from importlib import resources
 from pathlib import Path
 
 from .cli.wizard import DEFAULT_BRAINLAYER_CONFIG, write_gemini_env_file
-from .paths import SPOTLIGHT_EXCLUSION_MARKER, resolve_db_path
+from .paths import SPOTLIGHT_EXCLUSION_MARKER, get_canonical_db_path, resolve_db_path
 
 DEFAULT_GOOGLE_API_KEY_OP_REF = "op://Private/Google AI/Gemini API key"
 DEFAULT_MCP_PROTOCOL_VERSION = "2025-06-18"
@@ -51,10 +51,16 @@ def ensure_spotlight_excluded_layout(
     runtime_dir: Path | None = None,
     launchd_log_dir: Path | None = None,
     counter_dir: Path | None = None,
-) -> tuple[Path, Path, Path, Path]:
+) -> tuple[Path, ...]:
     """Create marker-backed roots for every high-churn BrainLayer runtime path."""
+    if data_dir is not None:
+        data_roots = (data_dir,)
+    else:
+        active_data_root = resolve_db_path().parent
+        canonical_data_root = get_canonical_db_path().parent
+        data_roots = tuple(dict.fromkeys((active_data_root, canonical_data_root)))
     requested_roots = (
-        data_dir or resolve_db_path().parent,
+        *data_roots,
         runtime_dir or Path.home() / ".brainlayer",
         launchd_log_dir or Path.home() / "Library" / "Logs" / "brainlayer",
         counter_dir or Path.home() / ".brainlayer-p0-counter",
@@ -67,11 +73,12 @@ def ensure_spotlight_excluded_layout(
         if root.is_dir() and not marker.is_file() and next(root.iterdir(), None) is not None:
             raise RuntimeError(f"existing runtime tree {root} requires the Spotlight exclusion migration runbook")
 
+    data_root_count = len(data_roots)
     roots = (
-        _ensure_spotlight_excluded_root(resolved_roots[0], _DATA_CHILDREN),
-        _ensure_spotlight_excluded_root(resolved_roots[1], _RUNTIME_CHILDREN),
-        _ensure_spotlight_excluded_root(resolved_roots[2]),
-        _ensure_spotlight_excluded_root(resolved_roots[3]),
+        *(_ensure_spotlight_excluded_root(root, _DATA_CHILDREN) for root in resolved_roots[:data_root_count]),
+        _ensure_spotlight_excluded_root(resolved_roots[data_root_count], _RUNTIME_CHILDREN),
+        _ensure_spotlight_excluded_root(resolved_roots[data_root_count + 1]),
+        _ensure_spotlight_excluded_root(resolved_roots[data_root_count + 2]),
     )
     return roots
 

--- a/src/brainlayer/spotlight.py
+++ b/src/brainlayer/spotlight.py
@@ -28,7 +28,9 @@ def _validate_override_data_root(
     home: Path,
     ismount: Callable[[Path], bool],
 ) -> None:
-    raw_active = active_root.expanduser().absolute()
+    raw_active = active_root.expanduser()
+    if not raw_active.is_absolute():
+        raise RuntimeError(f"BRAINLAYER_DB must be an absolute path; got: {raw_active}")
     for component in (*reversed(raw_active.parents), raw_active):
         if component.is_symlink():
             raise RuntimeError(f"BRAINLAYER_DB parent must not contain a symbolic link: {raw_active}")
@@ -64,6 +66,7 @@ def _ensure_spotlight_excluded_root(root: Path, children: Tuple[str, ...] = ()) 
 def ensure_spotlight_excluded_layout(
     *,
     data_dir: Optional[Path] = None,
+    env_file: Optional[Path] = None,
     runtime_dir: Optional[Path] = None,
     launchd_log_dir: Optional[Path] = None,
     counter_dir: Optional[Path] = None,
@@ -77,8 +80,14 @@ def ensure_spotlight_excluded_layout(
     if data_dir is not None:
         data_roots = (data_dir,)
     else:
-        active_data_root = resolve_db_path_fn().parent
         canonical_data_root = get_canonical_db_path_fn().parent
+        if env_file is not None:
+            from .config import configured_brainlayer_env_value
+
+            configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
+            active_data_root = Path(configured_db).expanduser().parent if configured_db else canonical_data_root
+        else:
+            active_data_root = resolve_db_path_fn().parent
         _validate_override_data_root(active_data_root, canonical_data_root, home=home, ismount=ismount_fn)
         data_roots = tuple(
             dict.fromkeys(root.expanduser().resolve(strict=False) for root in (active_data_root, canonical_data_root))

--- a/src/brainlayer/spotlight.py
+++ b/src/brainlayer/spotlight.py
@@ -19,6 +19,42 @@ _DATA_CHILDREN = (
     "storage",
 )
 _RUNTIME_CHILDREN = ("logs", "quarantine", "queue")
+_UNSUPPORTED_RUNTIME_PATH_OVERRIDES = (
+    "BRAINLAYER_BACKUP_LOG_PATH",
+    "BRAINLAYER_BACKUP_STAGING_DIR",
+    "BRAINLAYER_DRAIN_HEALTH_PATH",
+    "BRAINLAYER_DRAIN_LOG_PATH",
+    "BRAINLAYER_ENRICH_COST_DIR",
+    "BRAINLAYER_JSONL_BACKUP_LOG_PATH",
+    "BRAINLAYER_JSONL_BACKUP_STAGING_DIR",
+    "BRAINLAYER_JSONL_BACKUP_STATE_PATH",
+    "BRAINLAYER_LOG_DIR",
+    "BRAINLAYER_OFFSETS_PATH",
+    "BRAINLAYER_P0_COUNTER_DIR",
+    "BRAINLAYER_QUEUE_DIR",
+    "BRAINLAYER_WATCHER_HEALTH_PATH",
+    "BRAINLAYER_WATCHER_OFFSETS_PATH",
+    "BRAINLAYER_WATCHER_QUARANTINE_DIR",
+    "BRAINLAYER_WRITER_HEARTBEAT_DIR",
+    "BRAINLAYER_WRITER_TELEMETRY_PATH",
+)
+
+
+def _data_root_from_db_path(db_path: Path) -> Path:
+    expanded = db_path.expanduser()
+    if expanded.is_symlink():
+        raise RuntimeError(f"BRAINLAYER_DB must not be a symbolic link: {expanded}")
+    return expanded.parent
+
+
+def _reject_runtime_path_overrides(env_file: Path) -> None:
+    from .config import configured_brainlayer_env_value
+
+    for name in _UNSUPPORTED_RUNTIME_PATH_OVERRIDES:
+        if configured_brainlayer_env_value(name, env_file) not in (None, ""):
+            raise RuntimeError(
+                f"{name} is not supported by the Spotlight preflight; remove the override before installation"
+            )
 
 
 def _validate_override_data_root(
@@ -77,6 +113,8 @@ def ensure_spotlight_excluded_layout(
 ) -> Tuple[Path, ...]:
     """Create marker-backed roots for every high-churn BrainLayer runtime path."""
     home = home_fn()
+    if env_file is not None:
+        _reject_runtime_path_overrides(env_file)
     if data_dir is not None:
         data_roots = (data_dir,)
     else:
@@ -85,9 +123,9 @@ def ensure_spotlight_excluded_layout(
             from .config import configured_brainlayer_env_value
 
             configured_db = configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
-            active_data_root = Path(configured_db).expanduser().parent if configured_db else canonical_data_root
+            active_data_root = _data_root_from_db_path(Path(configured_db)) if configured_db else canonical_data_root
         else:
-            active_data_root = resolve_db_path_fn().parent
+            active_data_root = _data_root_from_db_path(resolve_db_path_fn())
         _validate_override_data_root(active_data_root, canonical_data_root, home=home, ismount=ismount_fn)
         data_roots = tuple(
             dict.fromkeys(root.expanduser().resolve(strict=False) for root in (active_data_root, canonical_data_root))

--- a/src/brainlayer/spotlight.py
+++ b/src/brainlayer/spotlight.py
@@ -1,0 +1,103 @@
+"""Lightweight Spotlight exclusion layout preflight."""
+
+import os
+from pathlib import Path
+from typing import Callable, Optional, Tuple
+
+from .paths import SPOTLIGHT_EXCLUSION_MARKER, get_canonical_db_path, resolve_db_path
+
+_DATA_CHILDREN = (
+    "backups",
+    "chromadb",
+    "chromadb.backup",
+    "enrichment-scratch",
+    "experiments",
+    "jsonl-backups",
+    "logs",
+    "prompts",
+    "style",
+    "storage",
+)
+_RUNTIME_CHILDREN = ("logs", "quarantine", "queue")
+
+
+def _validate_override_data_root(
+    active_root: Path,
+    canonical_root: Path,
+    *,
+    home: Path,
+    ismount: Callable[[Path], bool],
+) -> None:
+    active = active_root.expanduser().resolve(strict=False)
+    canonical = canonical_root.expanduser().resolve(strict=False)
+    if active == canonical:
+        return
+    unsafe_location = active == home.resolve() or active == Path(active.anchor) or ismount(active)
+    if unsafe_location or active in canonical.parents or "brainlayer" not in active.name.casefold():
+        raise RuntimeError(f"BRAINLAYER_DB must be inside a dedicated BrainLayer directory; unsafe parent: {active}")
+
+
+def _validate_disjoint_roots(roots: Tuple[Path, ...]) -> None:
+    resolved = tuple(root.expanduser().resolve(strict=False) for root in roots)
+    for index, root in enumerate(resolved):
+        for other in resolved[:index]:
+            if root == other or root in other.parents or other in root.parents:
+                raise RuntimeError(f"Spotlight exclusion roots must not overlap: {other} and {root}")
+
+
+def _ensure_spotlight_excluded_root(root: Path, children: Tuple[str, ...] = ()) -> Path:
+    resolved = root.expanduser()
+    resolved.mkdir(parents=True, exist_ok=True)
+    marker = resolved / SPOTLIGHT_EXCLUSION_MARKER
+    if not marker.is_file() and next(resolved.iterdir(), None) is not None:
+        raise RuntimeError(f"existing runtime tree {resolved} requires the Spotlight exclusion migration runbook")
+    marker.touch(exist_ok=True)
+    for child in children:
+        (resolved / child).mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def ensure_spotlight_excluded_layout(
+    *,
+    data_dir: Optional[Path] = None,
+    runtime_dir: Optional[Path] = None,
+    launchd_log_dir: Optional[Path] = None,
+    counter_dir: Optional[Path] = None,
+    resolve_db_path_fn: Callable[[], Path] = resolve_db_path,
+    get_canonical_db_path_fn: Callable[[], Path] = get_canonical_db_path,
+    home_fn: Callable[[], Path] = Path.home,
+    ismount_fn: Callable[[Path], bool] = os.path.ismount,
+) -> Tuple[Path, ...]:
+    """Create marker-backed roots for every high-churn BrainLayer runtime path."""
+    home = home_fn()
+    if data_dir is not None:
+        data_roots = (data_dir,)
+    else:
+        active_data_root = resolve_db_path_fn().parent
+        canonical_data_root = get_canonical_db_path_fn().parent
+        _validate_override_data_root(active_data_root, canonical_data_root, home=home, ismount=ismount_fn)
+        data_roots = tuple(
+            dict.fromkeys(root.expanduser().resolve(strict=False) for root in (active_data_root, canonical_data_root))
+        )
+    requested_roots = (
+        *data_roots,
+        runtime_dir or home / ".brainlayer",
+        launchd_log_dir or home / "Library" / "Logs" / "brainlayer",
+        counter_dir or home / ".brainlayer-p0-counter",
+    )
+    _validate_disjoint_roots(requested_roots)
+    resolved_roots = tuple(root.expanduser() for root in requested_roots)
+    for root in resolved_roots:
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            raise RuntimeError(f"runtime root {root} must be a directory")
+        marker = root / SPOTLIGHT_EXCLUSION_MARKER
+        if root.is_dir() and not marker.is_file() and next(root.iterdir(), None) is not None:
+            raise RuntimeError(f"existing runtime tree {root} requires the Spotlight exclusion migration runbook")
+
+    data_root_count = len(data_roots)
+    return (
+        *(_ensure_spotlight_excluded_root(root, _DATA_CHILDREN) for root in resolved_roots[:data_root_count]),
+        _ensure_spotlight_excluded_root(resolved_roots[data_root_count], _RUNTIME_CHILDREN),
+        _ensure_spotlight_excluded_root(resolved_roots[data_root_count + 1]),
+        _ensure_spotlight_excluded_root(resolved_roots[data_root_count + 2]),
+    )

--- a/src/brainlayer/spotlight.py
+++ b/src/brainlayer/spotlight.py
@@ -28,7 +28,11 @@ def _validate_override_data_root(
     home: Path,
     ismount: Callable[[Path], bool],
 ) -> None:
-    active = active_root.expanduser().resolve(strict=False)
+    raw_active = active_root.expanduser().absolute()
+    for component in (*reversed(raw_active.parents), raw_active):
+        if component.is_symlink():
+            raise RuntimeError(f"BRAINLAYER_DB parent must not contain a symbolic link: {raw_active}")
+    active = raw_active.resolve(strict=False)
     canonical = canonical_root.expanduser().resolve(strict=False)
     if active == canonical:
         return

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -407,6 +407,33 @@ def test_spotlight_exclusion_issue_accepts_marker_on_data_directory(tmp_path):
     assert doctor._spotlight_exclusion_issue(db_path) is None
 
 
+def test_spotlight_exclusion_issue_reports_path_check_failure(tmp_path, monkeypatch):
+    from brainlayer import doctor
+
+    monkeypatch.setattr(
+        doctor,
+        "is_spotlight_excluded",
+        lambda _path: (_ for _ in ()).throw(RuntimeError("symlink loop")),
+    )
+
+    issue = doctor._spotlight_exclusion_issue(tmp_path / "brainlayer.db")
+
+    assert issue is not None
+    assert issue.code == "spotlight_exclusion_check_failed"
+    assert issue.severity == "warning"
+
+
+@pytest.mark.parametrize(("platform", "expected"), [("darwin", True), ("linux", False)])
+def test_doctor_config_defaults_spotlight_check_by_platform(tmp_path, monkeypatch, platform, expected):
+    from brainlayer import doctor
+
+    monkeypatch.setattr(doctor.sys, "platform", platform)
+
+    config = doctor.DoctorConfig(db_path=tmp_path / "brainlayer.db")
+
+    assert config.spotlight_check_enabled is expected
+
+
 def test_run_doctor_reports_unexcluded_data_directory_as_warning(tmp_path):
     from brainlayer.doctor import run_doctor
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -455,6 +455,39 @@ def test_run_doctor_reports_unexcluded_data_directory_as_warning(tmp_path):
     assert result.exit_code == 0
 
 
+def test_poisoned_db_env_falls_back_and_doctor_reports_configuration_error(tmp_path, monkeypatch, caplog):
+    import brainlayer.config as runtime_config
+    from brainlayer.doctor import run_doctor
+
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text(
+        "BRAINLAYER_DB=/first/brainlayer.db\nBRAINLAYER_DB=/second/brainlayer.db\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    monkeypatch.setattr(runtime_config, "get_user_env_path", lambda: env_file)
+    monkeypatch.setattr(runtime_config, "_brainlayer_db_config_error", None, raising=False)
+
+    assert runtime_config.load_brainlayer_env() == {}
+    assert "BRAINLAYER_DB" not in os.environ
+    assert "falling back to the canonical database" in caplog.text
+
+    db_path = tmp_path / "canonical" / "brainlayer.db"
+    db_path.parent.mkdir()
+    _build_db(db_path)
+    result = run_doctor(
+        _doctor_config(tmp_path, db_path),
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "brainlayer_db_config_invalid")
+    assert issue.severity == "fatal"
+    assert "duplicate valid BRAINLAYER_DB assignments" in issue.details["error"]
+    assert result.exit_code == 1
+
+
 def test_run_doctor_reports_unavailable_process_snapshot_without_false_daemon_death(tmp_path):
     from brainlayer.doctor import run_doctor
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -382,6 +382,52 @@ def test_run_doctor_exits_zero_on_healthy_fixture(tmp_path):
     assert not [issue for issue in result.issues if issue.severity == "fatal"]
 
 
+def test_spotlight_exclusion_issue_warns_for_unmarked_db_directory(tmp_path):
+    from brainlayer import doctor
+
+    db_path = tmp_path / "data" / "brainlayer.db"
+    db_path.parent.mkdir()
+
+    issue = doctor._spotlight_exclusion_issue(db_path)
+
+    assert issue is not None
+    assert issue.code == "spotlight_indexing_enabled"
+    assert issue.severity == "warning"
+    assert issue.details["data_dir"] == str(db_path.parent)
+    assert issue.details["marker"] == ".metadata_never_index"
+
+
+def test_spotlight_exclusion_issue_accepts_marker_on_data_directory(tmp_path):
+    from brainlayer import doctor
+
+    db_path = tmp_path / "data" / "brainlayer.db"
+    db_path.parent.mkdir()
+    (db_path.parent / ".metadata_never_index").touch()
+
+    assert doctor._spotlight_exclusion_issue(db_path) is None
+
+
+def test_run_doctor_reports_unexcluded_data_directory_as_warning(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "unexcluded" / "healthy.db"
+    db_path.parent.mkdir()
+    _build_db(db_path)
+    config = _doctor_config(tmp_path, db_path)
+    config.spotlight_check_enabled = True
+
+    result = run_doctor(
+        config,
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    issue = next(issue for issue in result.issues if issue.code == "spotlight_indexing_enabled")
+    assert issue.severity == "warning"
+    assert result.exit_code == 0
+
+
 def test_run_doctor_reports_unavailable_process_snapshot_without_false_daemon_death(tmp_path):
     from brainlayer.doctor import run_doctor
 

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -351,7 +351,6 @@ def test_setup_marks_override_and_canonical_data_roots(tmp_path: Path, monkeypat
 
 
 def test_setup_uses_selected_env_file_db_override(tmp_path: Path, monkeypatch) -> None:
-    import brainlayer.config as config
     import brainlayer.setup as setup_helpers
 
     home = tmp_path / "home"
@@ -359,7 +358,6 @@ def test_setup_uses_selected_env_file_db_override(tmp_path: Path, monkeypatch) -
     canonical_data_dir = tmp_path / "canonical-data"
     env_file = tmp_path / "selected.env"
     env_file.write_text(f"BRAINLAYER_DB={override_data_dir / 'brainlayer.db'}\n", encoding="utf-8")
-    monkeypatch.setattr(config, "_PROCESS_ENV_AT_IMPORT", {})
     monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
 
     roots = setup_helpers.ensure_spotlight_excluded_layout(
@@ -1149,16 +1147,17 @@ def test_standalone_launchd_installer_preflights_selected_env_db(tmp_path: Path)
     fake_brainlayer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     fake_brainlayer.chmod(0o755)
     override_data_dir = tmp_path / "brainlayer-selected"
+    transient_process_data_dir = tmp_path / "brainlayer-transient-process"
     env_file = tmp_path / "selected.env"
     env_file.write_text(f"BRAINLAYER_DB={override_data_dir / 'brainlayer.db'}\n", encoding="utf-8")
     run_env = os.environ.copy()
-    run_env.pop("BRAINLAYER_DB", None)
     run_env.update(
         {
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "HOME": str(home),
             "BRAINLAYER_BIN": str(fake_brainlayer),
             "BRAINLAYER_ENV_FILE": str(env_file),
+            "BRAINLAYER_DB": str(transient_process_data_dir / "brainlayer.db"),
         }
     )
 
@@ -1173,25 +1172,57 @@ def test_standalone_launchd_installer_preflights_selected_env_db(tmp_path: Path)
 
     assert result.returncode != 0
     assert (override_data_dir / ".metadata_never_index").is_file()
+    assert not transient_process_data_dir.exists()
 
 
-def test_configured_env_value_prefers_original_process_then_selected_file(tmp_path: Path, monkeypatch) -> None:
+def test_configured_env_value_matches_selected_file_last_assignment(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.config as config
 
     env_file = tmp_path / "brainlayer.env"
     env_file.write_text("BRAINLAYER_DB=/from/selected/brainlayer.db\n", encoding="utf-8")
-    monkeypatch.setattr(config, "_PROCESS_ENV_AT_IMPORT", {"BRAINLAYER_DB": "/from/process/brainlayer.db"})
-
-    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/process/brainlayer.db"
-
-    monkeypatch.setattr(config, "_PROCESS_ENV_AT_IMPORT", {})
+    monkeypatch.setenv("BRAINLAYER_DB", "/from/process/brainlayer.db")
     assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/selected/brainlayer.db"
 
     env_file.write_text(
-        "BRAINLAYER_DB=$(not-allowed)\nBRAINLAYER_DB=/from/later/brainlayer.db\n",
+        "BRAINLAYER_DB=$(not-allowed)\n"
+        "BRAINLAYER_DB=/from/first/brainlayer.db\n"
+        "BRAINLAYER_DB=/from/later/brainlayer.db\n",
         encoding="utf-8",
     )
     assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/later/brainlayer.db"
+
+
+@pytest.mark.parametrize("action", ["remove", "unload"])
+def test_launchd_teardown_does_not_create_runtime_roots(tmp_path: Path, action: str) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_launchctl.chmod(0o755)
+    fake_brainlayer = tmp_path / "brainlayer"
+    fake_brainlayer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_brainlayer.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), action],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": str(fake_brainlayer),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (home / ".local" / "share" / "brainlayer").exists()
+    assert not (home / ".brainlayer").exists()
+    assert not (home / "Library" / "Logs" / "brainlayer").exists()
 
 
 def test_launchd_installer_renders_brainlayer_python_override(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1261,6 +1261,12 @@ def test_configured_env_value_matches_selected_file_last_assignment(tmp_path: Pa
         "/Volumes/brainlayer data/brainlayer.db"
     )
 
+    env_file.write_text(
+        "BRAINLAYER_DB=/from/runtime/brainlayer.db\nexport  BRAINLAYER_DB=/ignored/by/launchd/brainlayer.db\n",
+        encoding="utf-8",
+    )
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/runtime/brainlayer.db"
+
 
 def test_configured_env_value_logs_unreadable_file(tmp_path: Path, monkeypatch, caplog) -> None:
     import brainlayer.config as config

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1104,6 +1104,29 @@ def test_config_loader_does_not_resolve_op_when_process_env_already_has_key(tmp_
     assert os.environ["GOOGLE_API_KEY"] == "from-process"
 
 
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        r"BRAINLAYER_DB=/Volumes/brainlayer\ data/brainlayer.db",
+        'BRAINLAYER_DB="/outer"inner"/brainlayer.db"',
+        "export  BRAINLAYER_DB=/ignored/by/launchd/brainlayer.db",
+    ],
+)
+def test_config_loader_rejects_db_syntax_that_launchd_parses_differently(
+    tmp_path: Path, monkeypatch, assignment: str
+) -> None:
+    from brainlayer.config import load_brainlayer_env
+
+    user_env = tmp_path / "brainlayer.env"
+    user_env.write_text(f"{assignment}\n", encoding="utf-8")
+    monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+
+    with pytest.raises(RuntimeError, match="launchd and direct CLI"):
+        load_brainlayer_env(user_env)
+
+    assert "BRAINLAYER_DB" not in os.environ
+
+
 def test_config_loader_ignores_unreadable_user_env(monkeypatch, tmp_path: Path) -> None:
     from brainlayer.config import load_brainlayer_env
 

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1310,9 +1310,12 @@ def test_configured_env_value_matches_launchd_grammar_and_rejects_runtime_ambigu
         config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
 
     env_file.write_text(r"BRAINLAYER_DB=/Volumes/brainlayer\ data/brainlayer.db" + "\n", encoding="utf-8")
-    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == (
-        r"/Volumes/brainlayer\ data/brainlayer.db"
-    )
+    with pytest.raises(RuntimeError, match="parse identically"):
+        config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
+
+    env_file.write_text('BRAINLAYER_DB="/outer"inner"/brainlayer.db"\n', encoding="utf-8")
+    with pytest.raises(RuntimeError, match="parse identically"):
+        config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
 
     env_file.write_text('BRAINLAYER_DB="/Volumes/brainlayer data/brainlayer.db"\n', encoding="utf-8")
     assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == (

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1251,6 +1251,16 @@ def test_configured_env_value_matches_selected_file_last_assignment(tmp_path: Pa
     monkeypatch.setattr(config.subprocess, "run", fail_op_read)
     assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/runtime/brainlayer.db"
 
+    env_file.write_text(r"BRAINLAYER_DB=/Volumes/brainlayer\ data/brainlayer.db" + "\n", encoding="utf-8")
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == (
+        r"/Volumes/brainlayer\ data/brainlayer.db"
+    )
+
+    env_file.write_text('BRAINLAYER_DB="/Volumes/brainlayer data/brainlayer.db"\n', encoding="utf-8")
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == (
+        "/Volumes/brainlayer data/brainlayer.db"
+    )
+
 
 def test_configured_env_value_logs_unreadable_file(tmp_path: Path, monkeypatch, caplog) -> None:
     import brainlayer.config as config

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -371,6 +371,50 @@ def test_setup_uses_selected_env_file_db_override(tmp_path: Path, monkeypatch) -
     assert (override_data_dir / ".metadata_never_index").is_file()
 
 
+def test_setup_rejects_selected_env_db_file_symlink_before_creating_roots(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    target = tmp_path / "target.db"
+    target.touch()
+    override_data_dir = tmp_path / "brainlayer-selected"
+    override_data_dir.mkdir()
+    linked_db = override_data_dir / "brainlayer.db"
+    linked_db.symlink_to(target)
+    canonical_data_dir = tmp_path / "canonical-data"
+    env_file = tmp_path / "selected.env"
+    env_file.write_text(f"BRAINLAYER_DB={linked_db}\n", encoding="utf-8")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+
+    with pytest.raises(RuntimeError, match="must not be a symbolic link"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            env_file=env_file,
+            runtime_dir=tmp_path / "runtime",
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not canonical_data_dir.exists()
+
+
+def test_setup_rejects_selected_env_runtime_path_override_before_creating_roots(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    canonical_data_dir = tmp_path / "canonical-data"
+    env_file = tmp_path / "selected.env"
+    env_file.write_text(f"BRAINLAYER_QUEUE_DIR={tmp_path / 'queue-override'}\n", encoding="utf-8")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+
+    with pytest.raises(RuntimeError, match="BRAINLAYER_QUEUE_DIR"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            env_file=env_file,
+            runtime_dir=tmp_path / "runtime",
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not canonical_data_dir.exists()
+
+
 def test_spotlight_env_file_without_db_uses_canonical_not_process_override(tmp_path: Path, monkeypatch) -> None:
     from brainlayer.spotlight import ensure_spotlight_excluded_layout
 
@@ -1282,7 +1326,7 @@ def test_configured_env_value_matches_launchd_grammar_and_rejects_runtime_ambigu
     assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/runtime/brainlayer.db"
 
 
-def test_configured_env_value_logs_unreadable_file(tmp_path: Path, monkeypatch, caplog) -> None:
+def test_configured_env_value_rejects_unreadable_file(tmp_path: Path, monkeypatch, caplog) -> None:
     import brainlayer.config as config
 
     env_file = tmp_path / "brainlayer.env"
@@ -1296,7 +1340,8 @@ def test_configured_env_value_logs_unreadable_file(tmp_path: Path, monkeypatch, 
 
     monkeypatch.setattr(Path, "read_text", fail_read)
 
-    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) is None
+    with pytest.raises(RuntimeError, match="Could not read BrainLayer env file"):
+        config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
     assert "Could not read BrainLayer env file" in caplog.text
 
 

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -88,7 +88,7 @@ def _write_fake_ps(fake_bin: Path) -> None:
 def _copy_packaged_launchd(launchd_dir: Path) -> None:
     shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
     package_dir = launchd_dir.parent
-    for name in ("__init__.py", "paths.py", "spotlight.py"):
+    for name in ("__init__.py", "config.py", "paths.py", "spotlight.py"):
         shutil.copy2(REPO_ROOT / "src" / "brainlayer" / name, package_dir / name)
 
 
@@ -350,6 +350,29 @@ def test_setup_marks_override_and_canonical_data_roots(tmp_path: Path, monkeypat
     assert (canonical_data_dir / "prompts").is_dir()
 
 
+def test_setup_uses_selected_env_file_db_override(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.config as config
+    import brainlayer.setup as setup_helpers
+
+    home = tmp_path / "home"
+    override_data_dir = tmp_path / "brainlayer-selected"
+    canonical_data_dir = tmp_path / "canonical-data"
+    env_file = tmp_path / "selected.env"
+    env_file.write_text(f"BRAINLAYER_DB={override_data_dir / 'brainlayer.db'}\n", encoding="utf-8")
+    monkeypatch.setattr(config, "_PROCESS_ENV_AT_IMPORT", {})
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+
+    roots = setup_helpers.ensure_spotlight_excluded_layout(
+        env_file=env_file,
+        runtime_dir=home / ".brainlayer",
+        launchd_log_dir=home / "Library" / "Logs" / "brainlayer",
+        counter_dir=home / ".brainlayer-p0-counter",
+    )
+
+    assert roots[:2] == (override_data_dir, canonical_data_dir)
+    assert (override_data_dir / ".metadata_never_index").is_file()
+
+
 def test_setup_deduplicates_equivalent_resolved_data_roots(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.setup as setup_helpers
 
@@ -425,6 +448,28 @@ def test_setup_rejects_override_parent_that_is_mount_root(tmp_path: Path, monkey
         )
 
     assert not mount_root.exists()
+
+
+def test_setup_rejects_override_beneath_symlinked_parent(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    linked_parent = tmp_path / "linked"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    override_data_dir = linked_parent / "brainlayer-data"
+    canonical_data_dir = tmp_path / "canonical-data"
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: override_data_dir / "brainlayer.db")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+
+    with pytest.raises(RuntimeError, match="symbolic link"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            runtime_dir=tmp_path / "runtime",
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not override_data_dir.exists()
 
 
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:
@@ -691,23 +736,28 @@ def test_setup_command_writes_op_backed_env_without_plaintext_and_can_skip_launc
     assert oct(env_file.stat().st_mode & 0o777) == "0o600"
 
 
-def test_setup_command_excludes_runtime_layout_before_writing_env(tmp_path: Path, monkeypatch) -> None:
+def test_setup_command_excludes_runtime_layout_for_selected_env(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.cli as cli
     import brainlayer.setup as setup_helpers
 
     calls: list[str] = []
     monkeypatch.setattr(cli.sys, "platform", "darwin")
-    monkeypatch.setattr(setup_helpers, "ensure_spotlight_excluded_layout", lambda: calls.append("layout"))
+    env_file = tmp_path / "brainlayer.env"
+    monkeypatch.setattr(
+        setup_helpers,
+        "ensure_spotlight_excluded_layout",
+        lambda *, env_file: calls.append(f"layout:{env_file}"),
+    )
     monkeypatch.setattr(
         setup_helpers,
         "ensure_brainlayer_env",
-        lambda *_args, **_kwargs: calls.append("env") or tmp_path / "brainlayer.env",
+        lambda *_args, **_kwargs: calls.append("env") or env_file,
     )
 
     result = CliRunner().invoke(cli.app, ["setup", "--no-launchd"])
 
     assert result.exit_code == 0, result.stdout
-    assert calls == ["layout", "env"]
+    assert calls == ["env", f"layout:{env_file}"]
 
 
 def test_setup_command_skips_spotlight_layout_outside_macos(tmp_path: Path, monkeypatch) -> None:
@@ -716,7 +766,11 @@ def test_setup_command_skips_spotlight_layout_outside_macos(tmp_path: Path, monk
 
     calls: list[str] = []
     monkeypatch.setattr(cli.sys, "platform", "linux")
-    monkeypatch.setattr(setup_helpers, "ensure_spotlight_excluded_layout", lambda: calls.append("layout"))
+    monkeypatch.setattr(
+        setup_helpers,
+        "ensure_spotlight_excluded_layout",
+        lambda *, env_file: calls.append(f"layout:{env_file}"),
+    )
     monkeypatch.setattr(
         setup_helpers,
         "ensure_brainlayer_env",
@@ -883,14 +937,18 @@ def test_init_command_excludes_layout_before_wizard_and_launchd(monkeypatch) -> 
         gemini_env_file = Path("/tmp/brainlayer.env")
 
     monkeypatch.setattr(cli.sys, "platform", "darwin")
-    monkeypatch.setattr(setup_helpers, "ensure_spotlight_excluded_layout", lambda: calls.append("layout"))
+    monkeypatch.setattr(
+        setup_helpers,
+        "ensure_spotlight_excluded_layout",
+        lambda *, env_file: calls.append(f"layout:{env_file}"),
+    )
     monkeypatch.setattr(wizard, "run_wizard", lambda: calls.append("wizard") or Config())
     monkeypatch.setattr(setup_helpers, "install_launchd", lambda *_args, **_kwargs: calls.append("launchd"))
 
     result = CliRunner().invoke(cli.app, ["init", "--install-launchd"])
 
     assert result.exit_code == 0, result.stdout
-    assert calls == ["layout", "wizard", "launchd"]
+    assert calls == ["wizard", "layout:/tmp/brainlayer.env", "launchd"]
 
 
 def test_config_loader_prefers_process_env_then_user_env_and_ignores_repo_root_dotenv(
@@ -1039,6 +1097,11 @@ def test_launchd_installer_preflights_all_before_loading_without_google_key(tmp_
 
 
 def test_standalone_launchd_installer_runs_spotlight_preflight_before_mkdir(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_uname = fake_bin / "uname"
+    fake_uname.write_text("#!/bin/sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+    fake_uname.chmod(0o755)
     home = tmp_path / "home"
     home.mkdir()
     fake_brainlayer = tmp_path / "brainlayer"
@@ -1056,6 +1119,7 @@ def test_standalone_launchd_installer_runs_spotlight_preflight_before_mkdir(tmp_
         [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "watch"],
         env={
             **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "HOME": str(home),
             "BRAINLAYER_BIN": str(fake_brainlayer),
             "PYTHON_BIN": str(python_shim),
@@ -1071,6 +1135,63 @@ def test_standalone_launchd_installer_runs_spotlight_preflight_before_mkdir(tmp_
     assert "ensure_spotlight_excluded_layout" in preflight_log.read_text(encoding="utf-8")
     assert not (home / "Library" / "LaunchAgents").exists()
     assert not (home / ".local" / "share" / "brainlayer").exists()
+
+
+def test_standalone_launchd_installer_preflights_selected_env_db(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_uname = fake_bin / "uname"
+    fake_uname.write_text("#!/bin/sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+    fake_uname.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_brainlayer = tmp_path / "brainlayer"
+    fake_brainlayer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_brainlayer.chmod(0o755)
+    override_data_dir = tmp_path / "brainlayer-selected"
+    env_file = tmp_path / "selected.env"
+    env_file.write_text(f"BRAINLAYER_DB={override_data_dir / 'brainlayer.db'}\n", encoding="utf-8")
+    run_env = os.environ.copy()
+    run_env.pop("BRAINLAYER_DB", None)
+    run_env.update(
+        {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": str(fake_brainlayer),
+            "BRAINLAYER_ENV_FILE": str(env_file),
+        }
+    )
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "not-a-target"],
+        env=run_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert (override_data_dir / ".metadata_never_index").is_file()
+
+
+def test_configured_env_value_prefers_original_process_then_selected_file(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.config as config
+
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_DB=/from/selected/brainlayer.db\n", encoding="utf-8")
+    monkeypatch.setattr(config, "_PROCESS_ENV_AT_IMPORT", {"BRAINLAYER_DB": "/from/process/brainlayer.db"})
+
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/process/brainlayer.db"
+
+    monkeypatch.setattr(config, "_PROCESS_ENV_AT_IMPORT", {})
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/selected/brainlayer.db"
+
+    env_file.write_text(
+        "BRAINLAYER_DB=$(not-allowed)\nBRAINLAYER_DB=/from/later/brainlayer.db\n",
+        encoding="utf-8",
+    )
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/later/brainlayer.db"
 
 
 def test_launchd_installer_renders_brainlayer_python_override(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -195,6 +195,106 @@ def test_install_launchd_default_defers_to_bounded_installer_shutdown_waits(tmp_
     assert calls == [([str(install_script), "all"], None)]
 
 
+def test_setup_creates_complete_spotlight_excluded_layout_idempotently(tmp_path: Path) -> None:
+    import brainlayer.setup as setup_helpers
+
+    data_dir = tmp_path / "data"
+    runtime_dir = tmp_path / "runtime"
+    launchd_log_dir = tmp_path / "launchd-logs"
+    counter_dir = tmp_path / "counter"
+
+    first = setup_helpers.ensure_spotlight_excluded_layout(
+        data_dir=data_dir,
+        runtime_dir=runtime_dir,
+        launchd_log_dir=launchd_log_dir,
+        counter_dir=counter_dir,
+    )
+    second = setup_helpers.ensure_spotlight_excluded_layout(
+        data_dir=data_dir,
+        runtime_dir=runtime_dir,
+        launchd_log_dir=launchd_log_dir,
+        counter_dir=counter_dir,
+    )
+
+    roots = (data_dir, runtime_dir, launchd_log_dir, counter_dir)
+    assert first == roots
+    assert second == roots
+    assert all((root / ".metadata_never_index").is_file() for root in roots)
+    assert {path.name for path in data_dir.iterdir() if path.is_dir()} == {
+        "backups",
+        "chromadb",
+        "chromadb.backup",
+        "enrichment-scratch",
+        "experiments",
+        "jsonl-backups",
+        "logs",
+        "prompts",
+        "style",
+        "storage",
+    }
+    assert {path.name for path in runtime_dir.iterdir() if path.is_dir()} == {"logs", "quarantine", "queue"}
+
+
+def test_setup_refuses_to_mark_legacy_nonempty_runtime_tree(tmp_path: Path) -> None:
+    import brainlayer.setup as setup_helpers
+
+    data_dir = tmp_path / "legacy-data"
+    data_dir.mkdir()
+    (data_dir / "brainlayer.db").write_bytes(b"existing production data")
+
+    with pytest.raises(RuntimeError, match="requires the Spotlight exclusion migration runbook"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            data_dir=data_dir,
+            runtime_dir=tmp_path / "runtime",
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not (data_dir / ".metadata_never_index").exists()
+
+
+def test_setup_preflights_all_roots_before_creating_any_marker(tmp_path: Path) -> None:
+    import brainlayer.setup as setup_helpers
+
+    data_dir = tmp_path / "new-data"
+    runtime_dir = tmp_path / "legacy-runtime"
+    runtime_dir.mkdir()
+    (runtime_dir / "queue-item.jsonl").write_text("pending\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="requires the Spotlight exclusion migration runbook"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            data_dir=data_dir,
+            runtime_dir=runtime_dir,
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not data_dir.exists()
+    assert not (runtime_dir / ".metadata_never_index").exists()
+
+
+@pytest.mark.parametrize("invalid_kind", ["file", "dangling-symlink"])
+def test_setup_preflights_invalid_root_types_before_creating_any_marker(tmp_path: Path, invalid_kind: str) -> None:
+    import brainlayer.setup as setup_helpers
+
+    data_dir = tmp_path / "new-data"
+    runtime_dir = tmp_path / "invalid-runtime"
+    if invalid_kind == "file":
+        runtime_dir.write_text("not a directory\n", encoding="utf-8")
+    else:
+        runtime_dir.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="must be a directory"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            data_dir=data_dir,
+            runtime_dir=runtime_dir,
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not data_dir.exists()
+
+
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:
     from brainlayer.setup import migrate_legacy_mcp_configs
 
@@ -457,6 +557,24 @@ def test_setup_command_writes_op_backed_env_without_plaintext_and_can_skip_launc
     assert "GOOGLE_API_KEY=\"$(op read 'op://Private/Google AI/Gemini API key')\"" in content
     assert "AIza" not in content
     assert oct(env_file.stat().st_mode & 0o777) == "0o600"
+
+
+def test_setup_command_excludes_runtime_layout_before_writing_env(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+    from brainlayer.cli import app
+
+    calls: list[str] = []
+    monkeypatch.setattr(setup_helpers, "ensure_spotlight_excluded_layout", lambda: calls.append("layout"))
+    monkeypatch.setattr(
+        setup_helpers,
+        "ensure_brainlayer_env",
+        lambda *_args, **_kwargs: calls.append("env") or tmp_path / "brainlayer.env",
+    )
+
+    result = CliRunner().invoke(app, ["setup", "--no-launchd"])
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == ["layout", "env"]
 
 
 def test_launchd_env_runner_makes_homebrew_op_available_before_loading_env() -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -273,7 +273,7 @@ def test_setup_preflights_all_roots_before_creating_any_marker(tmp_path: Path) -
     assert not (runtime_dir / ".metadata_never_index").exists()
 
 
-@pytest.mark.parametrize("invalid_kind", ["file", "dangling-symlink"])
+@pytest.mark.parametrize("invalid_kind", ["file", "dangling-symlink", "directory-symlink"])
 def test_setup_preflights_invalid_root_types_before_creating_any_marker(tmp_path: Path, invalid_kind: str) -> None:
     import brainlayer.setup as setup_helpers
 
@@ -281,8 +281,12 @@ def test_setup_preflights_invalid_root_types_before_creating_any_marker(tmp_path
     runtime_dir = tmp_path / "invalid-runtime"
     if invalid_kind == "file":
         runtime_dir.write_text("not a directory\n", encoding="utf-8")
-    else:
+    elif invalid_kind == "dangling-symlink":
         runtime_dir.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+    else:
+        target = tmp_path / "runtime-target"
+        target.mkdir()
+        runtime_dir.symlink_to(target, target_is_directory=True)
 
     with pytest.raises(RuntimeError, match="must be a directory"):
         setup_helpers.ensure_spotlight_excluded_layout(
@@ -355,6 +359,24 @@ def test_setup_rejects_override_parent_that_is_not_dedicated_to_brainlayer(tmp_p
         )
 
     assert not broad_override_dir.exists()
+
+
+def test_setup_rejects_override_parent_that_overlaps_runtime_root(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    shared_root = tmp_path / "brainlayer-runtime"
+    canonical_data_dir = tmp_path / "canonical-data"
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: shared_root / "brainlayer.db")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+
+    with pytest.raises(RuntimeError, match="overlap"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            runtime_dir=shared_root,
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not shared_root.exists()
 
 
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -295,6 +295,24 @@ def test_setup_preflights_invalid_root_types_before_creating_any_marker(tmp_path
     assert not data_dir.exists()
 
 
+def test_setup_default_data_root_is_not_created_when_later_root_is_invalid(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    data_dir = tmp_path / "default-data"
+    runtime_dir = tmp_path / "invalid-runtime"
+    runtime_dir.write_text("not a directory\n", encoding="utf-8")
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: data_dir / "brainlayer.db")
+
+    with pytest.raises(RuntimeError, match="must be a directory"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            runtime_dir=runtime_dir,
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not data_dir.exists()
+
+
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:
     from brainlayer.setup import migrate_legacy_mcp_configs
 
@@ -560,10 +578,11 @@ def test_setup_command_writes_op_backed_env_without_plaintext_and_can_skip_launc
 
 
 def test_setup_command_excludes_runtime_layout_before_writing_env(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.cli as cli
     import brainlayer.setup as setup_helpers
-    from brainlayer.cli import app
 
     calls: list[str] = []
+    monkeypatch.setattr(cli.sys, "platform", "darwin")
     monkeypatch.setattr(setup_helpers, "ensure_spotlight_excluded_layout", lambda: calls.append("layout"))
     monkeypatch.setattr(
         setup_helpers,
@@ -571,10 +590,29 @@ def test_setup_command_excludes_runtime_layout_before_writing_env(tmp_path: Path
         lambda *_args, **_kwargs: calls.append("env") or tmp_path / "brainlayer.env",
     )
 
-    result = CliRunner().invoke(app, ["setup", "--no-launchd"])
+    result = CliRunner().invoke(cli.app, ["setup", "--no-launchd"])
 
     assert result.exit_code == 0, result.stdout
     assert calls == ["layout", "env"]
+
+
+def test_setup_command_skips_spotlight_layout_outside_macos(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.cli as cli
+    import brainlayer.setup as setup_helpers
+
+    calls: list[str] = []
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+    monkeypatch.setattr(setup_helpers, "ensure_spotlight_excluded_layout", lambda: calls.append("layout"))
+    monkeypatch.setattr(
+        setup_helpers,
+        "ensure_brainlayer_env",
+        lambda *_args, **_kwargs: calls.append("env") or tmp_path / "brainlayer.env",
+    )
+
+    result = CliRunner().invoke(cli.app, ["setup", "--no-launchd"])
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == ["env"]
 
 
 def test_launchd_env_runner_makes_homebrew_op_available_before_loading_env() -> None:
@@ -718,6 +756,27 @@ def test_init_command_reports_launchd_failure_without_traceback(monkeypatch) -> 
     assert result.exit_code == 1
     assert "BrainLayer init failed: missing install.sh" in result.stdout
     assert "Traceback" not in result.stdout
+
+
+def test_init_command_excludes_layout_before_wizard_and_launchd(monkeypatch) -> None:
+    import brainlayer.cli as cli
+    import brainlayer.cli.wizard as wizard
+    import brainlayer.setup as setup_helpers
+
+    calls: list[str] = []
+
+    class Config:
+        gemini_env_file = Path("/tmp/brainlayer.env")
+
+    monkeypatch.setattr(cli.sys, "platform", "darwin")
+    monkeypatch.setattr(setup_helpers, "ensure_spotlight_excluded_layout", lambda: calls.append("layout"))
+    monkeypatch.setattr(wizard, "run_wizard", lambda: calls.append("wizard") or Config())
+    monkeypatch.setattr(setup_helpers, "install_launchd", lambda *_args, **_kwargs: calls.append("launchd"))
+
+    result = CliRunner().invoke(cli.app, ["init", "--install-launchd"])
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == ["layout", "wizard", "launchd"]
 
 
 def test_config_loader_prefers_process_env_then_user_env_and_ignores_repo_root_dotenv(

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -302,6 +302,7 @@ def test_setup_default_data_root_is_not_created_when_later_root_is_invalid(tmp_p
     runtime_dir = tmp_path / "invalid-runtime"
     runtime_dir.write_text("not a directory\n", encoding="utf-8")
     monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: data_dir / "brainlayer.db")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: data_dir / "brainlayer.db", raising=False)
 
     with pytest.raises(RuntimeError, match="must be a directory"):
         setup_helpers.ensure_spotlight_excluded_layout(
@@ -311,6 +312,31 @@ def test_setup_default_data_root_is_not_created_when_later_root_is_invalid(tmp_p
         )
 
     assert not data_dir.exists()
+
+
+def test_setup_marks_override_and_canonical_data_roots(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    override_data_dir = tmp_path / "override-data"
+    canonical_data_dir = tmp_path / "canonical-data"
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: override_data_dir / "brainlayer.db")
+    monkeypatch.setattr(
+        setup_helpers,
+        "get_canonical_db_path",
+        lambda: canonical_data_dir / "brainlayer.db",
+        raising=False,
+    )
+
+    roots = setup_helpers.ensure_spotlight_excluded_layout(
+        runtime_dir=tmp_path / "runtime",
+        launchd_log_dir=tmp_path / "launchd-logs",
+        counter_dir=tmp_path / "counter",
+    )
+
+    assert roots[:2] == (override_data_dir, canonical_data_dir)
+    assert (override_data_dir / ".metadata_never_index").is_file()
+    assert (canonical_data_dir / ".metadata_never_index").is_file()
+    assert (canonical_data_dir / "prompts").is_dir()
 
 
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -317,7 +317,7 @@ def test_setup_default_data_root_is_not_created_when_later_root_is_invalid(tmp_p
 def test_setup_marks_override_and_canonical_data_roots(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.setup as setup_helpers
 
-    override_data_dir = tmp_path / "override-data"
+    override_data_dir = tmp_path / "brainlayer-override"
     canonical_data_dir = tmp_path / "canonical-data"
     monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: override_data_dir / "brainlayer.db")
     monkeypatch.setattr(
@@ -337,6 +337,24 @@ def test_setup_marks_override_and_canonical_data_roots(tmp_path: Path, monkeypat
     assert (override_data_dir / ".metadata_never_index").is_file()
     assert (canonical_data_dir / ".metadata_never_index").is_file()
     assert (canonical_data_dir / "prompts").is_dir()
+
+
+def test_setup_rejects_override_parent_that_is_not_dedicated_to_brainlayer(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    broad_override_dir = tmp_path / "shared-data"
+    canonical_data_dir = broad_override_dir / ".local" / "share" / "brainlayer"
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: broad_override_dir / "brainlayer.db")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+
+    with pytest.raises(RuntimeError, match="dedicated BrainLayer directory"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            runtime_dir=tmp_path / "runtime",
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not broad_override_dir.exists()
 
 
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -371,6 +371,29 @@ def test_setup_uses_selected_env_file_db_override(tmp_path: Path, monkeypatch) -
     assert (override_data_dir / ".metadata_never_index").is_file()
 
 
+def test_spotlight_env_file_without_db_uses_canonical_not_process_override(tmp_path: Path, monkeypatch) -> None:
+    from brainlayer.spotlight import ensure_spotlight_excluded_layout
+
+    env_file = tmp_path / "selected.env"
+    env_file.write_text("BRAINLAYER_ENRICH_ENABLED=0\n", encoding="utf-8")
+    process_data_dir = tmp_path / "brainlayer-process"
+    canonical_data_dir = tmp_path / "canonical-data"
+    monkeypatch.setenv("BRAINLAYER_DB", str(process_data_dir / "brainlayer.db"))
+
+    roots = ensure_spotlight_excluded_layout(
+        env_file=env_file,
+        runtime_dir=tmp_path / "runtime",
+        launchd_log_dir=tmp_path / "launchd-logs",
+        counter_dir=tmp_path / "counter",
+        resolve_db_path_fn=lambda: process_data_dir / "brainlayer.db",
+        get_canonical_db_path_fn=lambda: canonical_data_dir / "brainlayer.db",
+        home_fn=lambda: tmp_path,
+    )
+
+    assert roots[0] == canonical_data_dir
+    assert not process_data_dir.exists()
+
+
 def test_setup_deduplicates_equivalent_resolved_data_roots(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.setup as setup_helpers
 
@@ -468,6 +491,24 @@ def test_setup_rejects_override_beneath_symlinked_parent(tmp_path: Path, monkeyp
         )
 
     assert not override_data_dir.exists()
+
+
+def test_setup_rejects_relative_db_override(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: Path("brainlayer-relative/brainlayer.db"))
+    monkeypatch.setattr(
+        setup_helpers,
+        "get_canonical_db_path",
+        lambda: tmp_path / "canonical-data" / "brainlayer.db",
+    )
+
+    with pytest.raises(RuntimeError, match="absolute path"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            runtime_dir=tmp_path / "runtime",
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
 
 
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:
@@ -736,11 +777,13 @@ def test_setup_command_writes_op_backed_env_without_plaintext_and_can_skip_launc
 
 def test_setup_command_excludes_runtime_layout_for_selected_env(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.cli as cli
+    import brainlayer.config as config
     import brainlayer.setup as setup_helpers
 
     calls: list[str] = []
     monkeypatch.setattr(cli.sys, "platform", "darwin")
     env_file = tmp_path / "brainlayer.env"
+    monkeypatch.setattr(config, "get_user_env_path", lambda: env_file)
     monkeypatch.setattr(
         setup_helpers,
         "ensure_spotlight_excluded_layout",
@@ -755,7 +798,7 @@ def test_setup_command_excludes_runtime_layout_for_selected_env(tmp_path: Path, 
     result = CliRunner().invoke(cli.app, ["setup", "--no-launchd"])
 
     assert result.exit_code == 0, result.stdout
-    assert calls == ["env", f"layout:{env_file}"]
+    assert calls == [f"layout:{env_file}", "env"]
 
 
 def test_setup_command_skips_spotlight_layout_outside_macos(tmp_path: Path, monkeypatch) -> None:
@@ -935,6 +978,7 @@ def test_init_command_excludes_layout_before_wizard_and_launchd(monkeypatch) -> 
         gemini_env_file = Path("/tmp/brainlayer.env")
 
     monkeypatch.setattr(cli.sys, "platform", "darwin")
+    monkeypatch.setattr(wizard, "get_default_env_file", lambda: Path("/tmp/brainlayer.env"))
     monkeypatch.setattr(
         setup_helpers,
         "ensure_spotlight_excluded_layout",
@@ -946,7 +990,7 @@ def test_init_command_excludes_layout_before_wizard_and_launchd(monkeypatch) -> 
     result = CliRunner().invoke(cli.app, ["init", "--install-launchd"])
 
     assert result.exit_code == 0, result.stdout
-    assert calls == ["wizard", "layout:/tmp/brainlayer.env", "launchd"]
+    assert calls == ["layout:/tmp/brainlayer.env", "wizard", "launchd"]
 
 
 def test_config_loader_prefers_process_env_then_user_env_and_ignores_repo_root_dotenv(
@@ -1141,6 +1185,10 @@ def test_standalone_launchd_installer_preflights_selected_env_db(tmp_path: Path)
     fake_uname = fake_bin / "uname"
     fake_uname.write_text("#!/bin/sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
     fake_uname.chmod(0o755)
+    fake_launchctl = fake_bin / "launchctl"
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl.write_text("\n".join(_fake_launchctl_lines()), encoding="utf-8")
+    fake_launchctl.chmod(0o755)
     home = tmp_path / "home"
     home.mkdir()
     fake_brainlayer = tmp_path / "brainlayer"
@@ -1158,11 +1206,12 @@ def test_standalone_launchd_installer_preflights_selected_env_db(tmp_path: Path)
             "BRAINLAYER_BIN": str(fake_brainlayer),
             "BRAINLAYER_ENV_FILE": str(env_file),
             "BRAINLAYER_DB": str(transient_process_data_dir / "brainlayer.db"),
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
         }
     )
 
     result = subprocess.run(
-        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "not-a-target"],
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "watch"],
         env=run_env,
         capture_output=True,
         text=True,
@@ -1170,7 +1219,7 @@ def test_standalone_launchd_installer_preflights_selected_env_db(tmp_path: Path)
         check=False,
     )
 
-    assert result.returncode != 0
+    assert result.returncode == 0, result.stderr
     assert (override_data_dir / ".metadata_never_index").is_file()
     assert not transient_process_data_dir.exists()
 
@@ -1190,6 +1239,57 @@ def test_configured_env_value_matches_selected_file_last_assignment(tmp_path: Pa
         encoding="utf-8",
     )
     assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/later/brainlayer.db"
+
+    env_file.write_text(
+        "BRAINLAYER_DB=/from/runtime/brainlayer.db\nBRAINLAYER_DB=\"$(op read 'op://Private/Database/path')\"\n",
+        encoding="utf-8",
+    )
+
+    def fail_op_read(*args, **kwargs):
+        raise AssertionError("BRAINLAYER_DB command substitutions must be skipped")
+
+    monkeypatch.setattr(config.subprocess, "run", fail_op_read)
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/runtime/brainlayer.db"
+
+
+def test_configured_env_value_logs_unreadable_file(tmp_path: Path, monkeypatch, caplog) -> None:
+    import brainlayer.config as config
+
+    env_file = tmp_path / "brainlayer.env"
+    env_file.write_text("BRAINLAYER_DB=/unused/brainlayer.db\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def fail_read(path: Path, *args, **kwargs):
+        if path == env_file:
+            raise PermissionError("blocked")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) is None
+    assert "Could not read BrainLayer env file" in caplog.text
+
+
+def test_launchd_installer_rejects_unknown_target_before_creating_roots(tmp_path: Path) -> None:
+    fake_brainlayer = tmp_path / "brainlayer"
+    fake_brainlayer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_brainlayer.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "not-a-target"],
+        env={**os.environ, "HOME": str(home), "BRAINLAYER_BIN": str(fake_brainlayer)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Usage:" in result.stdout
+    assert not (home / ".local" / "share" / "brainlayer").exists()
+    assert not (home / ".brainlayer").exists()
 
 
 @pytest.mark.parametrize("action", ["remove", "unload"])

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -85,6 +85,13 @@ def _write_fake_ps(fake_bin: Path) -> None:
     fake_ps.chmod(0o755)
 
 
+def _copy_packaged_launchd(launchd_dir: Path) -> None:
+    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    package_dir = launchd_dir.parent
+    for name in ("__init__.py", "paths.py", "spotlight.py"):
+        shutil.copy2(REPO_ROOT / "src" / "brainlayer" / name, package_dir / name)
+
+
 def test_brainlayer_cli_entrypoint_imports_typer_app(monkeypatch) -> None:
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
 
@@ -343,6 +350,24 @@ def test_setup_marks_override_and_canonical_data_roots(tmp_path: Path, monkeypat
     assert (canonical_data_dir / "prompts").is_dir()
 
 
+def test_setup_deduplicates_equivalent_resolved_data_roots(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    canonical_data_dir = tmp_path / "brainlayer"
+    equivalent_data_dir = canonical_data_dir / ".." / "brainlayer"
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: equivalent_data_dir / "brainlayer.db")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+
+    roots = setup_helpers.ensure_spotlight_excluded_layout(
+        runtime_dir=tmp_path / "runtime",
+        launchd_log_dir=tmp_path / "launchd-logs",
+        counter_dir=tmp_path / "counter",
+    )
+
+    assert roots[0] == canonical_data_dir
+    assert roots.count(canonical_data_dir) == 1
+
+
 def test_setup_rejects_override_parent_that_is_not_dedicated_to_brainlayer(tmp_path: Path, monkeypatch) -> None:
     import brainlayer.setup as setup_helpers
 
@@ -377,6 +402,29 @@ def test_setup_rejects_override_parent_that_overlaps_runtime_root(tmp_path: Path
         )
 
     assert not shared_root.exists()
+
+
+def test_setup_rejects_override_parent_that_is_mount_root(tmp_path: Path, monkeypatch) -> None:
+    import brainlayer.setup as setup_helpers
+
+    mount_root = tmp_path / "brainlayer-mounted-volume"
+    canonical_data_dir = tmp_path / "canonical-data"
+    monkeypatch.setattr(setup_helpers, "resolve_db_path", lambda: mount_root / "brainlayer.db")
+    monkeypatch.setattr(setup_helpers, "get_canonical_db_path", lambda: canonical_data_dir / "brainlayer.db")
+    monkeypatch.setattr(
+        setup_helpers.os.path,
+        "ismount",
+        lambda path: Path(path).resolve(strict=False) == mount_root.resolve(strict=False),
+    )
+
+    with pytest.raises(RuntimeError, match="dedicated BrainLayer directory"):
+        setup_helpers.ensure_spotlight_excluded_layout(
+            runtime_dir=tmp_path / "runtime",
+            launchd_log_dir=tmp_path / "launchd-logs",
+            counter_dir=tmp_path / "counter",
+        )
+
+    assert not mount_root.exists()
 
 
 def test_setup_migrates_legacy_raw_socat_mcp_config_idempotently(tmp_path: Path) -> None:
@@ -990,6 +1038,41 @@ def test_launchd_installer_preflights_all_before_loading_without_google_key(tmp_
     assert not list((home / "Library" / "LaunchAgents").glob("com.brainlayer.*.plist"))
 
 
+def test_standalone_launchd_installer_runs_spotlight_preflight_before_mkdir(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_brainlayer = tmp_path / "brainlayer"
+    fake_brainlayer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_brainlayer.chmod(0o755)
+    preflight_log = tmp_path / "preflight.log"
+    python_shim = tmp_path / "python-shim"
+    python_shim.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$*" > "$PREFLIGHT_LOG"\nexit 73\n',
+        encoding="utf-8",
+    )
+    python_shim.chmod(0o755)
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "watch"],
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "BRAINLAYER_BIN": str(fake_brainlayer),
+            "PYTHON_BIN": str(python_shim),
+            "PREFLIGHT_LOG": str(preflight_log),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 73
+    assert "ensure_spotlight_excluded_layout" in preflight_log.read_text(encoding="utf-8")
+    assert not (home / "Library" / "LaunchAgents").exists()
+    assert not (home / ".local" / "share" / "brainlayer").exists()
+
+
 def test_launchd_installer_renders_brainlayer_python_override(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -1032,7 +1115,7 @@ def test_launchd_installer_renders_brainlayer_python_override(tmp_path: Path) ->
 
 def test_packaged_launchd_installer_renders_p0_counter_console_shim(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     launchctl_log = tmp_path / "launchctl.log"
@@ -1084,7 +1167,7 @@ def test_packaged_launchd_installer_renders_p0_counter_console_shim(tmp_path: Pa
 
 def test_packaged_launchd_installer_installs_tier0_watchdog_without_env_runner(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     source_script = REPO_ROOT / "scripts" / "tier0-watchdog.sh"
     assert source_script.exists(), "Tier-0 runtime script is missing"
     shutil.copy2(source_script, launchd_dir / "tier0-watchdog.sh")
@@ -1148,7 +1231,7 @@ def test_packaged_launchd_installer_installs_tier0_watchdog_without_env_runner(t
 
 def test_packaged_launchd_installer_installs_throughput_watchdog(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     source_script = REPO_ROOT / "scripts" / "launchd" / "throughput-watchdog.py"
 
     fake_bin = tmp_path / "bin"
@@ -1207,7 +1290,7 @@ def test_packaged_launchd_installer_installs_throughput_watchdog(tmp_path: Path)
 
 def test_packaged_launchd_installer_installs_hotlane_daemon(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     source_script = REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py"
     shutil.copy2(source_script, launchd_dir / "hotlane_brainbar_daemon.py")
 
@@ -1270,7 +1353,7 @@ def test_packaged_launchd_installer_installs_hotlane_daemon(tmp_path: Path) -> N
 
 def test_hotlane_installer_accepts_resolved_python_interpreter(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     shutil.copy2(
         REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
         launchd_dir / "hotlane_brainbar_daemon.py",
@@ -1323,7 +1406,7 @@ def test_hotlane_installer_accepts_resolved_python_interpreter(tmp_path: Path) -
 
 def test_hotlane_installer_rejects_unload_timeout_before_bootstrap(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     shutil.copy2(
         REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
         launchd_dir / "hotlane_brainbar_daemon.py",
@@ -1384,7 +1467,7 @@ def test_hotlane_installer_rejects_unload_timeout_before_bootstrap(tmp_path: Pat
 
 def test_launchd_installer_derives_unload_window_from_plist_exit_timeout(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -1475,7 +1558,7 @@ def test_launchd_installer_rejects_invalid_unload_attempt_overrides(tmp_path: Pa
     for index, (service, env_name, value) in enumerate(cases):
         case_dir = tmp_path / str(index)
         launchd_dir = case_dir / "site-packages" / "brainlayer" / "launchd"
-        shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+        _copy_packaged_launchd(launchd_dir)
         if service == "hotlane":
             shutil.copy2(
                 REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
@@ -1521,7 +1604,7 @@ def test_launchd_installer_rejects_invalid_unload_attempt_overrides(tmp_path: Pa
 
 def test_hotlane_installer_accepts_supervisor_reload_before_unload_poll(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     shutil.copy2(
         REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
         launchd_dir / "hotlane_brainbar_daemon.py",
@@ -1607,7 +1690,7 @@ def test_hotlane_installer_accepts_supervisor_reload_before_unload_poll(tmp_path
 
 def test_launchd_installer_accepts_supervisor_reload_for_healed_service(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -1682,7 +1765,7 @@ def test_launchd_installer_accepts_supervisor_reload_for_healed_service(tmp_path
 
 def test_hotlane_installer_rejects_pid_change_after_failed_bootout(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     shutil.copy2(
         REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
         launchd_dir / "hotlane_brainbar_daemon.py",
@@ -1760,7 +1843,7 @@ def test_hotlane_installer_rejects_pid_change_after_failed_bootout(tmp_path: Pat
 
 def test_hotlane_installer_rejects_launchd_job_that_is_not_running(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     shutil.copy2(
         REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
         launchd_dir / "hotlane_brainbar_daemon.py",
@@ -1810,7 +1893,7 @@ def test_hotlane_installer_rejects_launchd_job_that_is_not_running(tmp_path: Pat
 
 def test_hotlane_installer_rejects_stable_disabled_env_runner_pid(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     shutil.copy2(
         REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
         launchd_dir / "hotlane_brainbar_daemon.py",
@@ -1866,7 +1949,7 @@ def test_hotlane_installer_rejects_stable_disabled_env_runner_pid(tmp_path: Path
 
 def test_hotlane_installer_accepts_supervisor_bootstrap_race_after_confirmed_unload(tmp_path: Path) -> None:
     launchd_dir = tmp_path / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     shutil.copy2(
         REPO_ROOT / "scripts" / "hotlane_brainbar_daemon.py",
         launchd_dir / "hotlane_brainbar_daemon.py",
@@ -1991,7 +2074,7 @@ def test_launchd_installer_renders_homebrew_opt_symlink_instead_of_cellar_versio
     cellar_root = fake_homebrew / "Cellar" / "brainlayer" / "9.9.9"
     opt_root = fake_homebrew / "opt" / "brainlayer"
     launchd_dir = cellar_root / "libexec" / "lib" / "python3.12" / "site-packages" / "brainlayer" / "launchd"
-    shutil.copytree(REPO_ROOT / "scripts" / "launchd", launchd_dir)
+    _copy_packaged_launchd(launchd_dir)
     opt_root.parent.mkdir(parents=True)
     opt_root.symlink_to(cellar_root)
     fake_bin = tmp_path / "bin"
@@ -2125,6 +2208,7 @@ def test_launchd_installer_does_not_load_services_when_env_runner_install_fails(
             "HOME": str(home),
             "BRAINLAYER_BIN": sys.executable,
             "PYTHON_BIN": sys.executable,
+            "PYTHONPATH": str(REPO_ROOT / "src"),
             "BRAINLAYER_ENV_FILE": str(env_file),
             "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
         },

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1112,19 +1112,22 @@ def test_config_loader_does_not_resolve_op_when_process_env_already_has_key(tmp_
         "export  BRAINLAYER_DB=/ignored/by/launchd/brainlayer.db",
     ],
 )
-def test_config_loader_rejects_db_syntax_that_launchd_parses_differently(
-    tmp_path: Path, monkeypatch, assignment: str
+def test_config_loader_logs_and_falls_back_for_db_syntax_that_launchd_parses_differently(
+    tmp_path: Path, monkeypatch, caplog, assignment: str
 ) -> None:
-    from brainlayer.config import load_brainlayer_env
+    import brainlayer.config as runtime_config
 
     user_env = tmp_path / "brainlayer.env"
     user_env.write_text(f"{assignment}\n", encoding="utf-8")
     monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+    monkeypatch.setattr(runtime_config, "get_user_env_path", lambda: user_env)
+    monkeypatch.setattr(runtime_config, "_brainlayer_db_config_error", None)
 
-    with pytest.raises(RuntimeError, match="launchd and direct CLI"):
-        load_brainlayer_env(user_env)
+    assert runtime_config.load_brainlayer_env() == {}
 
     assert "BRAINLAYER_DB" not in os.environ
+    assert runtime_config.get_brainlayer_db_config_error() is not None
+    assert "falling back to the canonical database" in caplog.text
 
 
 def test_config_loader_ignores_unreadable_user_env(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1224,7 +1224,9 @@ def test_standalone_launchd_installer_preflights_selected_env_db(tmp_path: Path)
     assert not transient_process_data_dir.exists()
 
 
-def test_configured_env_value_matches_selected_file_last_assignment(tmp_path: Path, monkeypatch) -> None:
+def test_configured_env_value_matches_launchd_grammar_and_rejects_runtime_ambiguity(
+    tmp_path: Path, monkeypatch
+) -> None:
     import brainlayer.config as config
 
     env_file = tmp_path / "brainlayer.env"
@@ -1238,7 +1240,14 @@ def test_configured_env_value_matches_selected_file_last_assignment(tmp_path: Pa
         "BRAINLAYER_DB=/from/later/brainlayer.db\n",
         encoding="utf-8",
     )
-    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/later/brainlayer.db"
+    with pytest.raises(RuntimeError, match="duplicate"):
+        config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
+
+    env_file.write_text(
+        "BRAINLAYER_DB=$(not-allowed)\nBRAINLAYER_DB=/from/runtime/brainlayer.db\n",
+        encoding="utf-8",
+    )
+    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/runtime/brainlayer.db"
 
     env_file.write_text(
         "BRAINLAYER_DB=/from/runtime/brainlayer.db\nBRAINLAYER_DB=\"$(op read 'op://Private/Database/path')\"\n",

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1249,7 +1249,12 @@ def test_configured_env_value_matches_selected_file_last_assignment(tmp_path: Pa
         raise AssertionError("BRAINLAYER_DB command substitutions must be skipped")
 
     monkeypatch.setattr(config.subprocess, "run", fail_op_read)
-    assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == "/from/runtime/brainlayer.db"
+    with pytest.raises(RuntimeError, match="command substitution"):
+        config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
+
+    env_file.write_text("BRAINLAYER_DB=\"$(op read 'op://Private/Database/path')\"\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="command substitution"):
+        config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file)
 
     env_file.write_text(r"BRAINLAYER_DB=/Volumes/brainlayer\ data/brainlayer.db" + "\n", encoding="utf-8")
     assert config.configured_brainlayer_env_value("BRAINLAYER_DB", env_file) == (

--- a/tests/test_installable_build.py
+++ b/tests/test_installable_build.py
@@ -1325,6 +1325,94 @@ def test_launchd_teardown_does_not_create_runtime_roots(tmp_path: Path, action: 
     assert not (home / "Library" / "Logs" / "brainlayer").exists()
 
 
+def test_launchd_load_existing_unmarked_install_skips_spotlight_preflight(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    launchctl_log = tmp_path / "launchctl.log"
+    fake_launchctl = fake_bin / "launchctl"
+    fake_launchctl.write_text("\n".join(_fake_launchctl_lines()), encoding="utf-8")
+    fake_launchctl.chmod(0o755)
+    fake_brainlayer = tmp_path / "brainlayer"
+    fake_brainlayer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_brainlayer.chmod(0o755)
+    home = tmp_path / "home"
+    launch_dir = home / "Library" / "LaunchAgents"
+    launch_dir.mkdir(parents=True)
+    (launch_dir / "com.brainlayer.enrichment.plist").write_bytes(
+        plistlib.dumps({"Label": "com.brainlayer.enrichment", "ProgramArguments": ["/usr/bin/true"]})
+    )
+    legacy_data = home / ".local" / "share" / "brainlayer"
+    legacy_data.mkdir(parents=True)
+    (legacy_data / "brainlayer.db").touch()
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "load", "enrichment"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": str(fake_brainlayer),
+            "PYTHON_BIN": sys.executable,
+            "FAKE_LAUNCHCTL_LOG": str(launchctl_log),
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "bootstrap" in launchctl_log.read_text(encoding="utf-8")
+    assert not (legacy_data / ".metadata_never_index").exists()
+
+
+def test_launchd_install_preflight_refusal_names_runbook_without_traceback(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_uname = fake_bin / "uname"
+    fake_uname.write_text("#!/bin/sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+    fake_uname.chmod(0o755)
+    fake_brainlayer = tmp_path / "brainlayer"
+    fake_brainlayer.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_brainlayer.chmod(0o755)
+    home = tmp_path / "home"
+    legacy_data = home / ".local" / "share" / "brainlayer"
+    legacy_data.mkdir(parents=True)
+    (legacy_data / "brainlayer.db").touch()
+
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts" / "launchd" / "install.sh"), "watch"],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "BRAINLAYER_BIN": str(fake_brainlayer),
+            "PYTHON_BIN": sys.executable,
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "docs/operations/spotlight-exclusion-migration.md" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_spotlight_runbook_has_fail_closed_positive_control_and_complete_writer_fence() -> None:
+    runbook = (REPO_ROOT / "docs" / "operations" / "spotlight-exclusion-migration.md").read_text(encoding="utf-8")
+
+    assert "spotlight_positive_control_path" in runbook
+    assert 'spotlight_positive_control_parent="${HOME:?}/Documents"' in runbook
+    assert "/.local/share/brainlayer-spotlight-positive-control" not in runbook
+    assert "SPOTLIGHT PROBE INCONCLUSIVE" in runbook
+    assert "com.mcplayer.brainlayer-proxy" in runbook
+    assert "com.brainlayer.gemini-loopback" in runbook
+    assert "com.brainlayer.t3-ingest" in runbook
+    assert "-iTCP:48123" in runbook
+
+
 def test_launchd_installer_renders_brainlayer_python_override(tmp_path: Path) -> None:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -14,9 +14,10 @@ class TestGetDbPath:
 
     def test_env_var_override(self, tmp_path):
         """BRAINLAYER_DB env var takes highest priority."""
-        db_path = tmp_path / "custom.db"
+        db_path = tmp_path / "missing-parent" / "custom.db"
         with patch.dict(os.environ, {"BRAINLAYER_DB": str(db_path)}):
             assert get_db_path() == db_path
+            assert not db_path.parent.exists()
 
     def test_canonical_path_fresh_install(self, tmp_path, monkeypatch):
         """Canonical path used when no DB exists yet."""

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -19,6 +19,13 @@ class TestGetDbPath:
             assert get_db_path() == db_path
             assert not db_path.parent.exists()
 
+    def test_env_var_override_expands_home(self, tmp_path, monkeypatch):
+        """Runtime resolution matches the Spotlight preflight for tilde paths."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("BRAINLAYER_DB", "~/brainlayer-data/brainlayer.db")
+
+        assert resolve_db_path() == tmp_path / "brainlayer-data" / "brainlayer.db"
+
     def test_canonical_path_fresh_install(self, tmp_path, monkeypatch):
         """Canonical path used when no DB exists yet."""
         canonical = tmp_path / "brainlayer" / "brainlayer.db"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+import brainlayer.paths as brainlayer_paths
 from brainlayer.paths import get_db_path
 
 
@@ -33,3 +34,26 @@ class TestGetDbPath:
 
         assert DEFAULT_DB_PATH.exists(), f"DB not found at {DEFAULT_DB_PATH}"
         assert DEFAULT_DB_PATH.stat().st_size > 1_000_000, "DB too small — might be empty"
+
+
+def test_spotlight_exclusion_accepts_marker_on_directory(tmp_path):
+    marker_name = ".metadata_never_index"
+    (tmp_path / marker_name).touch()
+
+    assert brainlayer_paths.is_spotlight_excluded(tmp_path)
+
+
+def test_spotlight_exclusion_accepts_marker_on_ancestor(tmp_path):
+    marker_name = ".metadata_never_index"
+    (tmp_path / marker_name).touch()
+    child = tmp_path / "logs" / "nested"
+    child.mkdir(parents=True)
+
+    assert brainlayer_paths.is_spotlight_excluded(child)
+
+
+def test_spotlight_exclusion_rejects_unmarked_path(tmp_path):
+    child = tmp_path / "queue"
+    child.mkdir()
+
+    assert not brainlayer_paths.is_spotlight_excluded(child)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 import brainlayer.paths as brainlayer_paths
-from brainlayer.paths import get_db_path
+from brainlayer.paths import get_db_path, resolve_db_path
 
 
 class TestGetDbPath:
@@ -26,6 +26,14 @@ class TestGetDbPath:
             result = get_db_path()
             assert result == canonical
             assert canonical.parent.exists()  # Parent dir created
+
+    def test_resolve_db_path_does_not_create_parent(self, tmp_path, monkeypatch):
+        canonical = tmp_path / "brainlayer" / "brainlayer.db"
+        with patch("brainlayer.paths._CANONICAL_DB_PATH", canonical):
+            monkeypatch.delenv("BRAINLAYER_DB", raising=False)
+
+            assert resolve_db_path() == canonical
+            assert not canonical.parent.exists()
 
     @pytest.mark.integration
     def test_real_db_exists(self):


### PR DESCRIPTION
## Summary

- create `.metadata_never_index`-backed roots for every high-churn BrainLayer data/runtime location before macOS setup or init starts services, including both canonical and overridden DB roots
- refuse to mutate nonempty legacy trees and make `brainlayer doctor` warn when the active data directory is not excluded or cannot be checked
- document a READY checkpoint/stop/migrate/restart/verify/rollback runbook with exact partial-state recovery, a complete writer fence, and a fail-closed same-volume positive control

## Safety

- the canonical live BrainLayer data directory was not migrated or modified
- the live migration is explicitly deferred to an approved writer-stop window
- release PRs #705 and #707 merged first; this final head incorporates the v1.5.6 mainline
- pair review V2 declared the shipped code mergeable but found runbook-only execution defects; the live runbook remains blocked pending the immediately-following docs-only V3 delta

## Verification

- focused Spotlight suites: 162 passed
- final exact-head pre-push gate: 3,986 passed, 10 skipped, 61 deselected, 2 xfailed
- MCP registration: 3 passed; isolated eval/hook routing: 40 passed; Bun: 1 passed; FTS5 shell regression: passed
- Ruff, format check, `git diff --check`: clean
- prior hosted code findings were addressed; ambiguous duplicate DB assignments and op-backed DB paths now fail preflight rather than choosing between launchd and direct-Python semantics

— brainlayer-worker-1ciwjp (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayer-worker-1ciwjp","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feca9","ts":"2026-08-11T10:16:31Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches setup, launchd install, env DB loading, and path resolution on macOS; misconfiguration or legacy-tree refusal could block installs until migration, but live data is not modified by this PR.
> 
> **Overview**
> Adds **macOS Spotlight exclusion** for BrainLayer’s high-churn runtime trees using `.metadata_never_index`, wired into setup, launchd install, and doctor—without migrating live production data in this PR.
> 
> **Runtime behavior:** New `spotlight.py` layout preflight creates marker-backed roots (data, `~/.brainlayer`, launchd logs, P0 counter) before children, validates `BRAINLAYER_DB` override safety, and **refuses** to touch nonempty legacy trees (points operators at the migration runbook). `brainlayer setup` / `init` run this first on Darwin; `install.sh` runs the same Python preflight before `mkdir` for install actions (skipped for `remove`/`unload`/`load`). `paths` gains `is_spotlight_excluded`; `resolve_db_path` / `DEFAULT_DB_PATH` no longer create dirs at import.
> 
> **Doctor & config:** Darwin doctor warns on `spotlight_indexing_enabled` when the active DB directory isn’t excluded, and fatals on `brainlayer_db_config_invalid` when env `BRAINLAYER_DB` is ambiguous or launchd-incompatible—`load_brainlayer_env` now aligns DB parsing with launchd grammar and records fallback errors.
> 
> **Ops docs:** Adds design/plan docs and a **READY** writer-stop migration runbook (WAL checkpoint, full writer fence, stage/rename/mark/restore, fail-closed Spotlight probe with same-volume positive control, rollback).
> 
> **Tests:** Extensive pytest coverage for layout edge cases, CLI ordering, launchd preflight, config/DB validation, and runbook invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8cb0b6f4ff697faf942a7dfd003ae870acdd26d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude runtime data directories from macOS Spotlight indexing during setup
> - Adds `brainlayer.spotlight.ensure_spotlight_excluded_layout` to create and validate Spotlight-excluded root directories by placing `.metadata_never_index` markers; the function validates each root is disjoint, non-overlapping, and not under a symlink or shared parent.
> - Integrates the preflight into the `init` and `setup` CLI commands on Darwin, and into `scripts/launchd/install.sh` before any directory creation.
> - Adds `brainlayer.paths.is_spotlight_excluded` to check whether a path is under an excluded root, and `brainlayer.doctor` now warns when the data directory is not excluded and reports a fatal error when `BRAINLAYER_DB` config is ambiguous between launchd and direct parsing.
> - Adds `config.configured_brainlayer_env_value` to strictly parse and validate launchd-compatible env assignments, rejecting command substitutions, duplicates, and ambiguous quoting.
> - Risk: installs on macOS with pre-existing non-excluded runtime trees will fail the preflight and require a manual migration runbook before installation can proceed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8cb0b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->