### PR TITLE
fix(brainbar): unblock dashboard and menubar graphs

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift
@@ -394,6 +394,7 @@ private struct BrainBarDashboardView: View {
             totalCount: collector.stats.signalEligibleChunkCount,
             backlogCount: collector.stats.vectorBacklogCount,
             coveragePercent: collector.stats.vectorCoveragePercent,
+            isAvailable: collector.stats.signalCoverageIsAvailable,
             accentColor: .brainBarSignalVector,
             showsDetail: true,
             vectorNetDrainRatePerHour: collector.stats.vectorNetDrainRatePerHour,
@@ -1171,6 +1172,7 @@ private struct BrainBarSignalCoveragePanel: View {
                 totalCount: stats.signalEligibleChunkCount,
                 backlogCount: stats.vectorBacklogCount,
                 coveragePercent: stats.vectorCoveragePercent,
+                isAvailable: stats.signalCoverageIsAvailable,
                 accentColor: .brainBarSignalVector,
                 showsDetail: true,
                 vectorNetDrainRatePerHour: stats.vectorNetDrainRatePerHour,
@@ -1182,6 +1184,7 @@ private struct BrainBarSignalCoveragePanel: View {
                 totalCount: stats.signalEligibleChunkCount,
                 backlogCount: stats.ftsBacklogCount,
                 coveragePercent: stats.ftsCoveragePercent,
+                isAvailable: stats.signalCoverageIsAvailable,
                 accentColor: .brainBarSignalFTS5,
                 showsDetail: false,
                 vectorNetDrainRatePerHour: nil,
@@ -1193,6 +1196,7 @@ private struct BrainBarSignalCoveragePanel: View {
                 totalCount: stats.signalEligibleChunkCount,
                 backlogCount: stats.trigramBacklogCount,
                 coveragePercent: stats.trigramCoveragePercent,
+                isAvailable: stats.signalCoverageIsAvailable,
                 accentColor: .brainBarSignalTrigram,
                 showsDetail: false,
                 vectorNetDrainRatePerHour: nil,
@@ -1416,6 +1420,7 @@ private struct BrainBarSignalCoverage: Identifiable {
     let totalCount: Int
     let backlogCount: Int
     let coveragePercent: Double
+    let isAvailable: Bool
     let accentColor: Color
     let showsDetail: Bool
     let vectorNetDrainRatePerHour: Double?
@@ -1424,7 +1429,8 @@ private struct BrainBarSignalCoverage: Identifiable {
     var id: String { name }
 
     var percentText: String {
-        String(format: "%.0f%%", coveragePercent)
+        guard isAvailable else { return "computing…" }
+        return String(format: "%.0f%%", coveragePercent)
     }
 
     var clampedCoveragePercent: Double {
@@ -1432,7 +1438,8 @@ private struct BrainBarSignalCoverage: Identifiable {
     }
 
     var backlogText: String {
-        NumberFormatter.localizedString(from: NSNumber(value: backlogCount), number: .decimal)
+        guard isAvailable else { return "computing…" }
+        return NumberFormatter.localizedString(from: NSNumber(value: backlogCount), number: .decimal)
     }
 }
 
@@ -1455,8 +1462,14 @@ private struct BrainBarSignalCoverageRow: View {
                     .monospacedDigit()
             }
 
-            BrainBarAnimatedCoverageBar(percent: signal.clampedCoveragePercent, accentColor: signal.accentColor)
-            .frame(height: 6)
+            if signal.isAvailable {
+                BrainBarAnimatedCoverageBar(percent: signal.clampedCoveragePercent, accentColor: signal.accentColor)
+                    .frame(height: 6)
+            } else {
+                Capsule()
+                    .fill(signal.accentColor.opacity(0.16))
+                    .frame(height: 6)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -2301,7 +2301,11 @@ final class BrainDatabase: @unchecked Sendable {
         ftsIndexedChunkCount: Int,
         trigramIndexedChunkCount: Int
     ) {
+        guard let db else { throw DBError.notOpen }
         let searchableWhereClause = try searchableChunkWhereClause(alias: "c")
+        let mappedFTSColumns = try tableExists("chunk_fts_rowids")
+            ? try tableColumns(name: "chunk_fts_rowids", on: db)
+            : []
         return (
             eligibleChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks AS c WHERE \(searchableWhereClause)"),
             vectorIndexedChunkCount: try joinedCoverageCount(
@@ -2309,17 +2313,30 @@ final class BrainDatabase: @unchecked Sendable {
                 idColumn: "id",
                 searchableWhereClause: searchableWhereClause
             ),
-            ftsIndexedChunkCount: try joinedCoverageCount(
-                tableName: "chunks_fts",
-                idColumn: "chunk_id",
-                searchableWhereClause: searchableWhereClause
-            ),
-            trigramIndexedChunkCount: try joinedCoverageCount(
-                tableName: "chunks_fts_trigram",
-                idColumn: "chunk_id",
-                searchableWhereClause: searchableWhereClause
-            )
+            ftsIndexedChunkCount: mappedFTSColumns.contains("fts_rowid")
+                ? try mappedFTSRowCount(rowIDColumn: "fts_rowid")
+                : try joinedCoverageCount(
+                    tableName: "chunks_fts",
+                    idColumn: "chunk_id",
+                    searchableWhereClause: searchableWhereClause
+                ),
+            trigramIndexedChunkCount: mappedFTSColumns.contains("trigram_rowid")
+                ? try mappedFTSRowCount(rowIDColumn: "trigram_rowid")
+                : try joinedCoverageCount(
+                    tableName: "chunks_fts_trigram",
+                    idColumn: "chunk_id",
+                    searchableWhereClause: searchableWhereClause
+                )
         )
+    }
+
+    private func mappedFTSRowCount(rowIDColumn: String) throws -> Int {
+        guard ["fts_rowid", "trigram_rowid"].contains(rowIDColumn) else {
+            throw DBError.exec(SQLITE_ERROR, "invalid FTS rowid map column")
+        }
+        // This map is trigger-maintained and keyed by chunk_id. Rejoining it to chunks would
+        // reintroduce the content-heavy scan this dashboard path exists to avoid.
+        return try scalarInt("SELECT COUNT(*) FROM chunk_fts_rowids WHERE \(rowIDColumn) IS NOT NULL")
     }
 
     private func joinedCoverageCount(tableName: String, idColumn: String, searchableWhereClause: String) throws -> Int {

--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -72,6 +72,13 @@ final class BrainDatabase: @unchecked Sendable {
         }
     }
 
+    struct SignalCoverageSnapshot: Sendable, Equatable {
+        let eligibleChunkCount: Int
+        let vectorIndexedChunkCount: Int
+        let ftsIndexedChunkCount: Int
+        let trigramIndexedChunkCount: Int
+    }
+
     struct DashboardStats: Sendable, Equatable {
         struct WatcherHealth: Sendable, Equatable {
             let alerting: Bool
@@ -139,6 +146,7 @@ final class BrainDatabase: @unchecked Sendable {
         let vectorIndexedChunkCount: Int
         let ftsIndexedChunkCount: Int
         let trigramIndexedChunkCount: Int
+        let signalCoverageIsAvailable: Bool
         let pendingStoreQueueDepth: Int
         let pendingStoreFlushQueueDepth: Int
         let pendingStoreOldestQueuedAt: Date?
@@ -173,6 +181,7 @@ final class BrainDatabase: @unchecked Sendable {
             vectorIndexedChunkCount: Int = 0,
             ftsIndexedChunkCount: Int = 0,
             trigramIndexedChunkCount: Int = 0,
+            signalCoverageIsAvailable: Bool = true,
             pendingStoreQueueDepth: Int = 0,
             pendingStoreFlushQueueDepth: Int? = nil,
             pendingStoreOldestQueuedAt: Date? = nil,
@@ -206,6 +215,7 @@ final class BrainDatabase: @unchecked Sendable {
             self.vectorIndexedChunkCount = vectorIndexedChunkCount
             self.ftsIndexedChunkCount = ftsIndexedChunkCount
             self.trigramIndexedChunkCount = trigramIndexedChunkCount
+            self.signalCoverageIsAvailable = signalCoverageIsAvailable
             self.pendingStoreQueueDepth = pendingStoreQueueDepth
             self.pendingStoreFlushQueueDepth = pendingStoreFlushQueueDepth ?? pendingStoreQueueDepth
             self.pendingStoreOldestQueuedAt = pendingStoreOldestQueuedAt
@@ -343,6 +353,7 @@ final class BrainDatabase: @unchecked Sendable {
                 vectorIndexedChunkCount: vectorIndexedChunkCount,
                 ftsIndexedChunkCount: ftsIndexedChunkCount,
                 trigramIndexedChunkCount: trigramIndexedChunkCount,
+                signalCoverageIsAvailable: signalCoverageIsAvailable,
                 pendingStoreQueueDepth: pendingStoreQueueDepth,
                 pendingStoreFlushQueueDepth: pendingStoreFlushQueueDepth,
                 pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
@@ -380,6 +391,7 @@ final class BrainDatabase: @unchecked Sendable {
                 vectorIndexedChunkCount: vectorIndexedChunkCount,
                 ftsIndexedChunkCount: ftsIndexedChunkCount,
                 trigramIndexedChunkCount: trigramIndexedChunkCount,
+                signalCoverageIsAvailable: signalCoverageIsAvailable,
                 pendingStoreQueueDepth: pendingStoreQueueDepth,
                 pendingStoreFlushQueueDepth: pendingStoreFlushQueueDepth,
                 pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
@@ -417,6 +429,7 @@ final class BrainDatabase: @unchecked Sendable {
                 vectorIndexedChunkCount: vectorIndexedChunkCount,
                 ftsIndexedChunkCount: ftsIndexedChunkCount,
                 trigramIndexedChunkCount: trigramIndexedChunkCount,
+                signalCoverageIsAvailable: signalCoverageIsAvailable,
                 pendingStoreQueueDepth: pendingStoreQueueDepth,
                 pendingStoreFlushQueueDepth: pendingStoreFlushQueueDepth,
                 pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
@@ -426,6 +439,54 @@ final class BrainDatabase: @unchecked Sendable {
                 watcherProcessProbeResult: result,
                 watcherRecentDistinctChunkCount: watcherRecentDistinctChunkCount,
                 watcherFlowReadability: watcherFlowReadability
+            )
+        }
+
+        func withSignalCoverage(_ coverage: SignalCoverageSnapshot) -> DashboardStats {
+            DashboardStats(
+                chunkCount: chunkCount,
+                enrichedChunkCount: enrichedChunkCount,
+                failedEnrichmentCount: failedEnrichmentCount,
+                skippedEnrichmentCount: skippedEnrichmentCount,
+                pendingEnrichmentCount: pendingEnrichmentCount,
+                enrichmentPercent: enrichmentPercent,
+                enrichmentRatePerMinute: enrichmentRatePerMinute,
+                databaseSizeBytes: databaseSizeBytes,
+                recentActivityBuckets: recentActivityBuckets,
+                recentAgentWriteBuckets: recentAgentWriteBuckets,
+                recentWatcherWriteBuckets: recentWatcherWriteBuckets,
+                recentEnrichmentBuckets: recentEnrichmentBuckets,
+                recentWriteFiveMinuteCount: recentWriteFiveMinuteCount,
+                recentEnrichmentFiveMinuteCount: recentEnrichmentFiveMinuteCount,
+                activityWindowMinutes: activityWindowMinutes,
+                bucketCount: bucketCount,
+                liveWindowMinutes: liveWindowMinutes,
+                lastWriteAt: lastWriteAt,
+                lastEnrichedAt: lastEnrichedAt,
+                signalEligibleChunkCount: coverage.eligibleChunkCount,
+                vectorIndexedChunkCount: coverage.vectorIndexedChunkCount,
+                ftsIndexedChunkCount: coverage.ftsIndexedChunkCount,
+                trigramIndexedChunkCount: coverage.trigramIndexedChunkCount,
+                signalCoverageIsAvailable: true,
+                pendingStoreQueueDepth: pendingStoreQueueDepth,
+                pendingStoreFlushQueueDepth: pendingStoreFlushQueueDepth,
+                pendingStoreOldestQueuedAt: pendingStoreOldestQueuedAt,
+                pendingStoreFlushRatePerMinute: pendingStoreFlushRatePerMinute,
+                watcherHealth: watcherHealth,
+                replayDebtBreakdown: replayDebtBreakdown,
+                watcherProcessProbeResult: watcherProcessProbeResult,
+                watcherRecentDistinctChunkCount: watcherRecentDistinctChunkCount,
+                watcherFlowReadability: watcherFlowReadability
+            )
+        }
+
+        var signalCoverageSnapshot: SignalCoverageSnapshot? {
+            guard signalCoverageIsAvailable else { return nil }
+            return SignalCoverageSnapshot(
+                eligibleChunkCount: signalEligibleChunkCount,
+                vectorIndexedChunkCount: vectorIndexedChunkCount,
+                ftsIndexedChunkCount: ftsIndexedChunkCount,
+                trigramIndexedChunkCount: trigramIndexedChunkCount
             )
         }
     }
@@ -2039,7 +2100,11 @@ final class BrainDatabase: @unchecked Sendable {
         return Int(sqlite3_column_int(stmt, 0))
     }
 
-    func dashboardStats(activityWindowMinutes: Int = 30, bucketCount: Int = 12) throws -> DashboardStats {
+    func dashboardStats(
+        activityWindowMinutes: Int = 30,
+        bucketCount: Int = 12,
+        includeSignalCoverage: Bool = true
+    ) throws -> DashboardStats {
         let replayDebtBreakdown = replayDebtBreakdown()
         let pendingStoreFlushQueue = replayDebtBreakdown.pendingStores.snapshot
         let pendingStoreQueue = replayDebtBreakdown.deduplicatedSnapshot
@@ -2067,7 +2132,18 @@ final class BrainDatabase: @unchecked Sendable {
             }
 
             let counts = try dashboardCounts()
-            let signalCounts = try dashboardSignalCoverageCounts()
+            let signalCoverage: SignalCoverageSnapshot?
+            if includeSignalCoverage {
+                let counts = try dashboardSignalCoverageCounts()
+                signalCoverage = SignalCoverageSnapshot(
+                    eligibleChunkCount: counts.eligibleChunkCount,
+                    vectorIndexedChunkCount: counts.vectorIndexedChunkCount,
+                    ftsIndexedChunkCount: counts.ftsIndexedChunkCount,
+                    trigramIndexedChunkCount: counts.trigramIndexedChunkCount
+                )
+            } else {
+                signalCoverage = nil
+            }
             let lastEvents = try dashboardLastEvents(now: now)
             let chunkCount = counts.chunkCount
             let enrichedChunkCount = counts.enrichedChunkCount
@@ -2123,10 +2199,11 @@ final class BrainDatabase: @unchecked Sendable {
                 liveWindowMinutes: liveWindowMinutes,
                 lastWriteAt: lastEvents.lastWriteAt,
                 lastEnrichedAt: lastEvents.lastEnrichedAt,
-                signalEligibleChunkCount: signalCounts.eligibleChunkCount,
-                vectorIndexedChunkCount: signalCounts.vectorIndexedChunkCount,
-                ftsIndexedChunkCount: signalCounts.ftsIndexedChunkCount,
-                trigramIndexedChunkCount: signalCounts.trigramIndexedChunkCount,
+                signalEligibleChunkCount: signalCoverage?.eligibleChunkCount ?? 0,
+                vectorIndexedChunkCount: signalCoverage?.vectorIndexedChunkCount ?? 0,
+                ftsIndexedChunkCount: signalCoverage?.ftsIndexedChunkCount ?? 0,
+                trigramIndexedChunkCount: signalCoverage?.trigramIndexedChunkCount ?? 0,
+                signalCoverageIsAvailable: signalCoverage != nil,
                 pendingStoreQueueDepth: pendingStoreQueue.depth,
                 pendingStoreFlushQueueDepth: pendingStoreFlushQueue.depth,
                 pendingStoreOldestQueuedAt: pendingStoreQueue.oldestQueuedAt,
@@ -2134,6 +2211,18 @@ final class BrainDatabase: @unchecked Sendable {
                 replayDebtBreakdown: replayDebtBreakdown,
                 watcherRecentDistinctChunkCount: recentWatcherTruth.total,
                 watcherFlowReadability: recentWatcherTruth.readability
+            )
+        }
+    }
+
+    func dashboardSignalCoverageSnapshot() throws -> SignalCoverageSnapshot {
+        try withReadTransaction {
+            let counts = try dashboardSignalCoverageCounts()
+            return SignalCoverageSnapshot(
+                eligibleChunkCount: counts.eligibleChunkCount,
+                vectorIndexedChunkCount: counts.vectorIndexedChunkCount,
+                ftsIndexedChunkCount: counts.ftsIndexedChunkCount,
+                trigramIndexedChunkCount: counts.trigramIndexedChunkCount
             )
         }
     }
@@ -2301,11 +2390,7 @@ final class BrainDatabase: @unchecked Sendable {
         ftsIndexedChunkCount: Int,
         trigramIndexedChunkCount: Int
     ) {
-        guard let db else { throw DBError.notOpen }
         let searchableWhereClause = try searchableChunkWhereClause(alias: "c")
-        let mappedFTSColumns = try tableExists("chunk_fts_rowids")
-            ? try tableColumns(name: "chunk_fts_rowids", on: db)
-            : []
         return (
             eligibleChunkCount: try scalarInt("SELECT COUNT(*) FROM chunks AS c WHERE \(searchableWhereClause)"),
             vectorIndexedChunkCount: try joinedCoverageCount(
@@ -2313,30 +2398,17 @@ final class BrainDatabase: @unchecked Sendable {
                 idColumn: "id",
                 searchableWhereClause: searchableWhereClause
             ),
-            ftsIndexedChunkCount: mappedFTSColumns.contains("fts_rowid")
-                ? try mappedFTSRowCount(rowIDColumn: "fts_rowid")
-                : try joinedCoverageCount(
-                    tableName: "chunks_fts",
-                    idColumn: "chunk_id",
-                    searchableWhereClause: searchableWhereClause
-                ),
-            trigramIndexedChunkCount: mappedFTSColumns.contains("trigram_rowid")
-                ? try mappedFTSRowCount(rowIDColumn: "trigram_rowid")
-                : try joinedCoverageCount(
-                    tableName: "chunks_fts_trigram",
-                    idColumn: "chunk_id",
-                    searchableWhereClause: searchableWhereClause
-                )
+            ftsIndexedChunkCount: try joinedCoverageCount(
+                tableName: "chunks_fts",
+                idColumn: "chunk_id",
+                searchableWhereClause: searchableWhereClause
+            ),
+            trigramIndexedChunkCount: try joinedCoverageCount(
+                tableName: "chunks_fts_trigram",
+                idColumn: "chunk_id",
+                searchableWhereClause: searchableWhereClause
+            )
         )
-    }
-
-    private func mappedFTSRowCount(rowIDColumn: String) throws -> Int {
-        guard ["fts_rowid", "trigram_rowid"].contains(rowIDColumn) else {
-            throw DBError.exec(SQLITE_ERROR, "invalid FTS rowid map column")
-        }
-        // This map is trigger-maintained and keyed by chunk_id. Rejoining it to chunks would
-        // reintroduce the content-heavy scan this dashboard path exists to avoid.
-        return try scalarInt("SELECT COUNT(*) FROM chunk_fts_rowids WHERE \(rowIDColumn) IS NOT NULL")
     }
 
     private func joinedCoverageCount(tableName: String, idColumn: String, searchableWhereClause: String) throws -> Int {

--- a/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
+++ b/brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift
@@ -162,6 +162,8 @@ private func statsCollectorDarwinNotificationCallback(
 
 @MainActor
 final class StatsCollector: ObservableObject {
+    typealias DashboardStatsProvider = @Sendable () throws -> DashboardStats
+    typealias SignalCoverageProvider = @Sendable () throws -> BrainDatabase.SignalCoverageSnapshot
     typealias WindowedBucketsProvider = @Sendable (
         _ windowMinutes: Int,
         _ bucketCount: Int
@@ -170,6 +172,8 @@ final class StatsCollector: ObservableObject {
     static let defaultActivityWindowMinutes = 60
     static let defaultBucketCount = 12
     static let snapshotFreshnessThreshold: TimeInterval = 60
+    static let defaultSignalCoverageStartDelay: TimeInterval = 2
+    static let defaultSignalCoverageRefreshInterval: TimeInterval = 300
 
     @Published private(set) var stats: DashboardStats
     @Published private(set) var daemon: DaemonHealthSnapshot?
@@ -182,6 +186,8 @@ final class StatsCollector: ObservableObject {
     @Published private(set) var lastFetchError: String?
     @Published private(set) var snapshotFreshnessState: SnapshotFreshnessState
     @Published private(set) var heartbeat: DashboardHeartbeat
+    @Published private(set) var isSignalCoverageRefreshing = false
+    @Published private(set) var lastSignalCoverageError: String?
     /// REAL windowed buckets for the shared Live/3h/24h selector. `nil` means
     /// "no wider window selected yet" — the views fall back to the live `stats`
     /// buckets (the resting 1h view). When the selector picks 3h/24h, the view
@@ -199,6 +205,10 @@ final class StatsCollector: ObservableObject {
     private let databaseOpenConfiguration: BrainDatabase.OpenConfiguration
     private let daemonMonitor: DaemonHealthMonitor
     private let watcherProcessProbe: any WatcherProcessProbing
+    private let dashboardStatsProvider: DashboardStatsProvider
+    private let signalCoverageProvider: SignalCoverageProvider
+    private let signalCoverageStartDelay: TimeInterval
+    private let signalCoverageRefreshInterval: TimeInterval
     private let windowedBucketsProvider: WindowedBucketsProvider
     private let agentActivityMonitor: AgentActivityMonitor
     private let agentActivitySampleInterval: TimeInterval
@@ -216,6 +226,9 @@ final class StatsCollector: ObservableObject {
     private var pendingStatsRefreshBypassesCoalescing = false
     private var dashboardRefreshTask: Task<Void, Never>?
     private var dashboardRefreshGeneration = 0
+    private var signalCoverageTask: Task<Void, Never>?
+    private var signalCoverageGeneration = 0
+    private var lastSignalCoverageAttemptedAt: Date?
     private var watcherProcessRefreshTask: Task<Void, Never>?
     private var watcherProcessRefreshGeneration = 0
     private var isRunning = false
@@ -240,6 +253,10 @@ final class StatsCollector: ObservableObject {
         freshnessTickerInterval: TimeInterval = 1,
         nowProvider: @escaping () -> Date = Date.init,
         brainBusEvents: BrainBusEventSource? = nil,
+        dashboardStatsProvider: DashboardStatsProvider? = nil,
+        signalCoverageProvider: SignalCoverageProvider? = nil,
+        signalCoverageStartDelay: TimeInterval = 2,
+        signalCoverageRefreshInterval: TimeInterval = 300,
         windowedBucketsProvider: WindowedBucketsProvider? = nil,
         databaseOpenConfiguration: BrainDatabase.OpenConfiguration = BrainDatabase.OpenConfiguration()
     ) {
@@ -247,6 +264,26 @@ final class StatsCollector: ObservableObject {
         self.databaseOpenConfiguration = databaseOpenConfiguration
         self.daemonMonitor = daemonMonitor
         self.watcherProcessProbe = watcherProcessProbe
+        let defaultActivityWindowMinutes = Self.defaultActivityWindowMinutes
+        let defaultBucketCount = Self.defaultBucketCount
+        self.dashboardStatsProvider = dashboardStatsProvider ?? {
+            let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
+            defer { backgroundDatabase.close() }
+            backgroundDatabase.reopenIfNeeded()
+            return try backgroundDatabase.dashboardStats(
+                activityWindowMinutes: defaultActivityWindowMinutes,
+                bucketCount: defaultBucketCount,
+                includeSignalCoverage: false
+            )
+        }
+        self.signalCoverageProvider = signalCoverageProvider ?? {
+            let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
+            defer { backgroundDatabase.close() }
+            backgroundDatabase.reopenIfNeeded()
+            return try backgroundDatabase.dashboardSignalCoverageSnapshot()
+        }
+        self.signalCoverageStartDelay = max(0, signalCoverageStartDelay)
+        self.signalCoverageRefreshInterval = max(1, signalCoverageRefreshInterval)
         self.windowedBucketsProvider = windowedBucketsProvider ?? { windowMinutes, bucketCount in
             let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: databaseOpenConfiguration)
             defer { backgroundDatabase.close() }
@@ -274,7 +311,9 @@ final class StatsCollector: ObservableObject {
             recentActivityBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
             recentEnrichmentBuckets: Array(repeating: 0, count: Self.defaultBucketCount),
             activityWindowMinutes: Self.defaultActivityWindowMinutes,
-            bucketCount: Self.defaultBucketCount
+            bucketCount: Self.defaultBucketCount,
+            signalEligibleChunkCount: 0,
+            signalCoverageIsAvailable: false
         )
         self.agentActivity = .empty
         self.state = .degraded
@@ -320,6 +359,10 @@ final class StatsCollector: ObservableObject {
         freshnessTicker = nil
         dashboardRefreshTask?.cancel()
         dashboardRefreshTask = nil
+        signalCoverageTask?.cancel()
+        signalCoverageTask = nil
+        signalCoverageGeneration += 1
+        isSignalCoverageRefreshing = false
         watcherProcessRefreshTask?.cancel()
         watcherProcessRefreshTask = nil
         watcherProcessRefreshGeneration += 1
@@ -437,10 +480,7 @@ final class StatsCollector: ObservableObject {
         watcherProcessRefreshGeneration += 1
         let watcherProcessGeneration = watcherProcessRefreshGeneration
         let generation = dashboardRefreshGeneration
-        let dbPath = self.dbPath
-        let openConfiguration = self.databaseOpenConfiguration
-        let activityWindowMinutes = Self.defaultActivityWindowMinutes
-        let bucketCount = Self.defaultBucketCount
+        let dashboardStatsProvider = self.dashboardStatsProvider
         let startStats = stats
         let watcherProcessProbe = self.watcherProcessProbe
         let startUnix = snapshotTime.timeIntervalSince1970
@@ -464,13 +504,7 @@ final class StatsCollector: ObservableObject {
         dashboardRefreshTask = Task.detached(priority: .utility) { [weak self] in
             let nextWatcherProcess = watcherProcessProbe.sample()
             let result: Result<DashboardStats, Error> = Result {
-                let backgroundDatabase = BrainDatabase(path: dbPath, openConfiguration: openConfiguration)
-                defer { backgroundDatabase.close() }
-                backgroundDatabase.reopenIfNeeded()
-                return try backgroundDatabase.dashboardStats(
-                    activityWindowMinutes: activityWindowMinutes,
-                    bucketCount: bucketCount
-                )
+                try dashboardStatsProvider()
             }
 
             await self?.finishRequestedRefreshIfCurrent(
@@ -484,6 +518,54 @@ final class StatsCollector: ObservableObject {
                 generation: generation,
                 watcherProcessGeneration: watcherProcessGeneration
             )
+        }
+    }
+
+    private func requestSignalCoverageRefresh(force: Bool) {
+        guard signalCoverageTask == nil else { return }
+        let now = nowProvider()
+        if !force, let lastSignalCoverageAttemptedAt,
+           now.timeIntervalSince(lastSignalCoverageAttemptedAt) < signalCoverageRefreshInterval {
+            return
+        }
+
+        signalCoverageGeneration += 1
+        let generation = signalCoverageGeneration
+        let provider = signalCoverageProvider
+        let startDelay = signalCoverageStartDelay
+        isSignalCoverageRefreshing = true
+        lastSignalCoverageError = nil
+        signalCoverageTask = Task.detached(priority: .utility) { [weak self] in
+            if startDelay > 0 {
+                do {
+                    try await Task.sleep(for: .seconds(startDelay))
+                } catch {
+                    return
+                }
+            }
+            guard !Task.isCancelled else { return }
+            let result: Result<BrainDatabase.SignalCoverageSnapshot, Error> = Result {
+                try provider()
+            }
+            await self?.finishSignalCoverageRefresh(result, generation: generation)
+        }
+    }
+
+    private func finishSignalCoverageRefresh(
+        _ result: Result<BrainDatabase.SignalCoverageSnapshot, Error>,
+        generation: Int
+    ) {
+        guard !isStopped, generation == signalCoverageGeneration else { return }
+        signalCoverageTask = nil
+        isSignalCoverageRefreshing = false
+        lastSignalCoverageAttemptedAt = nowProvider()
+        switch result {
+        case .success(let coverage):
+            stats = stats.withSignalCoverage(coverage)
+            state = PipelineState.derive(daemon: daemon, stats: stats)
+            lastSignalCoverageError = nil
+        case .failure(let error):
+            lastSignalCoverageError = String(describing: error)
         }
     }
 
@@ -569,9 +651,15 @@ final class StatsCollector: ObservableObject {
         let finishDaemon = daemonMonitor.sample() ?? nextDaemon
         switch result {
         case .success(let nextStats):
-            let queueFlushRate = recordPendingStoreQueueDepth(nextStats.pendingStoreFlushQueueDepth, now: snapshotTime)
+            let hotStats: DashboardStats
+            if let cachedCoverage = stats.signalCoverageSnapshot {
+                hotStats = nextStats.withSignalCoverage(cachedCoverage)
+            } else {
+                hotStats = nextStats
+            }
+            let queueFlushRate = recordPendingStoreQueueDepth(hotStats.pendingStoreFlushQueueDepth, now: snapshotTime)
             stats = applyingWatcherProcessResultIfCurrent(
-                to: nextStats.withPendingStoreFlushRate(queueFlushRate),
+                to: hotStats.withPendingStoreFlushRate(queueFlushRate),
                 candidate: watcherProcess,
                 generation: watcherProcessGeneration
             )
@@ -585,6 +673,7 @@ final class StatsCollector: ObservableObject {
             if !force {
                 lastNonForcedStatsRefreshAt = snapshotTime
             }
+            requestSignalCoverageRefresh(force: force)
         case .failure(let error):
             daemon = finishDaemon
             stats = applyingWatcherProcessResultIfCurrent(

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -214,6 +214,41 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.trigramCoveragePercent, 66.666, accuracy: 0.01)
     }
 
+    func testDashboardCoverageUsesTriggerMaintainedRowidMapWhenAvailable() throws {
+        for id in ["mapped-signal-1", "mapped-signal-2", "unmapped-signal"] {
+            try db.insertChunk(
+                id: id,
+                content: "Mapped signal coverage fixture \(id)",
+                sessionId: "dashboard",
+                project: "brainlayer",
+                contentType: "assistant_text",
+                importance: 5
+            )
+        }
+        db.exec("""
+            CREATE TABLE chunk_fts_rowids (
+                chunk_id TEXT PRIMARY KEY,
+                fts_rowid INTEGER,
+                trigram_rowid INTEGER
+            )
+        """)
+        db.exec("""
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid)
+            SELECT f.chunk_id, f.rowid, t.rowid
+            FROM chunks_fts AS f
+            INNER JOIN chunks_fts_trigram AS t ON t.chunk_id = f.chunk_id
+            WHERE f.chunk_id IN ('mapped-signal-1', 'mapped-signal-2')
+        """)
+
+        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+
+        XCTAssertEqual(stats.signalEligibleChunkCount, 3)
+        XCTAssertEqual(stats.ftsIndexedChunkCount, 2)
+        XCTAssertEqual(stats.trigramIndexedChunkCount, 2)
+        XCTAssertEqual(stats.ftsBacklogCount, 1)
+        XCTAssertEqual(stats.trigramBacklogCount, 1)
+    }
+
     func testDashboardStatsTreatsLegacyFtsTableWithoutChunkIdAsUnknownCoverage() throws {
         try db.insertChunk(
             id: "legacy-fts-1",

--- a/brain-bar/Tests/BrainBarTests/DashboardTests.swift
+++ b/brain-bar/Tests/BrainBarTests/DashboardTests.swift
@@ -214,39 +214,27 @@ final class DashboardTests: XCTestCase {
         XCTAssertEqual(stats.trigramCoveragePercent, 66.666, accuracy: 0.01)
     }
 
-    func testDashboardCoverageUsesTriggerMaintainedRowidMapWhenAvailable() throws {
-        for id in ["mapped-signal-1", "mapped-signal-2", "unmapped-signal"] {
-            try db.insertChunk(
-                id: id,
-                content: "Mapped signal coverage fixture \(id)",
-                sessionId: "dashboard",
-                project: "brainlayer",
-                contentType: "assistant_text",
-                importance: 5
-            )
-        }
-        db.exec("""
-            CREATE TABLE chunk_fts_rowids (
-                chunk_id TEXT PRIMARY KEY,
-                fts_rowid INTEGER,
-                trigram_rowid INTEGER
-            )
-        """)
-        db.exec("""
-            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid)
-            SELECT f.chunk_id, f.rowid, t.rowid
-            FROM chunks_fts AS f
-            INNER JOIN chunks_fts_trigram AS t ON t.chunk_id = f.chunk_id
-            WHERE f.chunk_id IN ('mapped-signal-1', 'mapped-signal-2')
-        """)
+    func testDashboardStatsCanSkipSignalCoverageForHotSnapshot() throws {
+        try db.insertChunk(
+            id: "hot-snapshot",
+            content: "The hot snapshot must not wait for signal coverage.",
+            sessionId: "dashboard",
+            project: "brainlayer",
+            contentType: "assistant_text",
+            importance: 5
+        )
 
-        let stats = try db.dashboardStats(activityWindowMinutes: 30, bucketCount: 6)
+        let stats = try db.dashboardStats(
+            activityWindowMinutes: 30,
+            bucketCount: 6,
+            includeSignalCoverage: false
+        )
 
-        XCTAssertEqual(stats.signalEligibleChunkCount, 3)
-        XCTAssertEqual(stats.ftsIndexedChunkCount, 2)
-        XCTAssertEqual(stats.trigramIndexedChunkCount, 2)
-        XCTAssertEqual(stats.ftsBacklogCount, 1)
-        XCTAssertEqual(stats.trigramBacklogCount, 1)
+        XCTAssertFalse(stats.signalCoverageIsAvailable)
+        XCTAssertEqual(stats.signalEligibleChunkCount, 0)
+        XCTAssertEqual(stats.vectorIndexedChunkCount, 0)
+        XCTAssertEqual(stats.ftsIndexedChunkCount, 0)
+        XCTAssertEqual(stats.trigramIndexedChunkCount, 0)
     }
 
     func testDashboardStatsTreatsLegacyFtsTableWithoutChunkIdAsUnknownCoverage() throws {
@@ -614,6 +602,15 @@ final class DashboardTests: XCTestCase {
         XCTAssertTrue(source.contains("vectorBacklogCount"))
         XCTAssertTrue(source.contains("ftsBacklogCount"))
         XCTAssertTrue(source.contains("trigramBacklogCount"))
+    }
+
+    func testDashboardRendersUnavailableCoverageAsComputingWithoutNumericBar() throws {
+        let source = try brainBarSourceFile("Sources/BrainBar/BrainBarWindowRootView.swift")
+
+        XCTAssertTrue(source.contains("stats.signalCoverageIsAvailable"))
+        XCTAssertTrue(source.contains("isAvailable: Bool"))
+        XCTAssertTrue(source.contains("return \"computing…\""))
+        XCTAssertTrue(source.contains("if signal.isAvailable"))
     }
 
     func testVectorSignalDetailMountsAtRootToEscapePipelineAndScrollClips() throws {

--- a/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
+++ b/brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift
@@ -80,6 +80,84 @@ private final class CompletingWindowBucketsProvider: @unchecked Sendable {
     }
 }
 
+private final class BlockingSignalCoverageProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private let startedSemaphore = DispatchSemaphore(value: 0)
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private let snapshot: BrainDatabase.SignalCoverageSnapshot
+    private var calls = 0
+
+    init(snapshot: BrainDatabase.SignalCoverageSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    func fetch() -> BrainDatabase.SignalCoverageSnapshot {
+        lock.lock()
+        calls += 1
+        lock.unlock()
+        startedSemaphore.signal()
+        releaseSemaphore.wait()
+        return snapshot
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func waitUntilStarted(timeout: DispatchTime) -> Bool {
+        startedSemaphore.wait(timeout: timeout) == .success
+    }
+
+    func release() {
+        releaseSemaphore.signal()
+    }
+}
+
+private struct SignalCoverageProviderFailure: Error {}
+
+private final class FailingSignalCoverageProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func fetch() throws -> BrainDatabase.SignalCoverageSnapshot {
+        lock.lock()
+        calls += 1
+        lock.unlock()
+        throw SignalCoverageProviderFailure()
+    }
+}
+
+private final class CountingDashboardStatsProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private let stats: DashboardStats
+    private var calls = 0
+
+    init(stats: DashboardStats) {
+        self.stats = stats
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func fetch() -> DashboardStats {
+        lock.lock()
+        calls += 1
+        lock.unlock()
+        return stats
+    }
+}
+
 private final class SequencedBlockingWatcherProbe: WatcherProcessProbing, @unchecked Sendable {
     private let lock = NSLock()
     private let blockedSampleStarted = DispatchSemaphore(value: 0)
@@ -264,6 +342,136 @@ final class StatsCollectorTests: XCTestCase {
         """
         let execRC = sqlite3_exec(db, sql, nil, nil, nil)
         guard execRC == SQLITE_OK else { throw NSError(domain: "StatsCollectorTests", code: Int(execRC)) }
+    }
+
+    func testHotSnapshotPublishesBeforeExactSignalCoverage() async throws {
+        let hotStats = DashboardStats(
+            chunkCount: 3,
+            enrichedChunkCount: 1,
+            pendingEnrichmentCount: 2,
+            enrichmentPercent: 100.0 / 3.0,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 1_024,
+            recentActivityBuckets: [1, 2],
+            recentAgentWriteBuckets: [1, 0],
+            recentWatcherWriteBuckets: [0, 2],
+            recentEnrichmentBuckets: [0, 1],
+            activityWindowMinutes: 60,
+            bucketCount: 2,
+            signalEligibleChunkCount: 0,
+            signalCoverageIsAvailable: false
+        )
+        let exactCoverage = BrainDatabase.SignalCoverageSnapshot(
+            eligibleChunkCount: 3,
+            vectorIndexedChunkCount: 2,
+            ftsIndexedChunkCount: 3,
+            trigramIndexedChunkCount: 2
+        )
+        let coverageProvider = BlockingSignalCoverageProvider(snapshot: exactCoverage)
+        let hotProvider = CountingDashboardStatsProvider(stats: hotStats)
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 0,
+            dashboardStatsProvider: hotProvider.fetch,
+            signalCoverageProvider: coverageProvider.fetch,
+            signalCoverageStartDelay: 0,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer {
+            coverageProvider.release()
+            collector.stop()
+        }
+
+        collector.start()
+        let hotDeadline = Date().addingTimeInterval(2)
+        while (collector.isRefreshing || collector.lastDataFetchedAt == nil), Date() < hotDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertNotNil(collector.lastDataFetchedAt)
+        XCTAssertFalse(collector.snapshotFreshnessState.isLoading)
+        XCTAssertFalse(collector.stats.signalCoverageIsAvailable)
+        XCTAssertEqual(collector.stats.recentActivityBuckets, [1, 2])
+        XCTAssertTrue(
+            coverageProvider.waitUntilStarted(timeout: .now() + 1),
+            "Exact coverage should start only after the hot snapshot can publish."
+        )
+
+        coverageProvider.release()
+        let coverageDeadline = Date().addingTimeInterval(2)
+        while !collector.stats.signalCoverageIsAvailable, Date() < coverageDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertTrue(collector.stats.signalCoverageIsAvailable)
+        XCTAssertEqual(collector.stats.signalEligibleChunkCount, 3)
+        XCTAssertEqual(collector.stats.vectorIndexedChunkCount, 2)
+        XCTAssertEqual(collector.stats.ftsIndexedChunkCount, 3)
+        XCTAssertEqual(collector.stats.trigramIndexedChunkCount, 2)
+        XCTAssertEqual(collector.stats.recentActivityBuckets, [1, 2])
+
+        collector.refresh(force: false)
+        let secondHotDeadline = Date().addingTimeInterval(2)
+        while (collector.isRefreshing || hotProvider.callCount < 2), Date() < secondHotDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(hotProvider.callCount, 2, "The cache assertion must follow a real second hot snapshot.")
+        XCTAssertTrue(collector.stats.signalCoverageIsAvailable)
+        XCTAssertEqual(collector.stats.signalEligibleChunkCount, 3)
+        XCTAssertEqual(coverageProvider.callCount, 1, "Hot refreshes must reuse the last exact coverage until its interval expires.")
+    }
+
+    func testFailedSignalCoverageAttemptIsThrottledWithoutFailingHotSnapshot() async throws {
+        let hotStats = DashboardStats(
+            chunkCount: 3,
+            enrichedChunkCount: 1,
+            pendingEnrichmentCount: 2,
+            enrichmentPercent: 100.0 / 3.0,
+            enrichmentRatePerMinute: 0,
+            databaseSizeBytes: 1_024,
+            recentActivityBuckets: [1, 2],
+            recentEnrichmentBuckets: [0, 1],
+            activityWindowMinutes: 60,
+            bucketCount: 2,
+            signalEligibleChunkCount: 0,
+            signalCoverageIsAvailable: false
+        )
+        let coverageProvider = FailingSignalCoverageProvider()
+        let collector = StatsCollector(
+            dbPath: tempDBPath,
+            daemonMonitor: DaemonHealthMonitor(targetPID: ProcessInfo.processInfo.processIdentifier),
+            statsRefreshCoalesceInterval: 0,
+            dashboardStatsProvider: { hotStats },
+            signalCoverageProvider: coverageProvider.fetch,
+            signalCoverageStartDelay: 0,
+            signalCoverageRefreshInterval: 300,
+            databaseOpenConfiguration: BrainDatabase.OpenConfiguration(readOnly: true)
+        )
+        defer { collector.stop() }
+
+        collector.start()
+        let failureDeadline = Date().addingTimeInterval(2)
+        while collector.lastSignalCoverageError == nil, Date() < failureDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertNotNil(collector.lastSignalCoverageError)
+        XCTAssertNil(collector.lastFetchError)
+        XCTAssertFalse(collector.stats.signalCoverageIsAvailable)
+        XCTAssertEqual(coverageProvider.callCount, 1)
+
+        collector.refresh(force: false)
+        let secondHotDeadline = Date().addingTimeInterval(2)
+        while collector.isRefreshing, Date() < secondHotDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(coverageProvider.callCount, 1, "A failed exact scan must not retry before the periodic interval expires.")
+        XCTAssertNil(collector.lastFetchError)
+        XCTAssertEqual(collector.stats.recentActivityBuckets, [1, 2])
     }
 
     func testSelectTimeframeLiveClearsWindowedBuckets() async throws {

--- a/docs/plans/2026-08-13-brainbar-nonblocking-coverage-design.md
+++ b/docs/plans/2026-08-13-brainbar-nonblocking-coverage-design.md
@@ -1,0 +1,79 @@
+# BrainBar Non-Blocking Coverage Design
+
+Date: 2026-08-13
+Status: approved by lead ruling
+
+## Problem
+
+`StatsCollector` publishes nothing until `BrainDatabase.dashboardStats` completes. That method runs
+four full coverage scans after the ordinary dashboard metrics. On the production 15 GB database,
+each coverage query can exceed five seconds. The panel therefore remains in `.loading`, and the
+menubar graphs stay flat even though their own bucket data is available.
+
+A direct `chunk_fts_rowids` count is fast but not truthful. Lifecycle-only updates do not fire the
+FTS triggers, so archived or superseded chunks remain mapped and coverage can exceed 100 percent.
+Rejoining the map to `chunks` preserves correctness but exceeded an eight-second production fence
+for both FTS signals.
+
+## Considered approaches
+
+1. **Two-phase in-memory refresh (selected).** Publish cheap dashboard metrics first, then compute
+   exact coverage on a separate connection and task. This requires no schema change and restores
+   both UI surfaces immediately.
+2. **Persist a materialized coverage snapshot.** A worker would periodically write one small stats
+   row. This gives fast restart-time coverage but adds schema and writer ownership, which are outside
+   this hotfix's bounds.
+3. **Stream individual foreground coverage signals.** This can reveal partial results but still
+   couples refresh scheduling to four expensive scans and complicates truth/error presentation.
+
+## Selected data flow
+
+1. `StatsCollector` starts a hot refresh using `dashboardStats(includeSignalCoverage: false)`.
+2. `BrainDatabase` skips every coverage query and returns the pipeline, queue, health, and graph
+   buckets normally.
+3. `StatsCollector` publishes that snapshot, clears `.loading`, and preserves a previously cached
+   exact coverage snapshot when one exists.
+4. After a short scheduling gap, an independent utility-priority task opens its own read-only
+   database connection and runs the existing lifecycle-filtered coverage queries. The gap lets a
+   collector that has already stopped cancel before entering synchronous SQLite work.
+5. Until the first exact result arrives, coverage rows and chips render `computing…` and do not
+   imply zero backlog or zero-percent coverage.
+6. A successful exact result is merged into the current hot snapshot. The result remains cached
+   across ordinary hot refreshes and is recomputed periodically rather than on every mutation.
+7. A coverage failure leaves the hot snapshot live. Coverage remains unknown on first failure or
+   keeps the last exact cached value after a later failure; it never changes global snapshot
+   freshness to `.error`.
+
+## State and cancellation
+
+- The collector owns a separate coverage task, generation, last-attempt timestamp, and refresh
+  interval.
+- `stop()` cancels both hot and coverage tasks.
+- A forced manual refresh may request coverage, but it does not cancel a coverage computation that
+  is already in flight.
+- Coverage publication is generation-checked so a late task cannot update a stopped collector.
+
+## UI contract
+
+- `DashboardStats` carries whether exact signal coverage is available.
+- Coverage chips and expanded rows render `computing…` while unavailable.
+- Coverage bars do not animate a fabricated zero value while unavailable.
+- Menubar sparklines require no UI change: they already subscribe to the shared collector's hot
+  activity buckets and recover as soon as the first hot snapshot publishes.
+
+## Verification
+
+- RED-first collector test holds the coverage provider open and proves the hot snapshot becomes live
+  before coverage finishes, then proves exact coverage publishes after release.
+- Database test proves the hot stats path omits coverage work and marks it unavailable.
+- UI contract tests prove `computing…` is rendered for unavailable coverage.
+- Existing exact coverage tests remain unchanged and green.
+- Live deployment proof samples the installed app: dashboard refresh completes, the panel is not
+  `.loading`, menubar bucket values are non-flat when activity exists, and coverage transitions from
+  computing to exact without blocking the hot snapshot.
+
+## Follow-up
+
+File the lifecycle-trigger gap separately: changes to `archived_at`, `superseded_by`,
+`aggregated_into`, and `status` must keep FTS lifecycle state synchronized. Do not fold that schema
+work into this hotfix.

--- a/docs/plans/2026-08-13-brainbar-nonblocking-coverage.md
+++ b/docs/plans/2026-08-13-brainbar-nonblocking-coverage.md
@@ -1,0 +1,193 @@
+# BrainBar Non-Blocking Coverage Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make BrainBar publish dashboard and menubar graph data immediately while exact lifecycle-filtered coverage computes independently in the background.
+
+**Architecture:** Split `BrainDatabase.dashboardStats` into a hot snapshot that can omit signal coverage and a separate exact coverage provider. `StatsCollector` publishes the hot snapshot first, retains the last exact coverage result as an in-memory cache, and refreshes coverage on an independent generation-checked task. The UI represents missing coverage as `computing…`; no schema or trigger changes are included.
+
+**Tech Stack:** Swift 6, Swift concurrency, Combine/SwiftUI, SQLite3, XCTest.
+
+---
+
+### Task 1: RED — define the truthful hot-snapshot contract
+
+**Files:**
+- Modify: `brain-bar/Tests/BrainBarTests/DashboardTests.swift`
+- Modify: `brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift`
+
+**Step 1: Replace the rejected map-count regression**
+
+Add `testDashboardStatsCanSkipSignalCoverageForHotSnapshot`. Insert ordinary chunks, call
+`dashboardStats(..., includeSignalCoverage: false)`, and assert:
+
+```swift
+XCTAssertFalse(stats.signalCoverageIsAvailable)
+XCTAssertEqual(stats.signalEligibleChunkCount, 0)
+XCTAssertEqual(stats.vectorIndexedChunkCount, 0)
+XCTAssertEqual(stats.ftsIndexedChunkCount, 0)
+XCTAssertEqual(stats.trigramIndexedChunkCount, 0)
+```
+
+Keep the existing default-path test that proves exact eligible/indexed/backlog values.
+
+**Step 2: Add the collector ordering regression**
+
+Inject an immediate hot stats provider and a coverage provider held by a `DispatchSemaphore`. Start
+the collector and prove the snapshot becomes `.live` with `signalCoverageIsAvailable == false`
+before releasing coverage. Release the provider and prove the exact snapshot is merged later without
+changing the hot snapshot's graph buckets.
+
+**Step 3: Run RED tests**
+
+Run:
+
+```bash
+cd brain-bar
+swift test --filter DashboardTests/testDashboardStatsCanSkipSignalCoverageForHotSnapshot
+swift test --filter StatsCollectorTests/testHotSnapshotPublishesBeforeExactSignalCoverage
+```
+
+Expected: compile failures for the missing `includeSignalCoverage`, availability state, providers,
+and exact coverage snapshot API.
+
+### Task 2: Implement the split database contract
+
+**Files:**
+- Modify: `brain-bar/Sources/BrainBar/BrainDatabase.swift`
+
+**Step 1: Add exact coverage value state**
+
+Create `SignalCoverageSnapshot: Sendable, Equatable` with eligible, vector, FTS, and trigram counts.
+Add `signalCoverageIsAvailable` to `DashboardStats` with a default of `true` for existing fixtures.
+Add copy helpers that preserve availability and one helper that merges an exact snapshot.
+
+**Step 2: Add the hot-path switch**
+
+Change the database API to:
+
+```swift
+func dashboardStats(
+    activityWindowMinutes: Int = 30,
+    bucketCount: Int = 12,
+    includeSignalCoverage: Bool = true
+) throws -> DashboardStats
+```
+
+When false, do not call `dashboardSignalCoverageCounts`; publish zero placeholders marked
+unavailable. Keep the default true so existing exact callers and tests preserve behavior.
+
+**Step 3: Expose exact coverage separately**
+
+Add `dashboardSignalCoverageSnapshot()` that runs the existing lifecycle-filtered
+`dashboardSignalCoverageCounts()` inside its own read transaction and returns the snapshot. Restore
+the pre-PR virtual-table joins; remove all direct `chunk_fts_rowids` counting code.
+
+**Step 4: Run database tests**
+
+Run:
+
+```bash
+swift test --filter DashboardTests/testDashboardStatsCanSkipSignalCoverageForHotSnapshot
+swift test --filter DashboardTests/testDashboardStatsReportsPerSignalCoverageAndBacklogs
+```
+
+Expected: both pass.
+
+### Task 3: Publish hot stats before background coverage
+
+**Files:**
+- Modify: `brain-bar/Sources/BrainBar/Dashboard/StatsCollector.swift`
+- Test: `brain-bar/Tests/BrainBarTests/StatsCollectorTests.swift`
+
+**Step 1: Add injectable providers**
+
+Add `DashboardStatsProvider` and `SignalCoverageProvider` sendable closures. Defaults open separate
+short-lived database handles; the hot provider calls `dashboardStats(includeSignalCoverage: false)`
+and the coverage provider calls `dashboardSignalCoverageSnapshot()`.
+
+**Step 2: Add independent coverage lifecycle**
+
+Add a coverage task, generation, last-attempt time, error, refresh interval, and refreshing flag.
+Cancel/invalidate it in `stop()`. Never cancel a running coverage task because another hot refresh
+arrives.
+
+Failed exact attempts are throttled by the same interval so a broken or busy database cannot turn
+ordinary hot refreshes into an expensive retry storm.
+
+**Step 3: Preserve cached exact coverage**
+
+On hot success, merge the previous exact coverage into the new hot snapshot when available, publish
+and clear global `.loading`, then request coverage only when no task is active and the periodic
+interval is due. Coverage failure must not set `lastFetchError` or global snapshot freshness.
+
+**Step 4: Run the ordering test**
+
+Run:
+
+```bash
+swift test --filter StatsCollectorTests/testHotSnapshotPublishesBeforeExactSignalCoverage
+```
+
+Expected: pass; the hot assertion completes before the semaphore is released.
+
+### Task 4: Render unknown coverage honestly
+
+**Files:**
+- Modify: `brain-bar/Sources/BrainBar/BrainBarWindowRootView.swift`
+- Modify: `brain-bar/Tests/BrainBarTests/DashboardTests.swift`
+
+**Step 1: Write the UI RED test**
+
+Add a source-contract or model test proving unavailable coverage produces the exact visible string
+`computing…` and does not expose a numeric percent/backlog.
+
+**Step 2: Thread availability through the coverage model**
+
+Add `isAvailable` to `BrainBarSignalCoverage`; pass `stats.signalCoverageIsAvailable` for Vector,
+FTS5, and Trigram. Make `percentText` and `backlogText` return `computing…` while unavailable.
+Replace the animated foreground bar with a neutral background-only capsule while unavailable.
+
+**Step 3: Run focused UI/dashboard tests**
+
+Run:
+
+```bash
+swift test --filter DashboardTests
+swift test --filter StatsCollectorTests
+```
+
+Expected: all focused tests pass.
+
+### Task 5: Review, publish, and deploy
+
+**Files:**
+- Update: `docs/plans/2026-08-13-brainbar-nonblocking-coverage-design.md`
+- Update: `docs/plans/2026-08-13-brainbar-nonblocking-coverage.md`
+
+**Step 1: Verify and commit**
+
+Run `git diff --check`, focused Swift suites, the full Swift package, and `coderabbit review --agent`.
+Commit the replacement implementation and push with `BRAINLAYER_PREPUSH_SCOPE=changed-only`.
+
+**Step 2: Resolve review threads**
+
+Reply to MF-1/MF-2 with the replacement design and exact test evidence. Re-request the same Claude
+pair reviewer and `@codex review`; wait for CI and actionable review findings.
+
+**Step 3: Merge and deploy**
+
+Merge with a merge commit after clean review. Build/install the canonical app from merged `main`,
+restart the GUI and daemon, and prove new PIDs execute `/Applications/BrainBar.app`, launchd is live,
+and the embedded Git commit matches the merge.
+
+**Step 4: Live UI proof**
+
+Prove the installed collector logs a completed hot refresh before exact coverage, the dashboard is
+not `.loading`, menubar buckets carry real non-flat values when activity exists, and coverage either
+shows `computing…` or a later exact lifecycle-filtered value without blocking the hot snapshot.
+
+**Step 5: File the trigger-gap follow-up**
+
+Create a signed GitHub issue for lifecycle columns (`archived_at`, `superseded_by`,
+`aggregated_into`, `status`) not updating FTS trigger state. Do not implement it in this PR.


### PR DESCRIPTION
## Summary

- publish BrainBar's hot dashboard/menubar snapshot without running any of the four signal-coverage scans
- compute exact lifecycle-filtered eligible/vector/FTS5/trigram coverage independently on a short-lived read-only connection
- retain the last exact result for five minutes; throttle failures without degrading global snapshot health
- show `computing…` instead of fabricated zero coverage until the first exact result arrives
- add RED-first ordering, cache, failure, database-contract, and UI regressions

## Root cause and correction

`StatsCollector` published one all-or-nothing `dashboardStats` result. On the production 15 GB database, eligible, vector, FTS5, and trigram coverage scans each crossed the foreground latency boundary, so the dashboard stayed in `.loading` and the menubar graphs never received their already-cheap activity buckets.

The first PR head attempted direct `chunk_fts_rowids` counts. Review proved that path dropped lifecycle eligibility and could show 100.12% coverage with backlog pinned to zero; it also removed only two of four blocking scans. Replacement head `7706388b` removes that optimization entirely. Exact coverage again uses the existing lifecycle-filtered queries, but none run on the render-critical path.

## Runtime contract

1. `dashboardStats(includeSignalCoverage: false)` returns graph/activity/queue/health data without any coverage scan.
2. `StatsCollector` publishes it and clears global loading.
3. Coverage rows render `computing…` until an independent exact task finishes.
4. Exact results merge into the current snapshot and remain cached across ordinary hot refreshes.
5. Exact failures remain coverage-local and are throttled for five minutes.

## Test plan

- `DashboardTests`: 115 passed, 0 failed
- new collector ordering/cache/failure regressions: 2 passed, 0 failed
- full Swift package before the final reviewer-requested test hardening: 863 executed, 10 skipped, 0 failed
- changed-only push gates: MCP registration 3 passed; isolated eval/hook routing 40 passed; Bun 1 passed; FTS determinism shell regression passed
- remote CI on exact replacement head is the final clean-machine gate

## Follow-up

The missing lifecycle columns in the FTS update-trigger contract remain a separate schema issue and are deliberately not inlined into this UI hotfix.

— brainlayerCodex-backup-dashboard (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex-backup-dashboard","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019ff9b7","ts":"2026-08-13T09:56:00Z"} -->
