### PR TITLE
chore(release): bump BrainLayer and BrainBar to 1.5.6

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,11 +9,11 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.5.5</string>
+    <string>1.5.6</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.5</string>
+    <string>1.5.6</string>
     <key>BrainLayerReleaseVersion</key>
-    <string>1.5.5</string>
+    <string>1.5.6</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.5.5"
+version = "1.5.6"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"


### PR DESCRIPTION
## Summary

- bump BrainLayer and BrainBar metadata from 1.5.5 to 1.5.6
- preserve the normal main lineage carrying the dormant, schema-absent-compatible Swift source-class gate from #700/#703
- supersede the burned v1.5.4 and deployed v1.5.5 recovery artifacts without changing runtime code

## Release context

v1.5.5 shipped the #693 deferred-receipt wording, #698 scheduled-backup core-profile allowance, and #701 MCP queue-starvation fix. v1.5.6 is the required metadata-only follow-up for the Wave 3a exact-version contract.

## Verification

- exact diff: 7 literal `1.5.5` → `1.5.6` substitutions, zero runtime code
- full pre-push unit suite: 3,947 passed, 10 skipped, 61 deselected, 2 xfailed
- MCP registration: 3/3
- isolated eval/routing: 40/40
- Bun and FTS5 shell regression gates: passed

— brainlayer-worker-ygt7ve (worker) · codex/gpt-5.6-sol

<!-- golem-id v1 {"seat":"brainlayer-worker-ygt7ve","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019feaca","ts":"2026-08-10T21:00:00Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Seven literal version-string updates with no runtime, security, or data-path changes.
> 
> **Overview**
> **Metadata-only release:** every `1.5.5` version string is updated to **`1.5.6`** across BrainBar (`Info.plist` bundle/build/`BrainLayerReleaseVersion`), Python packaging (`pyproject.toml`, `__version__`), and MCP registry (`server.json` top-level and PyPI package entry).
> 
> No application or server logic changes in this diff—only version alignment for the Wave 3a exact-version contract after v1.5.5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407f99400498e075e88f619e455a457e193ae8a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump BrainLayer and BrainBar version to 1.5.6
> Updates version strings from 1.5.5 to 1.5.6 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/707/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/707/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/707/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/707/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 407f994.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->