### PR TITLE
chore(release): prepare BrainLayer and BrainBar v1.5.8

### DIFF
--- a/brain-bar/bundle/Info.plist
+++ b/brain-bar/bundle/Info.plist
@@ -9,11 +9,11 @@
     <key>CFBundleIdentifier</key>
     <string>com.brainlayer.brainbar</string>
     <key>CFBundleVersion</key>
-    <string>1.5.7</string>
+    <string>1.5.8</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.7</string>
+    <string>1.5.8</string>
     <key>BrainLayerReleaseVersion</key>
-    <string>1.5.7</string>
+    <string>1.5.8</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brainlayer"
-version = "1.5.7"
+version = "1.5.8"
 description = "Persistent memory MCP server for AI agents — 13 tools, semantic search, knowledge graph, on-device SQLite"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.etanhey/brainlayer",
   "title": "BrainLayer",
   "description": "Persistent memory for AI agents \u2014 local-first semantic search, knowledge graph, and 12 MCP tools with ToolAnnotations. One SQLite file, no cloud, no API keys.",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "websiteUrl": "https://brainlayer.etanheyman.com",
   "repository": {
     "url": "https://github.com/EtanHey/brainlayer",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "brainlayer",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/brainlayer/__init__.py
+++ b/src/brainlayer/__init__.py
@@ -1,3 +1,3 @@
 """BrainLayer (זיכרון) - Local knowledge pipeline for Claude Code conversations."""
 
-__version__ = "1.5.7"
+__version__ = "1.5.8"


### PR DESCRIPTION
## Summary

- bump BrainLayer, BrainBar, and MCP package metadata from 1.5.7 to 1.5.8
- cut the signed/notarized BrainBar release containing merged PR #716
- release note: retire the Python MCP entrypoint, add socket migrator + stdio-bridge plugin, and extend backup timeout to 8 hours

## Release context

PR #716 was merged at head `a89fed0e`. Live hosts still run brew 1.5.7, so this metadata-only bump is required to build, notarize, distribute, and install the reviewed work through the supported Homebrew lane.

## Verification

- focused version-sync + BrainBar release workflow tests: 6 passed
- pre-push gate: pytest unit suite + MCP isolated eval/routing 40/40 + bun + FTS5 shell PASS
- diff contains only the standard version metadata substitutions; no runtime code changes

## Distribution gate after merge

Tag the verified merge as v1.5.8, wait for PyPI plus signed/notarized BrainBar.zip, update the Homebrew formula and cask with published hashes, then `brew upgrade` on Main and M1 (`ssh m1`) and run the after-verification checklist on both hosts.

— brainlayerCursor-82779ef2 (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"brainlayerCursor-82779ef2","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","session":"d6254ad3","ts":"2026-08-17T15:51:54Z"} -->
