### PR TITLE
chore(release): prepare BrainLayer and BrainBar v1.5.7

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,11 +9,11 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.5.6</string>
+    <string>1.5.7</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.6</string>
+    <string>1.5.7</string>
     <key>BrainLayerReleaseVersion</key>
-    <string>1.5.6</string>
+    <string>1.5.7</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.5.6"
+version = "1.5.7"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.5.6"
+__version__ = "1.5.7"


### PR DESCRIPTION
## Summary

- bump BrainLayer, BrainBar, and MCP package metadata from 1.5.6 to 1.5.7
- cut the signed/notarized BrainBar release containing merged PR #710
- release note: fix dashboard and menubar graph starvation by removing exact coverage work from the hot refresh path

## Release context

PR #710 was accepted and merged at head 7706388b (merge b326fd3f). The installed canonical app is still v1.5.6, so this metadata-only bump is required to build, notarize, distribute, and install the reviewed fix through the supported Homebrew lane.

## Verification

- focused version-sync tests: 12 passed
- full pre-push unit suite: 3,993 passed, 10 skipped, 61 deselected, 2 xfailed
- MCP registration: 3/3
- isolated eval/routing: 40/40
- Bun and FTS5 shell regression gates: passed
- diff contains only the standard version metadata substitutions; no runtime code changes

## Distribution gate after merge

Tag the verified merge as v1.5.7, wait for PyPI plus signed/notarized BrainBar.zip, update the Homebrew formula and cask with published hashes, install the canonical cask, and prove the running installed app renders dashboard and graph data.

— brainlayerCodex-backup-dashboard (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex-backup-dashboard","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"019ff9b7","ts":"2026-08-13T10:37:13Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version strings in packaging and plist metadata; no logic, security, or data-path changes.
> 
> **Overview**
> Bumps **1.5.6 → 1.5.7** across BrainLayer (PyPI/`__version__`), MCP `server.json`, and BrainBar `Info.plist` (`CFBundleVersion`, `CFBundleShortVersionString`, `BrainLayerReleaseVersion`).
> 
> This is a **metadata-only** release cut so the signed/notarized BrainBar build and PyPI package can ship the fix from merged PR #710 (dashboard/menubar graph starvation by moving exact coverage work off the hot refresh path). **No runtime or application code changes** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad26ff96ce42d1851977f3eb34225c64547859e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump BrainLayer and BrainBar version to 1.5.7
> Updates version strings from 1.5.6 to 1.5.7 across [Info.plist](https://github.com/EtanHey/brainlayer/pull/712/files#diff-2df8f275d2c273f09d5236a36482bda20f0d532d1add3b4b1300d61420a9bd39), [pyproject.toml](https://github.com/EtanHey/brainlayer/pull/712/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), [server.json](https://github.com/EtanHey/brainlayer/pull/712/files#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429), and [brainlayer/__init__.py](https://github.com/EtanHey/brainlayer/pull/712/files#diff-c0fbbdca19c49a96c615724c93c645a7ea4437b08a00053a44a79d3b3afa4954).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad26ff9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->