### PR TITLE
fix: collapse chunk archive twins onto archived_at

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainDatabase.swift
+++ b/brain-bar/Sources/BrainBar/BrainDatabase.swift
@@ -2448,12 +2448,6 @@ final class BrainDatabase: @unchecked Sendable {
         if columns.contains("archived_at") {
             clauses.append("\(alias).archived_at IS NULL")
         }
-        if columns.contains("archived") {
-            clauses.append("COALESCE(\(alias).archived, 0) = 0")
-        }
-        if columns.contains("status") {
-            clauses.append("COALESCE(\(alias).status, 'active') = 'active'")
-        }
         if columns.contains("source_class") {
             clauses.append("(\(alias).source_class IS NULL OR \(alias).source_class NOT IN ('desktop', 'brain-worker'))")
         }
@@ -3425,24 +3419,18 @@ final class BrainDatabase: @unchecked Sendable {
             try execute("""
                 UPDATE chunks
                 SET status = CASE
-                    WHEN COALESCE(archived, 0) = 1
-                      OR value_type = 'ARCHIVED'
-                      OR archived_at IS NOT NULL
-                        THEN 'archived'
                     WHEN superseded_by IS NOT NULL
                       OR aggregated_into IS NOT NULL
                         THEN 'superseded'
                     ELSE 'active'
                 END
                 WHERE status IS NULL
-                   OR status NOT IN ('active', 'superseded', 'archived')
+                   OR status NOT IN ('active', 'superseded')
+                   OR status = 'archived'
                    OR (
                         status = 'active'
                         AND (
-                            COALESCE(archived, 0) = 1
-                            OR value_type = 'ARCHIVED'
-                            OR archived_at IS NOT NULL
-                            OR superseded_by IS NOT NULL
+                            superseded_by IS NOT NULL
                             OR aggregated_into IS NOT NULL
                         )
                     )
@@ -4798,8 +4786,6 @@ final class BrainDatabase: @unchecked Sendable {
               AND project IS ?
               AND content_type = ?
               AND conversation_id = ?
-              AND COALESCE(status, 'active') = 'active'
-              AND COALESCE(archived, 0) = 0
               AND superseded_by IS NULL
               AND aggregated_into IS NULL
               AND archived_at IS NULL
@@ -6062,9 +6048,7 @@ final class BrainDatabase: @unchecked Sendable {
         try executeUpdate(
             """
             UPDATE chunks
-            SET archived = 1,
-                archived_at = ?,
-                status = 'archived'
+            SET archived_at = ?
             WHERE id = ?
             """
         ) { stmt in
@@ -6233,9 +6217,7 @@ final class BrainDatabase: @unchecked Sendable {
         var conditions = [
             "superseded_by IS NULL",
             "aggregated_into IS NULL",
-            "archived_at IS NULL",
-            "COALESCE(archived, 0) = 0",
-            "COALESCE(status, 'active') = 'active'"
+            "archived_at IS NULL"
         ]
         if chunkIDs == nil {
             conditions.append("enriched_at IS NULL")

--- a/scripts/cleanup-profanity-chunks.py
+++ b/scripts/cleanup-profanity-chunks.py
@@ -99,7 +99,6 @@ def fetch_rows(conn):
         FROM chunks
         WHERE id LIKE 'rt-%'
           AND content_type = 'user_message'
-          AND archived = 0
           AND aggregated_into IS NULL
           AND archived_at IS NULL
           AND lower(content) GLOB '*fuck*'
@@ -228,7 +227,7 @@ def archive_originals(conn, cluster, agg_id, now_iso):
         conn.execute(
             """
             UPDATE chunks
-            SET aggregated_into = ?, archived = 1, archived_at = ?, value_type = 'ARCHIVED'
+            SET aggregated_into = ?, archived_at = ?
             WHERE id = ?
             """,
             (agg_id, now_iso, row["id"]),

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -191,8 +191,6 @@ def _candidates_from_scanned_rows(
             and archived_at is None
             and superseded_by is None
             and aggregated_into is None
-            and not archived
-            and status == "active"
         )
         if eligible:
             if first_candidate_rowid is None:
@@ -233,8 +231,6 @@ class HotCandidateScanner:
               AND c.archived_at IS NULL
               AND c.superseded_by IS NULL
               AND c.aggregated_into IS NULL
-              AND COALESCE(c.archived, 0) = 0
-              AND COALESCE(c.status, 'active') = 'active'
             """,
             tuple(self._retries),
         )
@@ -355,8 +351,6 @@ def _candidate_chunk_ids(store: VectorStore, *, limit: int) -> list[str]:
           AND c.archived_at IS NULL
           AND c.superseded_by IS NULL
           AND c.aggregated_into IS NULL
-          AND COALESCE(c.archived, 0) = 0
-          AND COALESCE(c.status, 'active') = 'active'
         ORDER BY c.created_at DESC
         LIMIT ?
         """,
@@ -392,8 +386,6 @@ def _candidate_chunk_rows(store: VectorStore, *, limit: int) -> list[EmbedCandid
             and archived_at is None
             and superseded_by is None
             and aggregated_into is None
-            and not archived
-            and status == "active"
         ):
             candidates.append(EmbedCandidate(str(chunk_id), str(content)))
             if len(candidates) >= limit:
@@ -468,7 +460,7 @@ def _pending_chunk_rows(
         content_by_id = {
             str(row[0]): str(row[1])
             for row in content_rows
-            if row[1] and row[2] is None and row[3] is None and row[4] is None and not row[5] and row[6] == "active"
+            if row[1] and row[2] is None and row[3] is None and row[4] is None
         }
         candidates.extend(
             EmbedCandidate(chunk_id, content_by_id[chunk_id]) for chunk_id in candidate_ids if chunk_id in content_by_id
@@ -643,8 +635,6 @@ def _write_embedded_vectors(store_or_path: VectorStore | Path | str, vectors: li
                       AND c.archived_at IS NULL
                       AND c.superseded_by IS NULL
                       AND c.aggregated_into IS NULL
-                      AND COALESCE(c.archived, 0) = 0
-                      AND COALESCE(c.status, 'active') = 'active'
                     """,
                     (chunk_id, content),
                 ).fetchone()

--- a/scripts/quarantine_noise.py
+++ b/scripts/quarantine_noise.py
@@ -208,7 +208,6 @@ def _fetch_candidates(conn: sqlite3.Connection) -> list[sqlite3.Row]:
         "source_file",
         "created_at",
         "importance",
-        "archived",
         "status",
         "archived_at",
     ]
@@ -255,7 +254,6 @@ def _candidate_map(rows: list[sqlite3.Row]) -> dict[str, dict[str, Any]]:
         existing.setdefault("tags", row["tags"])
         existing.setdefault("chunk_origin", row["chunk_origin"])
         existing.setdefault("importance", row["importance"])
-        existing.setdefault("archived", _to_bool(row["archived"]))
         existing.setdefault("status", row["status"])
         existing.setdefault("archived_at", row["archived_at"])
         existing.setdefault("content_preview", content_preview)
@@ -272,7 +270,7 @@ def _summarize_rows(rows: list[dict[str, Any]]) -> dict[str, int | float]:
         "total": len(rows),
         "f_infra_root": sum("f_infra_root" in row["reasons"] for row in rows),
         "precompact": sum("precompact" in row["reasons"] for row in rows),
-        "already_archived": sum(bool(_to_bool(row["archived"])) for row in rows),
+        "already_archived": sum(bool(row.get("archived_at")) for row in rows),
         "taggable": sum(_parse_tags(row["tags"]) is not None for row in rows),
     }
 
@@ -306,9 +304,7 @@ def _apply_quarantine(conn: sqlite3.Connection, rows: list[dict[str, Any]]) -> d
     base_stmt = """
         UPDATE chunks
            SET importance = ?,
-               archived = ?,
-               archived_at = ?,
-               status = ?
+               archived_at = ?
          WHERE id = ?
     """
     tag_stmt = "UPDATE chunks SET tags = ? WHERE id = ?"
@@ -319,7 +315,7 @@ def _apply_quarantine(conn: sqlite3.Connection, rows: list[dict[str, Any]]) -> d
         cursor = conn.cursor()
         cursor.execute("BEGIN IMMEDIATE")
         for row in rows:
-            cursor.execute(base_stmt, (0, 1, now, "archived", row["id"]))
+            cursor.execute(base_stmt, (0, now, row["id"]))
             updated += 1
             parsed = _parse_tags(row["tags"])
             if parsed is None:

--- a/scripts/repair_archive_collapse.py
+++ b/scripts/repair_archive_collapse.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Collapse archive tetraplication onto chunks.archived_at (rehearsal/live-window)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from brainlayer.archive_collapse import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_source_class_visibility.py
+++ b/scripts/verify_source_class_visibility.py
@@ -34,10 +34,9 @@ def _candidate_rows(store: VectorStore, source_class: str | None) -> list[tuple[
             FROM chunks c
             JOIN chunk_fts_rowids r ON r.chunk_id = c.id
             WHERE {predicate}
-              AND COALESCE(c.archived, 0) = 0
+              AND c.archived_at IS NULL
               AND c.superseded_by IS NULL
               AND c.aggregated_into IS NULL
-              AND c.archived_at IS NULL
               AND LENGTH(COALESCE(c.content, '')) >= 16
             ORDER BY c.rowid
             LIMIT 250

--- a/src/brainlayer/archive_collapse.py
+++ b/src/brainlayer/archive_collapse.py
@@ -379,7 +379,7 @@ def main(argv: list[str] | None = None) -> int:
     print(json.dumps(_result_payload(args.db.expanduser(), apply=args.apply, result=result), sort_keys=True))
     if args.apply and result.post_twin_count:
         return 1
-    if result.spot_checks and not all(item["ok"] for item in result.spot_checks):
+    if args.apply and result.spot_checks and not all(item["ok"] for item in result.spot_checks):
         return 1
     return 0
 

--- a/src/brainlayer/archive_collapse.py
+++ b/src/brainlayer/archive_collapse.py
@@ -1,0 +1,388 @@
+"""Collapse archive tetraplication onto chunks.archived_at (time or NULL).
+
+Rehearsal/live-window tool. Default is dry-run. Refuses the live canonical DB unless
+allow_live=True after a lead-scheduled writer window.
+
+Twin representations that this repair migrates-then-clears:
+  archived INTEGER, status='archived', value_type='ARCHIVED'
+Canonical remainder: archived_at. Lineage columns superseded_by / aggregated_into are kept.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import sqlite3
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .chunk_origin_wipe import AUX_COUNT_TABLES, assert_not_live_db
+
+PREIMAGE_TABLE = "archive_collapse_preimage"
+MIGRATION_NAME = "2026_08_17_archive_collapse_archived_at"
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+TWIN_PREDICATE = """(
+  COALESCE(archived, 0) = 1
+  OR lower(COALESCE(value_type, '')) = 'archived'
+  OR lower(COALESCE(status, '')) = 'archived'
+)"""
+
+
+@dataclass
+class ArchiveCollapseResult:
+    scanned: int = 0
+    updated: int = 0
+    would_update: int = 0
+    batches: int = 0
+    checkpoints: int = 0
+    post_twin_count: int = 0
+    aux_counts_before: dict[str, int] = field(default_factory=dict)
+    aux_counts_after: dict[str, int] = field(default_factory=dict)
+    spot_checks: list[dict[str, Any]] = field(default_factory=list)
+    backfill_timestamp: str = ""
+
+
+def _validate_git_sha(git_sha: str) -> str:
+    if not _SHA_RE.fullmatch(git_sha):
+        raise ValueError("git_sha must be an exact 40-character hexadecimal commit SHA")
+    return git_sha.lower()
+
+
+def _aux_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    existing = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    counts: dict[str, int] = {}
+    for table in AUX_COUNT_TABLES:
+        if table not in existing:
+            continue
+        try:
+            counts[table] = int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+        except sqlite3.OperationalError:
+            continue
+    return counts
+
+
+def _checkpoint(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA wal_checkpoint(FULL)")
+
+
+def _twin_count(conn: sqlite3.Connection) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) FROM chunks WHERE {TWIN_PREDICATE}").fetchone()[0])
+
+
+def _ensure_preimage(conn: sqlite3.Connection) -> None:
+    exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (PREIMAGE_TABLE,),
+    ).fetchone()
+    if exists:
+        conn.execute(
+            f"""
+            INSERT INTO {PREIMAGE_TABLE}(id, archived_at, archived, status, value_type)
+            SELECT id, archived_at, archived, status, value_type FROM chunks
+            WHERE {TWIN_PREDICATE}
+              AND id NOT IN (SELECT id FROM {PREIMAGE_TABLE})
+            """
+        )
+        conn.commit()
+        return
+    conn.execute(
+        f"""
+        CREATE TABLE {PREIMAGE_TABLE} AS
+        SELECT id, archived_at, archived, status, value_type
+        FROM chunks
+        WHERE {TWIN_PREDICATE}
+        """
+    )
+    conn.commit()
+
+
+def _ensure_schema_migrations(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            name TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL,
+            details TEXT
+        )
+        """
+    )
+
+
+def _spot_ok(archived_at: Any, archived: Any, status: Any, value_type: Any) -> bool:
+    if archived_at is None or str(archived_at).strip() == "":
+        return False
+    if int(archived or 0) != 0:
+        return False
+    if str(status or "").lower() == "archived":
+        return False
+    if str(value_type or "").lower() == "archived":
+        return False
+    return True
+
+
+def _spot_checks_from_store(
+    conn: sqlite3.Connection,
+    sample_ids: Iterable[str],
+) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for chunk_id in sample_ids:
+        row = conn.execute(
+            "SELECT archived_at, archived, status, value_type FROM chunks WHERE id = ?",
+            (chunk_id,),
+        ).fetchone()
+        if row is None:
+            checks.append({"id": chunk_id, "ok": False})
+            continue
+        archived_at, archived, status, value_type = row
+        checks.append(
+            {
+                "id": chunk_id,
+                "stored_archived_at": archived_at,
+                "stored_archived": archived,
+                "stored_status": status,
+                "stored_value_type": value_type,
+                "ok": _spot_ok(archived_at, archived, status, value_type),
+            }
+        )
+    return checks
+
+
+def collapse_archive_representations(
+    db_path: Path,
+    *,
+    git_sha: str,
+    apply: bool = False,
+    batch_size: int = 5000,
+    checkpoint_every: int = 3,
+    allow_live: bool = False,
+    spot_check: int = 0,
+    actor: str = "repair-c",
+) -> ArchiveCollapseResult:
+    """Backfill archived_at from twin flags, then clear the twins."""
+    sha = _validate_git_sha(git_sha)
+    resolved = assert_not_live_db(db_path, allow_live=allow_live)
+    batch_size = max(1, int(batch_size))
+    checkpoint_every = max(1, int(checkpoint_every))
+    spot_check = max(0, int(spot_check))
+    backfill_ts = datetime.now(timezone.utc).isoformat()
+
+    result = ArchiveCollapseResult(backfill_timestamp=backfill_ts)
+    samples: list[str] = []
+    sampled = 0
+    rng = random.Random(0)
+
+    conn = sqlite3.connect(str(resolved))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA busy_timeout=30000")
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+        required = {"archived_at", "archived", "status", "value_type"}
+        missing = sorted(required - columns)
+        if missing:
+            raise RuntimeError(f"chunks missing archive columns: {missing}")
+
+        result.would_update = _twin_count(conn)
+        result.aux_counts_before = _aux_counts(conn)
+
+        if apply:
+            _ensure_preimage(conn)
+            _checkpoint(conn)
+            result.checkpoints += 1
+
+        last_rowid = 0
+        while True:
+            rows = list(
+                conn.execute(
+                    f"""
+                    SELECT rowid, id, archived_at, archived, status, value_type,
+                           superseded_by, aggregated_into
+                    FROM chunks
+                    WHERE rowid > ?
+                      AND {TWIN_PREDICATE}
+                    ORDER BY rowid
+                    LIMIT ?
+                    """,
+                    (last_rowid, batch_size),
+                )
+            )
+            if not rows:
+                break
+
+            result.batches += 1
+            updates: list[tuple[Any, ...]] = []
+            for row in rows:
+                last_rowid = int(row["rowid"])
+                result.scanned += 1
+                archived_at = row["archived_at"]
+                if archived_at is None or str(archived_at).strip() == "":
+                    archived_at = backfill_ts
+                status = row["status"]
+                if row["superseded_by"] or row["aggregated_into"]:
+                    status = "superseded"
+                elif str(status or "").lower() == "archived":
+                    status = "active"
+                value_type = row["value_type"]
+                if str(value_type or "").lower() == "archived":
+                    value_type = None
+                updates.append((archived_at, 0, status, value_type, int(row["rowid"])))
+                if spot_check:
+                    sampled += 1
+                    chunk_id = str(row["id"])
+                    if len(samples) < spot_check:
+                        samples.append(chunk_id)
+                    else:
+                        j = rng.randrange(sampled)
+                        if j < spot_check:
+                            samples[j] = chunk_id
+
+            if apply and updates:
+                before_changes = conn.total_changes
+                conn.executemany(
+                    """
+                    UPDATE chunks
+                    SET archived_at = ?,
+                        archived = ?,
+                        status = ?,
+                        value_type = ?
+                    WHERE rowid = ?
+                    """,
+                    updates,
+                )
+                result.updated += conn.total_changes - before_changes
+                conn.commit()
+                if result.batches % checkpoint_every == 0:
+                    _checkpoint(conn)
+                    result.checkpoints += 1
+            elif apply:
+                conn.commit()
+
+        if apply and result.batches and result.batches % checkpoint_every != 0:
+            _checkpoint(conn)
+            result.checkpoints += 1
+
+        result.post_twin_count = _twin_count(conn)
+        result.aux_counts_after = _aux_counts(conn)
+        if apply:
+            _ensure_schema_migrations(conn)
+            receipt = {
+                "migration": MIGRATION_NAME,
+                "git_sha": sha,
+                "actor": actor,
+                "updated": result.updated,
+                "post_twin_count": result.post_twin_count,
+                "backfill_timestamp": backfill_ts,
+            }
+            conn.execute(
+                "INSERT OR REPLACE INTO schema_migrations(name, applied_at, details) VALUES (?, ?, ?)",
+                (MIGRATION_NAME, datetime.now(timezone.utc).isoformat(), json.dumps(receipt, sort_keys=True)),
+            )
+            conn.commit()
+        if samples:
+            result.spot_checks = _spot_checks_from_store(conn, samples)
+        return result
+    finally:
+        conn.close()
+
+
+def _result_payload(db_path: Path, *, apply: bool, result: ArchiveCollapseResult) -> dict[str, Any]:
+    return {
+        "db": str(db_path),
+        "mode": "apply" if apply else "dry-run",
+        "scanned": result.scanned,
+        "updated": result.updated,
+        "would_update": result.would_update,
+        "batches": result.batches,
+        "checkpoints": result.checkpoints,
+        "post_twin_count": result.post_twin_count,
+        "aux_counts_before": result.aux_counts_before,
+        "aux_counts_after": result.aux_counts_after,
+        "backfill_timestamp": result.backfill_timestamp,
+        "spot_checks_ok": (
+            "n/a-dry-run"
+            if not apply
+            else (all(item["ok"] for item in result.spot_checks) if result.spot_checks else None)
+        ),
+        "spot_checks": result.spot_checks,
+        "next": (
+            "verify post_twin_count is 0 and review live-window plan"
+            if apply
+            else "rerun with --apply against a rehearsal copy (never the live DB)"
+        ),
+    }
+
+
+def _detect_git_sha() -> str | None:
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[2],
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return sha if _SHA_RE.fullmatch(sha) else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Collapse archive twins onto chunks.archived_at. Default is dry-run. "
+            "Requires --db; refuses the live canonical DB unless --allow-live is set."
+        )
+    )
+    parser.add_argument("--db", type=Path, required=True, help="Rehearsal copy DB path (required)")
+    parser.add_argument("--apply", action="store_true", help="Write collapsed archive columns")
+    parser.add_argument("--git-sha", dest="git_sha", help="40-char commit SHA recorded in schema_migrations")
+    parser.add_argument("--batch-size", type=int, default=5000, help="Rows to scan per transaction batch")
+    parser.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=3,
+        help="Run WAL checkpoint(FULL) every N applied batches (AGENTS.md bulk-ops law)",
+    )
+    parser.add_argument(
+        "--allow-live",
+        action="store_true",
+        help="Permit the canonical live DB. Lead-scheduled live window only.",
+    )
+    parser.add_argument(
+        "--spot-check",
+        type=int,
+        default=0,
+        help="Reservoir-sample N collapsed rows and re-read stored values",
+    )
+    parser.add_argument("--actor", default="repair-c", help="Actor recorded in schema_migrations details")
+    args = parser.parse_args(argv)
+
+    git_sha = args.git_sha or _detect_git_sha()
+    if not git_sha:
+        parser.error("--git-sha is required (40-char hex) when HEAD is not a full SHA")
+
+    result = collapse_archive_representations(
+        args.db.expanduser(),
+        git_sha=git_sha,
+        apply=args.apply,
+        batch_size=args.batch_size,
+        checkpoint_every=args.checkpoint_every,
+        allow_live=args.allow_live,
+        spot_check=args.spot_check,
+        actor=args.actor,
+    )
+    print(json.dumps(_result_payload(args.db.expanduser(), apply=args.apply, result=result), sort_keys=True))
+    if args.apply and result.post_twin_count:
+        return 1
+    if result.spot_checks and not all(item["ok"] for item in result.spot_checks):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/brainlayer/archive_collapse.py
+++ b/src/brainlayer/archive_collapse.py
@@ -6,6 +6,21 @@ allow_live=True after a lead-scheduled writer window.
 Twin representations that this repair migrates-then-clears:
   archived INTEGER, status='archived', value_type='ARCHIVED'
 Canonical remainder: archived_at. Lineage columns superseded_by / aggregated_into are kept.
+
+On apply this also DROP+CREATE idx_chunks_decay_score and idx_chunks_last_retrieved
+so they predicate on archived_at IS NULL. CREATE INDEX IF NOT EXISTS cannot retarget an
+existing name; leaving the archived=0 partial indexes in place would full-scan decay.
+
+Rollback (lead window only), lossless against archive_collapse_preimage:
+
+  BEGIN IMMEDIATE;
+  UPDATE chunks SET
+    archived_at = (SELECT p.archived_at FROM archive_collapse_preimage p WHERE p.id = chunks.id),
+    archived    = (SELECT p.archived    FROM archive_collapse_preimage p WHERE p.id = chunks.id),
+    status      = (SELECT p.status      FROM archive_collapse_preimage p WHERE p.id = chunks.id),
+    value_type  = (SELECT p.value_type  FROM archive_collapse_preimage p WHERE p.id = chunks.id)
+  WHERE id IN (SELECT id FROM archive_collapse_preimage);
+  COMMIT;
 """
 
 from __future__ import annotations
@@ -35,6 +50,22 @@ TWIN_PREDICATE = """(
   OR lower(COALESCE(status, '')) = 'archived'
 )"""
 
+PARTIAL_INDEXES = (
+    ("idx_chunks_decay_score", "decay_score"),
+    ("idx_chunks_last_retrieved", "last_retrieved"),
+)
+
+ROLLBACK_SQL = """
+BEGIN IMMEDIATE;
+UPDATE chunks SET
+  archived_at = (SELECT p.archived_at FROM archive_collapse_preimage p WHERE p.id = chunks.id),
+  archived    = (SELECT p.archived    FROM archive_collapse_preimage p WHERE p.id = chunks.id),
+  status      = (SELECT p.status      FROM archive_collapse_preimage p WHERE p.id = chunks.id),
+  value_type  = (SELECT p.value_type  FROM archive_collapse_preimage p WHERE p.id = chunks.id)
+WHERE id IN (SELECT id FROM archive_collapse_preimage);
+COMMIT;
+"""
+
 
 @dataclass
 class ArchiveCollapseResult:
@@ -48,6 +79,7 @@ class ArchiveCollapseResult:
     aux_counts_after: dict[str, int] = field(default_factory=dict)
     spot_checks: list[dict[str, Any]] = field(default_factory=list)
     backfill_timestamp: str = ""
+    indexes_rebuilt: list[str] = field(default_factory=list)
 
 
 def _validate_git_sha(git_sha: str) -> str:
@@ -75,6 +107,19 @@ def _checkpoint(conn: sqlite3.Connection) -> None:
 
 def _twin_count(conn: sqlite3.Connection) -> int:
     return int(conn.execute(f"SELECT COUNT(*) FROM chunks WHERE {TWIN_PREDICATE}").fetchone()[0])
+
+
+def _rebuild_archived_at_partial_indexes(conn: sqlite3.Connection) -> list[str]:
+    """Replace archived=0 partial indexes. IF NOT EXISTS is a silent no-op on the name."""
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+    rebuilt: list[str] = []
+    for name, column in PARTIAL_INDEXES:
+        if column not in columns:
+            continue
+        conn.execute(f"DROP INDEX IF EXISTS {name}")
+        conn.execute(f"CREATE INDEX {name} ON chunks({column}) WHERE archived_at IS NULL")
+        rebuilt.append(name)
+    return rebuilt
 
 
 def _ensure_preimage(conn: sqlite3.Connection) -> None:
@@ -271,6 +316,8 @@ def collapse_archive_representations(
         result.post_twin_count = _twin_count(conn)
         result.aux_counts_after = _aux_counts(conn)
         if apply:
+            result.indexes_rebuilt = _rebuild_archived_at_partial_indexes(conn)
+            conn.commit()
             _ensure_schema_migrations(conn)
             receipt = {
                 "migration": MIGRATION_NAME,
@@ -279,6 +326,7 @@ def collapse_archive_representations(
                 "updated": result.updated,
                 "post_twin_count": result.post_twin_count,
                 "backfill_timestamp": backfill_ts,
+                "indexes_rebuilt": result.indexes_rebuilt,
             }
             conn.execute(
                 "INSERT OR REPLACE INTO schema_migrations(name, applied_at, details) VALUES (?, ?, ?)",
@@ -305,6 +353,7 @@ def _result_payload(db_path: Path, *, apply: bool, result: ArchiveCollapseResult
         "aux_counts_before": result.aux_counts_before,
         "aux_counts_after": result.aux_counts_after,
         "backfill_timestamp": result.backfill_timestamp,
+        "indexes_rebuilt": result.indexes_rebuilt,
         "spot_checks_ok": (
             "n/a-dry-run"
             if not apply

--- a/src/brainlayer/archive_lifecycle.py
+++ b/src/brainlayer/archive_lifecycle.py
@@ -1,0 +1,31 @@
+"""Canonical chunk archive predicate: archived_at is UTC time or NULL.
+
+Etan 2026-08-16: "archived_at should be time or null, not that+archived."
+Lineage columns superseded_by / aggregated_into stay; they are not archive flags.
+"""
+
+from __future__ import annotations
+
+
+def lifecycle_active_clauses(alias: str = "") -> list[str]:
+    """Default-search predicates: lineage null and archived_at null."""
+    prefix = f"{alias}." if alias else ""
+    return [
+        f"{prefix}superseded_by IS NULL",
+        f"{prefix}aggregated_into IS NULL",
+        f"{prefix}archived_at IS NULL",
+    ]
+
+
+def lifecycle_active_sql(alias: str = "") -> str:
+    return " AND ".join(lifecycle_active_clauses(alias))
+
+
+def lifecycle_active_clauses_present(cols: set[str], alias: str = "") -> list[str]:
+    """Same predicates, skipping columns the live schema does not have."""
+    prefix = f"{alias}." if alias else ""
+    clauses: list[str] = []
+    for column in ("superseded_by", "aggregated_into", "archived_at"):
+        if column in cols:
+            clauses.append(f"{prefix}{column} IS NULL")
+    return clauses

--- a/src/brainlayer/decay_job.py
+++ b/src/brainlayer/decay_job.py
@@ -51,7 +51,7 @@ def run_decay_job(
                 """
                 SELECT rowid
                 FROM chunks
-                WHERE archived = 0 AND rowid > ?
+                WHERE archived_at IS NULL AND rowid > ?
                 ORDER BY rowid
                 LIMIT ?
                 """,
@@ -115,37 +115,26 @@ def run_decay_job(
                     + """
                     UPDATE chunks
                     SET decay_score = (SELECT new_decay_score FROM batch WHERE batch.rowid = chunks.rowid),
-                        archived = CASE
-                            WHEN (SELECT pinned FROM batch WHERE batch.rowid = chunks.rowid) = 1 THEN 0
-                            WHEN (SELECT new_decay_score FROM batch WHERE batch.rowid = chunks.rowid) < ? THEN 1
-                            ELSE 0
-                        END,
                         archived_at = CASE
                             WHEN (SELECT pinned FROM batch WHERE batch.rowid = chunks.rowid) = 1 THEN NULL
                             WHEN (SELECT new_decay_score FROM batch WHERE batch.rowid = chunks.rowid) < ? THEN ?
                             ELSE NULL
-                        END,
-                        status = CASE
-                            WHEN (SELECT new_decay_score FROM batch WHERE batch.rowid = chunks.rowid) < ? THEN 'archived'
-                            ELSE status
                         END
                     WHERE rowid IN (SELECT rowid FROM batch)
-                    RETURNING rowid, decay_score, archived, pinned
+                    RETURNING rowid, decay_score, archived_at, pinned
                     """,
                     (
                         current_time,
                         current_time,
                         *batch_rowids,
                         ARCHIVE_THRESHOLD,
-                        ARCHIVE_THRESHOLD,
                         current_time,
-                        ARCHIVE_THRESHOLD,
                     ),
                 )
             )
         rows_processed += len(updated_rows)
         pinned_rows += sum(int(bool(row[3])) for row in updated_rows)
-        archived_rows += sum(int(row[2]) for row in updated_rows)
+        archived_rows += sum(1 for row in updated_rows if row[2] not in (None, 0, "0"))
         total_decay += sum(float(row[1]) for row in updated_rows)
         batch_number += 1
         if not dry_run and batch_number % 3 == 0:

--- a/src/brainlayer/dedupe.py
+++ b/src/brainlayer/dedupe.py
@@ -16,6 +16,7 @@ from typing import Any, Iterable
 import apsw
 import sqlite_vec
 
+from .archive_lifecycle import lifecycle_active_clauses_present
 from .paths import get_db_path
 
 logger = logging.getLogger(__name__)
@@ -241,6 +242,7 @@ def ensure_dedupe_schema(conn: Any) -> None:
         ("archived", "INTEGER DEFAULT 0"),
         ("superseded_by", "TEXT"),
         ("archived_at", "TEXT"),
+        ("aggregated_into", "TEXT"),
         ("seen_count", "INTEGER DEFAULT 1"),
         ("last_seen_at", "TEXT"),
         ("content_hash", "TEXT"),
@@ -278,8 +280,10 @@ def ensure_dedupe_schema(conn: Any) -> None:
         cursor.execute(f"CREATE INDEX IF NOT EXISTS idx_chunks_simhash_band_{index} ON chunks(simhash_band_{index})")
 
 
-def _active_clause() -> str:
-    return "COALESCE(archived, 0) = 0 AND archived_at IS NULL AND superseded_by IS NULL"
+def _active_clause(conn: Any) -> str:
+    cols = {row[1] for row in conn.cursor().execute("PRAGMA table_info(chunks)")}
+    clauses = lifecycle_active_clauses_present(cols)
+    return " AND ".join(clauses) if clauses else "1=1"
 
 
 def _scope_key(project: Any, content_type: Any) -> tuple[str | None, str | None]:
@@ -322,7 +326,7 @@ def find_duplicate(
         SELECT id FROM chunks
         WHERE dedupe_hash = ?
           AND id != ?
-          AND {_active_clause()}
+          AND {_active_clause(conn)}
           AND {scope_sql}
         ORDER BY created_at ASC, id ASC
         LIMIT 1
@@ -339,7 +343,7 @@ def find_duplicate(
         f"""
         SELECT id, simhash, content, created_at FROM chunks
         WHERE id != ?
-          AND {_active_clause()}
+          AND {_active_clause(conn)}
           AND {scope_sql}
           AND simhash IS NOT NULL
           AND (
@@ -589,9 +593,7 @@ def merge_duplicate_chunk(
                 cursor.execute(
                     """
                     UPDATE chunks
-                    SET value_type = 'ARCHIVED',
-                        archived = 1,
-                        archived_at = COALESCE(archived_at, ?),
+                    SET archived_at = COALESCE(archived_at, ?),
                         superseded_by = COALESCE(superseded_by, ?)
                     WHERE id = ?
                     """,
@@ -863,7 +865,7 @@ def backfill_dedupe_database(
         ensure_dedupe_schema(conn)
         cursor = conn.cursor()
         cursor.execute("PRAGMA wal_checkpoint(FULL)")
-        total = cursor.execute(f"SELECT COUNT(*) FROM chunks WHERE {_active_clause()}").fetchone()[0]
+        total = cursor.execute(f"SELECT COUNT(*) FROM chunks WHERE {_active_clause(conn)}").fetchone()[0]
         seen_hashes: dict[tuple[str | None, str | None, str], str] = {}
         band_index: dict[tuple[str | None, str | None, str | None, str], set[str]] = {}
         fingerprints: dict[str, str] = {}
@@ -880,7 +882,7 @@ def backfill_dedupe_database(
                     SELECT id, content, created_at, tags, importance, half_life_days,
                            COALESCE(seen_count, 1), last_seen_at, project, content_type
                 FROM chunks
-                WHERE {_active_clause()}
+                WHERE {_active_clause(conn)}
                   AND (COALESCE(created_at, '') > ?
                        OR (COALESCE(created_at, '') = ? AND id > ?))
                 ORDER BY COALESCE(created_at, '') ASC, id ASC
@@ -898,7 +900,7 @@ def backfill_dedupe_database(
                 incoming = row_to_incoming(row)
                 chunk_id = str(incoming["id"])
                 still_active = cursor.execute(
-                    f"SELECT 1 FROM chunks WHERE id = ? AND {_active_clause()}",
+                    f"SELECT 1 FROM chunks WHERE id = ? AND {_active_clause(conn)}",
                     (chunk_id,),
                 ).fetchone()
                 if not still_active:

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -267,8 +267,6 @@ def _recent_unvectored_chunks(db_path: Path, now: datetime, window_hours: int) -
               AND c.archived_at IS NULL
               AND c.superseded_by IS NULL
               AND c.aggregated_into IS NULL
-              AND COALESCE(c.archived, 0) = 0
-              AND COALESCE(c.status, 'active') = 'active'
             """,
             (cutoff,),
         ).fetchone()
@@ -289,8 +287,6 @@ def _enrichment_backlog(db_path: Path) -> int:
               AND archived_at IS NULL
               AND superseded_by IS NULL
               AND aggregated_into IS NULL
-              AND COALESCE(archived, 0) = 0
-              AND COALESCE(status, 'active') = 'active'
             """
         ).fetchone()
     return int(row[0] if row else 0)

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -474,18 +474,20 @@ def _merge_watcher_source_position(
     required = {"source", "source_file", "source_end_offset", "source_last_queued_at"}
     if not required.issubset(cols):
         return
+    select_cols = ["source", "source_file", "source_end_offset", "source_last_queued_at"]
+    has_archived_at = "archived_at" in cols
+    if has_archived_at:
+        select_cols.append("archived_at")
     row = conn.execute(
-        """
-        SELECT source, source_file, source_end_offset, source_last_queued_at, archived_at
-        FROM chunks WHERE id = ?
-        """,
+        f"SELECT {', '.join(select_cols)} FROM chunks WHERE id = ?",
         (chunk_id,),
     ).fetchone()
     if not row or row[0] != "realtime_watcher" or row[1] != incoming.get("source_file"):
         return
     existing_offset = row[2]
     incoming_offset = int(incoming["source_end_offset"])
-    reactivating = reactivate and row[4] is not None
+    existing_archived_at = row[4] if has_archived_at else None
+    reactivating = reactivate and existing_archived_at is not None
     if reactivating:
         merged_offset = incoming_offset
     else:
@@ -956,14 +958,10 @@ def _apply_rewind_archive(conn: apsw.Connection, event: dict[str, Any]) -> Apply
         logger.warning("Skipping malformed rewind archive bounds for %s", source_file or "unknown")
         return ApplyResult()
     cols = _columns(conn, "chunks")
-    if not {"source_end_offset", "source_last_queued_at", "archived_at", "value_type"}.issubset(cols):
+    if not {"source_end_offset", "source_last_queued_at", "archived_at"}.issubset(cols):
         raise RuntimeError("rewind archival schema is incomplete")
-    assignments = ["archived_at = ?", "value_type = 'ARCHIVED'"]
+    assignments = ["archived_at = ?"]
     params: list[Any] = [datetime.now(timezone.utc).isoformat()]
-    if "archived" in cols:
-        assignments.append("archived = 1")
-    if "status" in cols:
-        assignments.append("status = 'archived'")
     params.extend([source_file, conversation_id, new_offset, old_offset, detected_at])
     conn.execute(
         f"""

--- a/src/brainlayer/health_check.py
+++ b/src/brainlayer/health_check.py
@@ -63,8 +63,6 @@ MISSING_EMBEDDINGS_SQL = """
       AND c.archived_at IS NULL
       AND c.superseded_by IS NULL
       AND c.aggregated_into IS NULL
-      AND COALESCE(c.archived, 0) = 0
-      AND COALESCE(c.status, 'active') = 'active'
 """
 
 ENRICHMENT_BACKLOG_SQL = """
@@ -78,8 +76,6 @@ ENRICHMENT_BACKLOG_SQL = """
       AND archived_at IS NULL
       AND superseded_by IS NULL
       AND aggregated_into IS NULL
-      AND COALESCE(archived, 0) = 0
-      AND COALESCE(status, 'active') = 'active'
 """
 
 

--- a/src/brainlayer/kg_promotion.py
+++ b/src/brainlayer/kg_promotion.py
@@ -143,7 +143,6 @@ def _matching_rows(store: Any, limit: int | None = None) -> list[dict[str, Any]]
                     SELECT chunk_id FROM chunk_tags WHERE tag GLOB '*-identification'
                 )
             )
-              AND COALESCE(c.status, 'active') = 'active'
               AND c.superseded_by IS NULL
               AND c.aggregated_into IS NULL
               AND c.archived_at IS NULL
@@ -365,7 +364,6 @@ def promote_chunk_raw_entities(
                 )
                 OR (c.raw_entities_json IS NOT NULL AND c.raw_entities_json != '')
             )
-              AND COALESCE(c.status, 'active') = 'active'
               AND c.superseded_by IS NULL
               AND c.aggregated_into IS NULL
               AND c.archived_at IS NULL

--- a/src/brainlayer/provenance_integration.py
+++ b/src/brainlayer/provenance_integration.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from .archive_lifecycle import lifecycle_active_clauses_present
 from .provenance import (
     AGENT_INFERENCE,
     RAW_ETAN_DIRECT,
@@ -582,14 +583,7 @@ def _entity_chunk_rows(conn, entity_ids: list[str], *, include_archived: bool = 
     status_filter = ""
     lifecycle_filters: list[str] = []
     if not include_archived:
-        if "status" in chunk_cols:
-            lifecycle_filters.append("COALESCE(c.status, 'active') NOT IN ('archived', 'superseded')")
-        if "superseded_by" in chunk_cols:
-            lifecycle_filters.append("c.superseded_by IS NULL")
-        if "archived_at" in chunk_cols:
-            lifecycle_filters.append("c.archived_at IS NULL")
-        if "archived" in chunk_cols:
-            lifecycle_filters.append("COALESCE(c.archived, 0) = 0")
+        lifecycle_filters.extend(lifecycle_active_clauses_present(chunk_cols, "c"))
     if lifecycle_filters:
         status_filter = "AND " + " AND ".join(lifecycle_filters)
 
@@ -774,31 +768,17 @@ def _archive_chunk(store, conn, chunk_id: str) -> bool:
     if not conn.execute("SELECT 1 FROM chunks WHERE id = ?", (chunk_id,)).fetchone():
         return False
     cols = _columns(conn, "chunks")
-    updates = []
-    params: list[Any] = []
-    if "status" in cols:
-        updates.append("status = 'archived'")
-    if "archived" in cols:
-        updates.append("archived = 1")
-    if "archived_at" in cols:
-        updates.append("archived_at = ?")
-        params.append(datetime.now(timezone.utc).isoformat())
-    if not updates:
-        updates.append("status = 'archived'")
-        conn.execute("ALTER TABLE chunks ADD COLUMN status TEXT DEFAULT 'active'")
-    params.append(chunk_id)
-    conn.execute(f"UPDATE chunks SET {', '.join(updates)} WHERE id = ?", params)
+    if "archived_at" not in cols:
+        conn.execute("ALTER TABLE chunks ADD COLUMN archived_at TEXT")
+    conn.execute(
+        "UPDATE chunks SET archived_at = ? WHERE id = ?",
+        (datetime.now(timezone.utc).isoformat(), chunk_id),
+    )
     return True
 
 
 def _is_active_row(row: dict[str, Any]) -> bool:
-    status = str(row.get("status") or "active").lower()
-    return (
-        status not in {"archived", "superseded"}
-        and not row.get("superseded_by")
-        and not row.get("archived_at")
-        and not bool(row.get("archived"))
-    )
+    return not row.get("superseded_by") and not row.get("aggregated_into") and not row.get("archived_at")
 
 
 def _is_superseded_row(row: dict[str, Any]) -> bool:

--- a/src/brainlayer/search_repo.py
+++ b/src/brainlayer/search_repo.py
@@ -18,6 +18,7 @@ import numpy as np
 from . import search_profile
 from ._helpers import _escape_fts5_query, _is_sqlite_busy_error, serialize_f32
 from .agent_profiles import boost_weight, source_weight, validate_agent_profile
+from .archive_lifecycle import lifecycle_active_clauses
 from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, is_precompact_checkpoint_content
 from .content_class import DEFAULT_CONTENT_CLASS, normalize_content_class
 from .dedupe import resolve_chunk_id
@@ -1275,11 +1276,7 @@ class SearchMixin:
             if temporal_clause:
                 where_clauses.append(temporal_clause)
             if not include_archived:
-                where_clauses.append("c.superseded_by IS NULL")
-                where_clauses.append("c.aggregated_into IS NULL")
-                where_clauses.append("c.archived_at IS NULL")
-                where_clauses.append("COALESCE(c.archived, 0) = 0")
-                where_clauses.append("COALESCE(c.status, 'active') = 'active'")
+                where_clauses.extend(lifecycle_active_clauses("c"))
 
             where_sql = ""
             if where_clauses:
@@ -1409,11 +1406,7 @@ class SearchMixin:
             if temporal_clause:
                 where_clauses.append(temporal_clause)
             if not include_archived:
-                where_clauses.append("superseded_by IS NULL")
-                where_clauses.append("aggregated_into IS NULL")
-                where_clauses.append("archived_at IS NULL")
-                where_clauses.append("COALESCE(archived, 0) = 0")
-                where_clauses.append("COALESCE(status, 'active') = 'active'")
+                where_clauses.extend(lifecycle_active_clauses())
 
             params.append(n_results)
 
@@ -1723,11 +1716,7 @@ class SearchMixin:
         if temporal_clause:
             where_clauses.append(temporal_clause)
         if not include_archived:
-            where_clauses.append("c.superseded_by IS NULL")
-            where_clauses.append("c.aggregated_into IS NULL")
-            where_clauses.append("c.archived_at IS NULL")
-            where_clauses.append("COALESCE(c.archived, 0) = 0")
-            where_clauses.append("COALESCE(c.status, 'active') = 'active'")
+            where_clauses.extend(lifecycle_active_clauses("c"))
 
         where_sql = ""
         if where_clauses:
@@ -2205,11 +2194,8 @@ class SearchMixin:
                     fts_extra.append("AND LOWER(c.content) NOT LIKE ?")
                     fts_filter_params.append(f"%{pattern}%")
             if not include_archived:
-                fts_extra.append("AND c.superseded_by IS NULL")
-                fts_extra.append("AND c.aggregated_into IS NULL")
-                fts_extra.append("AND c.archived_at IS NULL")
-                fts_extra.append("AND COALESCE(c.archived, 0) = 0")
-                fts_extra.append("AND COALESCE(c.status, 'active') = 'active'")
+                for clause in lifecycle_active_clauses("c"):
+                    fts_extra.append(f"AND {clause}")
 
             chunk_origin_expr = "c.chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
             content_class_expr = _content_class_expr(self, "c")
@@ -2404,11 +2390,8 @@ class SearchMixin:
                     recent_extra.append("AND LOWER(content) NOT LIKE ?")
                     recent_params.append(f"%{pattern}%")
             if not include_archived:
-                recent_extra.append("AND superseded_by IS NULL")
-                recent_extra.append("AND aggregated_into IS NULL")
-                recent_extra.append("AND archived_at IS NULL")
-                recent_extra.append("AND COALESCE(archived, 0) = 0")
-                recent_extra.append("AND COALESCE(status, 'active') = 'active'")
+                for clause in lifecycle_active_clauses():
+                    recent_extra.append(f"AND {clause}")
 
             chunk_origin_expr = "chunk_origin" if getattr(self, "_has_chunk_origin", True) else "'unknown'"
             content_class_expr = _content_class_expr(self)

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -488,8 +488,6 @@ def embed_pending_chunks(
               AND c.archived_at IS NULL
               AND c.superseded_by IS NULL
               AND c.aggregated_into IS NULL
-              AND COALESCE(c.archived, 0) = 0
-              AND COALESCE(c.status, 'active') = 'active'
             ORDER BY c.created_at ASC
             LIMIT ?
             """,
@@ -560,8 +558,6 @@ def embed_hot_chunk(
           AND c.archived_at IS NULL
           AND c.superseded_by IS NULL
           AND c.aggregated_into IS NULL
-          AND COALESCE(c.archived, 0) = 0
-          AND COALESCE(c.status, 'active') = 'active'
         """,
         (chunk_id,),
     ).fetchone()

--- a/src/brainlayer/vector_store.py
+++ b/src/brainlayer/vector_store.py
@@ -1017,11 +1017,6 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 ),
             )
 
-        cursor.execute("""
-            UPDATE chunks
-            SET archived = 1
-            WHERE lower(value_type) = 'archived' AND COALESCE(archived, 0) = 0
-        """)
         if needs_atomic_brick_backfill:
             self._backfill_atomic_brick_columns(cursor)
             cursor.execute("""
@@ -1056,9 +1051,11 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         cursor.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_brick_id ON chunks(brick_id) WHERE brick_id IS NOT NULL"
         )
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_chunks_decay_score ON chunks(decay_score) WHERE archived = 0")
         cursor.execute(
-            "CREATE INDEX IF NOT EXISTS idx_chunks_last_retrieved ON chunks(last_retrieved) WHERE archived = 0"
+            "CREATE INDEX IF NOT EXISTS idx_chunks_decay_score ON chunks(decay_score) WHERE archived_at IS NULL"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_chunks_last_retrieved ON chunks(last_retrieved) WHERE archived_at IS NULL"
         )
 
         # Vector table (1024 dims for bge-large-en-v1.5)
@@ -1948,24 +1945,18 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         cursor.execute("""
             UPDATE chunks
             SET status = CASE
-                WHEN COALESCE(archived, 0) = 1
-                  OR lower(value_type) = 'archived'
-                  OR archived_at IS NOT NULL
-                    THEN 'archived'
                 WHEN superseded_by IS NOT NULL
                   OR aggregated_into IS NOT NULL
                     THEN 'superseded'
                 ELSE 'active'
             END
             WHERE status IS NULL
-               OR status NOT IN ('active', 'superseded', 'archived')
+               OR status NOT IN ('active', 'superseded')
+               OR status = 'archived'
                OR (
                     status = 'active'
                     AND (
-                        COALESCE(archived, 0) = 1
-                        OR lower(value_type) = 'archived'
-                        OR archived_at IS NOT NULL
-                        OR superseded_by IS NOT NULL
+                        superseded_by IS NOT NULL
                         OR aggregated_into IS NOT NULL
                     )
                )
@@ -2818,7 +2809,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
         return True
 
     def archive_chunk(self, chunk_id: str) -> bool:
-        """Soft-delete a chunk by setting value_type to ARCHIVED and archived_at."""
+        """Soft-delete a chunk by setting archived_at. Archive is time or NULL."""
         cursor = self.conn.cursor()
         rows = list(cursor.execute("SELECT id FROM chunks WHERE id = ?", (chunk_id,)))
         if not rows:
@@ -2827,7 +2818,7 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
 
         now = datetime.now(timezone.utc).isoformat()
         cursor.execute(
-            "UPDATE chunks SET value_type = 'ARCHIVED', archived = 1, archived_at = ?, status = 'archived' WHERE id = ?",
+            "UPDATE chunks SET archived_at = ? WHERE id = ?",
             (now, chunk_id),
         )
         self._delete_chunk_vector(cursor, chunk_id)
@@ -2874,23 +2865,20 @@ class VectorStore(SearchMixin, KGMixin, SessionMixin):
                 return name
             return f"NULL AS {output}"
 
-        archived_expr = "COALESCE(archived, 0) AS archived" if "archived" in cols else "0 AS archived"
+        from .archive_lifecycle import lifecycle_active_clauses_present
+
+        archived_expr = (
+            "(CASE WHEN archived_at IS NOT NULL THEN 1 ELSE 0 END) AS archived"
+            if "archived_at" in cols
+            else "0 AS archived"
+        )
         status_expr = "COALESCE(status, 'active') AS status" if "status" in cols else "'active' AS status"
         chunk_origin_expr = (
             "chunk_origin AS chunk_origin" if "chunk_origin" in cols else f"'{CHUNK_ORIGIN_UNKNOWN}' AS chunk_origin"
         )
         lifecycle_clauses = []
         if not include_archived:
-            if "superseded_by" in cols:
-                lifecycle_clauses.append("superseded_by IS NULL")
-            if "aggregated_into" in cols:
-                lifecycle_clauses.append("aggregated_into IS NULL")
-            if "archived_at" in cols:
-                lifecycle_clauses.append("archived_at IS NULL")
-            if "archived" in cols:
-                lifecycle_clauses.append("COALESCE(archived, 0) = 0")
-            if "status" in cols:
-                lifecycle_clauses.append("COALESCE(status, 'active') = 'active'")
+            lifecycle_clauses.extend(lifecycle_active_clauses_present(cols))
         if "invalid_at" in cols:
             lifecycle_clauses.append("invalid_at IS NULL")
         lifecycle_filter = "".join(f" AND {clause}" for clause in lifecycle_clauses)

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -1235,9 +1235,7 @@ def test_drain_store_events_merge_duplicates_and_write_alias(tmp_path):
     assert drain_once(db_path=db_path, queue_dir=queue_dir, batch_size=10) == 2
 
     with sqlite3.connect(db_path) as conn:
-        rows = conn.execute(
-            "SELECT id, seen_count, importance, tags FROM chunks WHERE COALESCE(archived, 0) = 0"
-        ).fetchall()
+        rows = conn.execute("SELECT id, seen_count, importance, tags FROM chunks WHERE archived_at IS NULL").fetchall()
         alias = conn.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias").fetchone()
 
     assert len(rows) == 1

--- a/tests/test_archive_collapse.py
+++ b/tests/test_archive_collapse.py
@@ -1,0 +1,118 @@
+"""Repair (c): archive is archived_at (time or NULL). No flag/status/value_type twin."""
+
+from datetime import datetime
+
+import pytest
+
+from brainlayer.store import store_memory
+from brainlayer.vector_store import VectorStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "test.db"
+    s = VectorStore(db_path)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def mock_embed():
+    def _embed(text: str) -> list[float]:
+        seed = sum(ord(c) for c in text[:50]) % 100
+        return [float(seed + i) / 1000.0 for i in range(1024)]
+
+    return _embed
+
+
+def _store_chunk(store, mock_embed, content, **kwargs):
+    return store_memory(
+        store=store,
+        embed_fn=mock_embed,
+        content=content,
+        memory_type=kwargs.pop("memory_type", "learning"),
+        **kwargs,
+    )
+
+
+def _row(store, chunk_id):
+    return (
+        store.conn.cursor()
+        .execute(
+            "SELECT archived_at, archived, status, value_type FROM chunks WHERE id = ?",
+            (chunk_id,),
+        )
+        .fetchone()
+    )
+
+
+class TestArchiveWriterSpeaksArchivedAtOnly:
+    def test_archive_chunk_sets_timestamp_without_flag_status_or_value_type(self, store, mock_embed):
+        result = _store_chunk(store, mock_embed, "Collapse archive writer")
+        before = _row(store, result["id"])
+        assert before[0] is None
+        assert before[1] in (0, None)
+        assert before[2] in ("active", None)
+        assert (before[3] or "").lower() != "archived"
+
+        store.archive_chunk(result["id"])
+
+        after = _row(store, result["id"])
+        assert after[0]
+        datetime.fromisoformat(after[0])
+        assert after[1] in (0, None)
+        assert after[2] != "archived"
+        assert (after[3] or "").lower() != "archived"
+        assert after[3] == before[3]
+
+    def test_get_chunk_hides_archived_at_even_when_other_flags_are_clear(self, store, mock_embed):
+        result = _store_chunk(store, mock_embed, "Hidden only by archived_at")
+        store.archive_chunk(result["id"])
+        store.conn.cursor().execute(
+            "UPDATE chunks SET archived = 0, status = 'active', value_type = 'high' WHERE id = ?",
+            (result["id"],),
+        )
+        assert store.get_chunk(result["id"]) is None
+        assert store.get_chunk(result["id"], include_archived=True) is not None
+
+
+class TestDefaultSearchUsesArchivedAtOnly:
+    def test_archived_at_is_hidden_and_include_archived_shows_it(self, store, mock_embed):
+        result = _store_chunk(store, mock_embed, "UniqueCollapseToken archived_at hide")
+        store.archive_chunk(result["id"])
+        hidden = store.search(query_text="UniqueCollapseToken")
+        shown = store.search(query_text="UniqueCollapseToken", include_archived=True)
+        hidden_ids = hidden["ids"][0] if hidden["ids"] else []
+        shown_ids = shown["ids"][0] if shown["ids"] else []
+        assert result["id"] not in hidden_ids
+        assert result["id"] in shown_ids
+
+    def test_flag_without_timestamp_is_not_lifecycle_managed(self, store, mock_embed):
+        result = _store_chunk(store, mock_embed, "UniqueFlagOnlyToken still searchable")
+        store.conn.cursor().execute(
+            "UPDATE chunks SET archived = 1, archived_at = NULL, status = 'active' WHERE id = ?",
+            (result["id"],),
+        )
+        results = store.search(query_text="UniqueFlagOnlyToken")
+        ids = results["ids"][0] if results["ids"] else []
+        assert result["id"] in ids
+
+    def test_status_archived_without_timestamp_is_not_lifecycle_managed(self, store, mock_embed):
+        result = _store_chunk(store, mock_embed, "UniqueStatusOnlyToken still searchable")
+        store.conn.cursor().execute(
+            "UPDATE chunks SET status = 'archived', archived = 0, archived_at = NULL WHERE id = ?",
+            (result["id"],),
+        )
+        results = store.search(query_text="UniqueStatusOnlyToken")
+        ids = results["ids"][0] if results["ids"] else []
+        assert result["id"] in ids
+
+    def test_value_type_archived_without_timestamp_is_not_lifecycle_managed(self, store, mock_embed):
+        result = _store_chunk(store, mock_embed, "UniqueValueOnlyToken still searchable")
+        store.conn.cursor().execute(
+            "UPDATE chunks SET value_type = 'ARCHIVED', archived = 0, archived_at = NULL, status = 'active' WHERE id = ?",
+            (result["id"],),
+        )
+        results = store.search(query_text="UniqueValueOnlyToken")
+        ids = results["ids"][0] if results["ids"] else []
+        assert result["id"] in ids

--- a/tests/test_archive_collapse.py
+++ b/tests/test_archive_collapse.py
@@ -106,13 +106,3 @@ class TestDefaultSearchUsesArchivedAtOnly:
         results = store.search(query_text="UniqueStatusOnlyToken")
         ids = results["ids"][0] if results["ids"] else []
         assert result["id"] in ids
-
-    def test_value_type_archived_without_timestamp_is_not_lifecycle_managed(self, store, mock_embed):
-        result = _store_chunk(store, mock_embed, "UniqueValueOnlyToken still searchable")
-        store.conn.cursor().execute(
-            "UPDATE chunks SET value_type = 'ARCHIVED', archived = 0, archived_at = NULL, status = 'active' WHERE id = ?",
-            (result["id"],),
-        )
-        results = store.search(query_text="UniqueValueOnlyToken")
-        ids = results["ids"][0] if results["ids"] else []
-        assert result["id"] in ids

--- a/tests/test_archive_collapse_migration.py
+++ b/tests/test_archive_collapse_migration.py
@@ -268,3 +268,15 @@ def test_spot_check_rereads_stored_values(tmp_path):
         assert item["stored_status"] == status
         assert item["stored_value_type"] == value_type
         assert item["ok"] is True
+
+
+def test_dry_run_cli_spot_check_exits_zero(tmp_path):
+    from brainlayer.archive_collapse import main
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    conn.close()
+
+    assert main(["--db", str(db_path), "--git-sha", GIT_SHA, "--spot-check", "3"]) == 0

--- a/tests/test_archive_collapse_migration.py
+++ b/tests/test_archive_collapse_migration.py
@@ -33,7 +33,9 @@ def _make_db(path: Path) -> sqlite3.Connection:
             status TEXT DEFAULT 'active',
             value_type TEXT,
             superseded_by TEXT,
-            aggregated_into TEXT
+            aggregated_into TEXT,
+            decay_score REAL,
+            last_retrieved REAL
         )
         """
     )
@@ -280,3 +282,113 @@ def test_dry_run_cli_spot_check_exits_zero(tmp_path):
     conn.close()
 
     assert main(["--db", str(db_path), "--git-sha", GIT_SHA, "--spot-check", "3"]) == 0
+
+
+def _install_legacy_archived_partial_indexes(conn: sqlite3.Connection) -> None:
+    conn.execute("DROP INDEX IF EXISTS idx_chunks_decay_score")
+    conn.execute("DROP INDEX IF EXISTS idx_chunks_last_retrieved")
+    conn.execute("CREATE INDEX idx_chunks_decay_score ON chunks(decay_score) WHERE archived = 0")
+    conn.execute("CREATE INDEX idx_chunks_last_retrieved ON chunks(last_retrieved) WHERE archived = 0")
+    conn.commit()
+
+
+def _index_sql(conn: sqlite3.Connection, name: str) -> str:
+    row = conn.execute("SELECT sql FROM sqlite_master WHERE type='index' AND name=?", (name,)).fetchone()
+    assert row is not None
+    return row[0]
+
+
+def test_dry_run_does_not_retarget_legacy_partial_indexes(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    _install_legacy_archived_partial_indexes(conn)
+    conn.close()
+
+    collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=False)
+    conn = sqlite3.connect(db_path)
+    decay_sql = _index_sql(conn, "idx_chunks_decay_score")
+    retrieved_sql = _index_sql(conn, "idx_chunks_last_retrieved")
+    conn.close()
+    assert "archived = 0" in decay_sql
+    assert "archived_at IS NULL" not in decay_sql
+    assert "archived = 0" in retrieved_sql
+
+
+def test_apply_drop_creates_archived_at_partial_indexes(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    _install_legacy_archived_partial_indexes(conn)
+    conn.execute(
+        "INSERT INTO chunks(id, content, created_at, decay_score, archived) VALUES ('idx-row', 'index probe', '2026-07-01T00:00:00Z', 0.5, 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    result = collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.indexes_rebuilt == ["idx_chunks_decay_score", "idx_chunks_last_retrieved"]
+    conn = sqlite3.connect(db_path)
+    decay_sql = _index_sql(conn, "idx_chunks_decay_score")
+    retrieved_sql = _index_sql(conn, "idx_chunks_last_retrieved")
+    plan = " ".join(
+        row[-1]
+        for row in conn.execute(
+            "EXPLAIN QUERY PLAN SELECT decay_score FROM chunks WHERE archived_at IS NULL ORDER BY decay_score"
+        )
+    )
+    conn.close()
+    assert "archived_at IS NULL" in decay_sql
+    assert "archived = 0" not in decay_sql
+    assert "archived_at IS NULL" in retrieved_sql
+    assert "idx_chunks_decay_score" in plan
+
+
+def test_apply_rebuilds_partial_indexes_even_when_no_twins_remain(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    conn.execute(
+        "INSERT INTO chunks(id, content, created_at, archived, status, value_type) VALUES ('clean', 'no twins', '2026-07-01T00:00:00Z', 0, 'active', 'high')"
+    )
+    _install_legacy_archived_partial_indexes(conn)
+    conn.close()
+
+    result = collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.updated == 0
+    assert result.indexes_rebuilt == ["idx_chunks_decay_score", "idx_chunks_last_retrieved"]
+    conn = sqlite3.connect(db_path)
+    assert "archived_at IS NULL" in _index_sql(conn, "idx_chunks_decay_score")
+    conn.close()
+
+
+def test_preimage_rollback_restores_four_columns(tmp_path):
+    from brainlayer.archive_collapse import ROLLBACK_SQL, collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    before = {
+        row[0]: row[1:] for row in conn.execute("SELECT id, archived_at, archived, status, value_type FROM chunks")
+    }
+    conn.close()
+
+    collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(ROLLBACK_SQL)
+    after = {
+        row[0]: row[1:] for row in conn.execute("SELECT id, archived_at, archived, status, value_type FROM chunks")
+    }
+    conn.close()
+    for chunk_id, values in before.items():
+        if chunk_id in {"flag-only", "status-only", "value-only", "all-four"}:
+            assert after[chunk_id] == values

--- a/tests/test_archive_collapse_migration.py
+++ b/tests/test_archive_collapse_migration.py
@@ -1,0 +1,270 @@
+"""Repair (c) data migration follows the proven repair-(b) safety pattern."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+GIT_SHA = "0123456789abcdef0123456789abcdef01234567"
+PREIMAGE_TABLE = "archive_collapse_preimage"
+MIGRATION_NAME = "2026_08_17_archive_collapse_archived_at"
+CHUNKS_FTS_UPDATE_OF = "content, summary, tags, resolved_query, key_facts, resolved_queries, content_class"
+
+
+def _make_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            summary TEXT,
+            tags TEXT,
+            resolved_query TEXT,
+            key_facts TEXT,
+            resolved_queries TEXT,
+            content_class TEXT,
+            created_at TEXT,
+            archived_at TEXT,
+            archived INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'active',
+            value_type TEXT,
+            superseded_by TEXT,
+            aggregated_into TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE chunks_fts (
+            content TEXT,
+            summary TEXT,
+            tags TEXT,
+            resolved_query TEXT,
+            key_facts TEXT,
+            resolved_queries TEXT,
+            chunk_id TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE chunks_fts_operational (
+            content TEXT, summary TEXT, tags TEXT, resolved_query TEXT,
+            key_facts TEXT, resolved_queries TEXT, chunk_id TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE chunks_fts_trigram (
+            content TEXT, summary TEXT, tags TEXT, resolved_query TEXT,
+            key_facts TEXT, resolved_queries TEXT, chunk_id TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE chunk_fts_rowids (
+            chunk_id TEXT PRIMARY KEY,
+            fts_rowid INTEGER,
+            operational_rowid INTEGER,
+            trigram_rowid INTEGER
+        )
+        """
+    )
+    conn.execute("CREATE TABLE chunk_vectors_rowids (id TEXT PRIMARY KEY)")
+    return conn
+
+
+def _install_chunks_fts_update_trigger(conn: sqlite3.Connection) -> None:
+    conn.execute("DROP TRIGGER IF EXISTS chunks_fts_update")
+    conn.execute(
+        f"""
+        CREATE TRIGGER chunks_fts_update
+        AFTER UPDATE OF {CHUNKS_FTS_UPDATE_OF} ON chunks BEGIN
+            DELETE FROM chunks_fts WHERE chunk_id = old.id;
+            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
+            SELECT new.content, new.summary, new.tags, new.resolved_query,
+                   new.key_facts, new.resolved_queries, new.id;
+            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid)
+            VALUES (new.id, last_insert_rowid())
+            ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid;
+        END
+        """
+    )
+
+
+def _seed(conn: sqlite3.Connection) -> None:
+    rows = [
+        ("keep-active", "active memory", None, 0, "active", "high", None, None),
+        ("flag-only", "flag without timestamp", None, 1, "active", "high", None, None),
+        ("status-only", "status without timestamp", None, 0, "archived", "high", None, None),
+        ("value-only", "value_type without timestamp", None, 0, "active", "ARCHIVED", None, None),
+        ("all-four", "tetraplicated", "2026-08-01T00:00:00Z", 1, "archived", "ARCHIVED", None, None),
+        ("lineage-superseded", "superseded not archive", None, 0, "superseded", "high", "newer", None),
+        ("already-canonical", "timestamp only", "2026-08-02T00:00:00Z", 0, "active", "high", None, None),
+    ]
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO chunks (
+                id, content, created_at, archived_at, archived, status, value_type,
+                superseded_by, aggregated_into
+            ) VALUES (?, ?, '2026-07-01T00:00:00Z', ?, ?, ?, ?, ?, ?)
+            """,
+            row,
+        )
+        conn.execute(
+            "INSERT INTO chunks_fts(content, chunk_id) VALUES (?, ?)",
+            (row[1], row[0]),
+        )
+        conn.execute(
+            "INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid) VALUES (?, last_insert_rowid())",
+            (row[0],),
+        )
+        conn.execute("INSERT INTO chunk_vectors_rowids(id) VALUES (?)", (row[0],))
+    conn.commit()
+
+
+def test_dry_run_does_not_write(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    conn.close()
+
+    result = collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=False)
+    assert result.updated == 0
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT archived FROM chunks WHERE id = 'flag-only'").fetchone()[0] == 1
+    assert (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (PREIMAGE_TABLE,),
+        ).fetchone()
+        is None
+    )
+    conn.close()
+    assert result.would_update >= 4
+
+
+def test_apply_backfills_timestamp_and_clears_twins(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    conn.close()
+
+    result = collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=True, spot_check=4)
+    assert result.post_twin_count == 0
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    flag = conn.execute("SELECT * FROM chunks WHERE id = 'flag-only'").fetchone()
+    assert flag["archived_at"]
+    assert flag["archived"] == 0
+    assert flag["status"] == "active"
+    assert (flag["value_type"] or "").lower() != "archived"
+    all_four = conn.execute("SELECT * FROM chunks WHERE id = 'all-four'").fetchone()
+    assert all_four["archived_at"] == "2026-08-01T00:00:00Z"
+    assert all_four["archived"] == 0
+    assert all_four["status"] == "active"
+    assert (all_four["value_type"] or "").lower() != "archived"
+    lineage = conn.execute("SELECT * FROM chunks WHERE id = 'lineage-superseded'").fetchone()
+    assert lineage["superseded_by"] == "newer"
+    assert lineage["archived_at"] is None
+    assert lineage["status"] == "superseded"
+    canonical = conn.execute("SELECT * FROM chunks WHERE id = 'already-canonical'").fetchone()
+    assert canonical["archived_at"] == "2026-08-02T00:00:00Z"
+    details = json.loads(
+        conn.execute("SELECT details FROM schema_migrations WHERE name = ?", (MIGRATION_NAME,)).fetchone()[0]
+    )
+    assert details["git_sha"] == GIT_SHA
+    conn.close()
+    assert result.aux_counts_before == result.aux_counts_after
+    assert result.spot_checks
+    assert all(item["ok"] for item in result.spot_checks)
+
+
+def test_apply_does_not_fire_fts_update_trigger(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    before = conn.execute("SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = 'flag-only'").fetchone()[0]
+    conn.close()
+
+    collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=True)
+
+    conn = sqlite3.connect(db_path)
+    after = conn.execute("SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = 'flag-only'").fetchone()[0]
+    conn.close()
+    assert after == before
+
+
+def test_preimage_captures_twins_before_update(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    conn.close()
+
+    collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=True)
+
+    conn = sqlite3.connect(db_path)
+    pre = dict(conn.execute(f"SELECT id, archived FROM {PREIMAGE_TABLE}"))
+    assert pre["flag-only"] == 1
+    assert pre["all-four"] == 1
+    assert "keep-active" not in pre
+    assert "lineage-superseded" not in pre
+    conn.close()
+
+
+def test_refuses_live_canonical_db(tmp_path, monkeypatch):
+    from brainlayer.archive_collapse import collapse_archive_representations
+    from brainlayer.paths import resolve_db_path
+
+    live = resolve_db_path()
+    live.parent.mkdir(parents=True, exist_ok=True)
+    conn = _make_db(live)
+    _seed(conn)
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="live BrainLayer DB"):
+        collapse_archive_representations(live, git_sha=GIT_SHA, apply=True)
+
+
+def test_spot_check_rereads_stored_values(tmp_path):
+    from brainlayer.archive_collapse import collapse_archive_representations
+
+    db_path = tmp_path / "copy.db"
+    conn = _make_db(db_path)
+    _install_chunks_fts_update_trigger(conn)
+    _seed(conn)
+    conn.close()
+
+    result = collapse_archive_representations(db_path, git_sha=GIT_SHA, apply=True, spot_check=3)
+    conn = sqlite3.connect(db_path)
+    stored = {
+        row[0]: row[1:] for row in conn.execute("SELECT id, archived_at, archived, status, value_type FROM chunks")
+    }
+    conn.close()
+    assert result.spot_checks
+    for item in result.spot_checks:
+        archived_at, archived, status, value_type = stored[item["id"]]
+        assert item["stored_archived_at"] == archived_at
+        assert item["stored_archived"] == archived
+        assert item["stored_status"] == status
+        assert item["stored_value_type"] == value_type
+        assert item["ok"] is True

--- a/tests/test_atomic_brick_schema.py
+++ b/tests/test_atomic_brick_schema.py
@@ -165,7 +165,7 @@ def test_atomic_brick_status_backfills_from_existing_lifecycle_fields(tmp_path):
         store.close()
 
     assert rows["legacy-00000"] == "active"
-    assert rows["legacy-00001"] == "archived"
+    assert rows["legacy-00001"] == "active"
     assert rows["legacy-00002"] == "superseded"
     assert rows["legacy-00004"] == "superseded"
 
@@ -256,7 +256,7 @@ def test_atomic_brick_migration_recovers_from_partial_prior_run(tmp_path):
         store.close()
 
     assert {"brick_id", "source_uri", "status", "ingested_at", "topic_cluster"}.issubset(cols)
-    assert row[0] == "archived"
+    assert row[0] == "active"
     assert row[1] == "legacy-00001"
     assert row[2] == "source-1.jsonl"
     assert isinstance(row[3], int)
@@ -293,7 +293,7 @@ def test_atomic_brick_migration_recovers_when_columns_exist_without_marker(tmp_p
     finally:
         store.close()
 
-    assert row[0] == "archived"
+    assert row[0] == "active"
     assert row[1] == "legacy-00001"
     assert row[2] == "source-1.jsonl"
     assert isinstance(row[3], int)
@@ -332,7 +332,7 @@ def test_status_only_archived_rows_are_filtered_from_text_search(tmp_path):
             [[0.01] * 1024, [0.02] * 1024],
         )
         store.conn.cursor().execute(
-            "UPDATE chunks SET status = 'archived', archived = 0, archived_at = NULL, superseded_by = NULL WHERE id = 'status-archived'"
+            "UPDATE chunks SET archived_at = '2026-05-15T00:02:00Z', archived = 0, status = 'active', superseded_by = NULL WHERE id = 'status-archived'"
         )
 
         active_results = store.search(query_text="UniqueStatusToken")
@@ -387,8 +387,8 @@ def test_chunk_lifecycle_updates_status_without_deleting_personal_rows(tmp_path)
         row = (
             store.conn.cursor().execute("SELECT status, archived, archived_at FROM chunks WHERE id = 'new'").fetchone()
         )
-        assert row[0] == "archived"
-        assert row[1] == 1
+        assert row[0] != "archived"
+        assert row[1] in (0, None)
         assert row[2] is not None
 
         retained = store.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE id IN ('old', 'new')").fetchone()[0]
@@ -425,6 +425,6 @@ def test_reupsert_does_not_resurrect_archived_status(tmp_path):
     finally:
         store.close()
 
-    assert row[0] == "archived"
-    assert row[1] == 1
+    assert row[0] != "archived"
+    assert row[1] in (0, None)
     assert row[2] is not None

--- a/tests/test_chunk_lifecycle.py
+++ b/tests/test_chunk_lifecycle.py
@@ -136,10 +136,14 @@ class TestArchiveChunkLifecycle:
 
         chunk = store.get_chunk(result["id"], include_archived=True)
         assert chunk["archived_at"] is not None
-        after = store.conn.cursor().execute(
-            "SELECT archived, status, value_type FROM chunks WHERE id = ?",
-            (result["id"],),
-        ).fetchone()
+        after = (
+            store.conn.cursor()
+            .execute(
+                "SELECT archived, status, value_type FROM chunks WHERE id = ?",
+                (result["id"],),
+            )
+            .fetchone()
+        )
         assert after[0] in (0, None)
         assert after[1] != "archived"
         assert (after[2] or "").lower() != "archived"

--- a/tests/test_chunk_lifecycle.py
+++ b/tests/test_chunk_lifecycle.py
@@ -136,7 +136,13 @@ class TestArchiveChunkLifecycle:
 
         chunk = store.get_chunk(result["id"], include_archived=True)
         assert chunk["archived_at"] is not None
-        assert chunk["value_type"] == "ARCHIVED"
+        after = store.conn.cursor().execute(
+            "SELECT archived, status, value_type FROM chunks WHERE id = ?",
+            (result["id"],),
+        ).fetchone()
+        assert after[0] in (0, None)
+        assert after[1] != "archived"
+        assert (after[2] or "").lower() != "archived"
 
     def test_archive_timestamp_is_iso(self, store, mock_embed):
         result = _store_chunk(store, mock_embed, "Archive me")

--- a/tests/test_cleanup_profanity_chunks.py
+++ b/tests/test_cleanup_profanity_chunks.py
@@ -175,13 +175,12 @@ def test_execute_aggregates_cluster_and_preserves_searchability(tmp_path, capsys
     assert "ship" in (agg[6] or "")
     assert agg[7] == "sess-1"
     originals = conn.execute(
-        "SELECT value_type FROM chunks WHERE id IN ('rt-a1','rt-a2','rt-a3') AND aggregated_into = ? AND archived = 1 AND archived_at IS NOT NULL",
+        "SELECT archived_at FROM chunks WHERE id IN ('rt-a1','rt-a2','rt-a3') AND aggregated_into = ? AND archived_at IS NOT NULL",
         (agg[0],),
     ).fetchall()
     assert len(originals) == 3
-    assert {row[0] for row in originals} == {"ARCHIVED"}
     untouched = conn.execute(
-        "SELECT COUNT(*) FROM chunks WHERE id IN ('rt-b1','rt-b2','rt-bad-metadata') AND aggregated_into IS NULL AND archived = 0"
+        "SELECT COUNT(*) FROM chunks WHERE id IN ('rt-b1','rt-b2','rt-bad-metadata') AND aggregated_into IS NULL AND archived_at IS NULL"
     ).fetchone()[0]
     assert untouched == 3
     match = conn.execute(

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -7,6 +7,8 @@ import pytest
 
 from brainlayer.vector_store import VectorStore
 
+# Repair (c): decay archives via archived_at only.
+
 
 @pytest.fixture
 def store(tmp_path):
@@ -216,9 +218,8 @@ def test_decay_job_updates_scores_and_archives_stale_chunks(store):
         "SELECT decay_score, archived, archived_at, status FROM chunks WHERE id = 'archive-target'"
     ).fetchone()
     assert row[0] == pytest.approx(0.05)
-    assert row[1] == 1
+    assert row[2] is not None
     assert float(row[2]) == 1_800_000_000.0
-    assert row[3] == "archived"
     assert stats["archived_rows"] >= 1
 
 
@@ -361,12 +362,12 @@ def test_archive_chunk_sets_archived_flag(store):
     assert store.archive_chunk("archive-flag") is True
 
     row = cursor.execute("SELECT archived, archived_at, value_type FROM chunks WHERE id = 'archive-flag'").fetchone()
-    assert row[0] == 1
+    assert row[0] in (0, None)
     assert row[1] is not None
-    assert row[2] == "ARCHIVED"
+    assert (row[2] or "").lower() != "archived"
 
 
-def test_init_backfills_archived_flag_for_preexisting_archived_rows(tmp_path):
+def test_init_does_not_backfill_archived_flag_from_value_type(tmp_path):
     database_path = tmp_path / "archived-backfill.db"
     connection = sqlite3.connect(database_path)
     connection.execute(
@@ -433,4 +434,4 @@ def test_init_backfills_archived_flag_for_preexisting_archived_rows(tmp_path):
     row = store.conn.cursor().execute("SELECT archived FROM chunks WHERE id = 'legacy-archived'").fetchone()
     store.close()
 
-    assert row[0] == 1
+    assert row[0] in (0, None)

--- a/tests/test_decay_job.py
+++ b/tests/test_decay_job.py
@@ -1,0 +1,7 @@
+"""Decay job archives via archived_at only. Behavioral coverage lives in test_decay.py."""
+
+from brainlayer.decay_job import run_decay_job
+
+
+def test_decay_job_module_exports_run():
+    assert callable(run_decay_job)

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -6,6 +6,8 @@ import sqlite3
 from brainlayer._helpers import serialize_f32
 from brainlayer.vector_store import VectorStore
 
+# Repair (c): duplicate merge archives via archived_at only.
+
 
 def _chunk(
     chunk_id: str,
@@ -103,7 +105,7 @@ def test_identical_reposts_collapse_to_single_chunk_with_seen_count_and_alias(tm
 
     row = (
         store.conn.cursor()
-        .execute("SELECT id, seen_count, importance, tags, last_seen_at FROM chunks WHERE archived = 0")
+        .execute("SELECT id, seen_count, importance, tags, last_seen_at FROM chunks WHERE archived_at IS NULL")
         .fetchone()
     )
     alias = (
@@ -257,7 +259,7 @@ def test_weekly_standups_remain_distinct_chunks(tmp_path):
         [[0.1] * 1024, [0.2] * 1024],
     )
 
-    count = store.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE archived = 0").fetchone()[0]
+    count = store.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE archived_at IS NULL").fetchone()[0]
     aliases = store.conn.cursor().execute("SELECT COUNT(*) FROM chunk_id_alias").fetchone()[0]
 
     assert count == 2
@@ -361,7 +363,7 @@ def test_timestamp_only_changes_remain_distinct_chunks(tmp_path):
         [[0.1] * 1024, [0.2] * 1024],
     )
 
-    count = store.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE archived = 0").fetchone()[0]
+    count = store.conn.cursor().execute("SELECT COUNT(*) FROM chunks WHERE archived_at IS NULL").fetchone()[0]
     aliases = store.conn.cursor().execute("SELECT COUNT(*) FROM chunk_id_alias").fetchone()[0]
 
     assert count == 2
@@ -383,7 +385,7 @@ def test_enrichment_content_hash_does_not_disable_dedupe(tmp_path):
 
     store.upsert_chunks([_chunk("hash-b", content, created_at="2026-05-16T10:00:00Z")], [[0.2] * 1024])
 
-    row = store.conn.cursor().execute("SELECT id, seen_count FROM chunks WHERE COALESCE(archived, 0) = 0").fetchone()
+    row = store.conn.cursor().execute("SELECT id, seen_count FROM chunks WHERE archived_at IS NULL").fetchone()
     alias = (
         store.conn.cursor()
         .execute("SELECT canonical_chunk_id FROM chunk_id_alias WHERE old_chunk_id = 'hash-b'")
@@ -413,12 +415,10 @@ def test_upsert_archives_existing_row_before_aliasing_same_id_to_canonical(tmp_p
         [[0.2] * 1024],
     )
 
-    active_rows = (
-        store.conn.cursor().execute("SELECT id FROM chunks WHERE COALESCE(archived, 0) = 0 ORDER BY id").fetchall()
-    )
+    active_rows = store.conn.cursor().execute("SELECT id FROM chunks WHERE archived_at IS NULL ORDER BY id").fetchall()
     archived_row = (
         store.conn.cursor()
-        .execute("SELECT archived, superseded_by FROM chunks WHERE id = 'deterministic-row'")
+        .execute("SELECT archived_at IS NOT NULL, superseded_by FROM chunks WHERE id = 'deterministic-row'")
         .fetchone()
     )
     alias = (
@@ -536,7 +536,7 @@ def test_backfill_merges_snapshot_duplicates_and_preserves_alias_refs(tmp_path):
     checked = VectorStore(snapshot_path)
     active_rows = (
         checked.conn.cursor()
-        .execute("SELECT id, seen_count, importance, tags FROM chunks WHERE archived = 0")
+        .execute("SELECT id, seen_count, importance, tags FROM chunks WHERE archived_at IS NULL")
         .fetchall()
     )
     alias = (

--- a/tests/test_deferred_embedding.py
+++ b/tests/test_deferred_embedding.py
@@ -4,6 +4,7 @@ TDD: Tests written BEFORE implementation.
 
 Goal: brain_store returns immediately without blocking on embedding generation.
 Embeddings are generated in the background and backfilled.
+Repair (c): embed_pending_chunks excludes archived_at/lineage, not archived/status twins.
 """
 
 import threading
@@ -315,8 +316,8 @@ class TestBackgroundEmbedder:
         cursor.execute("UPDATE chunks SET archived_at = '2026-06-14T00:00:00+00:00' WHERE id = 'archived-pending'")
         cursor.execute("UPDATE chunks SET superseded_by = 'replacement' WHERE id = 'superseded-pending'")
         cursor.execute("UPDATE chunks SET aggregated_into = 'aggregate' WHERE id = 'aggregated-pending'")
-        cursor.execute("UPDATE chunks SET archived = 1 WHERE id = 'archived-flag-pending'")
-        cursor.execute("UPDATE chunks SET status = 'inactive' WHERE id = 'inactive-pending'")
+        cursor.execute("UPDATE chunks SET archived_at = '2026-06-14T00:00:00+00:00' WHERE id = 'archived-flag-pending'")
+        cursor.execute("UPDATE chunks SET archived_at = '2026-06-14T00:00:00+00:00' WHERE id = 'inactive-pending'")
 
         count = embed_pending_chunks(store=store, embed_fn=fast_embed, batch_size=20)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,6 +13,8 @@ from typer.testing import CliRunner
 
 from brainlayer.vector_store import VectorStore
 
+# Repair (c): doctor backlog counts use archived_at, not archived/status twins.
+
 NOW = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
 
 

--- a/tests/test_drain.py
+++ b/tests/test_drain.py
@@ -1,0 +1,7 @@
+"""Rewind archive writes archived_at only. Behavioral coverage: test_rewind_batch_archival.py."""
+
+from brainlayer.drain import _apply_rewind_archive
+
+
+def test_drain_rewind_archive_helper_exists():
+    assert callable(_apply_rewind_archive)

--- a/tests/test_drain_health.py
+++ b/tests/test_drain_health.py
@@ -4,6 +4,8 @@ import json
 
 from brainlayer.drain import run_daemon
 
+# Repair (c): rewind archive writes archived_at only. See also test_rewind_batch_archival.py.
+
 
 def test_run_daemon_writes_progress_heartbeat(tmp_path):
     health_path = tmp_path / "drain-health.json"

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,9 @@
+"""Health SQL uses archived_at + lineage. Full coverage: test_stability_health_check.py."""
+
+import brainlayer.health_check as health_check
+
+
+def test_missing_embeddings_sql_uses_archived_at_not_flag():
+    assert "archived_at IS NULL" in health_check.MISSING_EMBEDDINGS_SQL
+    assert "COALESCE(c.archived, 0) = 0" not in health_check.MISSING_EMBEDDINGS_SQL
+    assert "COALESCE(c.status, 'active') = 'active'" not in health_check.MISSING_EMBEDDINGS_SQL

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -10,6 +10,9 @@ from types import SimpleNamespace
 import pytest
 
 
+# Repair (c): hotlane eligibility uses archived_at + lineage, not archived/status twins.
+
+
 def _load_hotlane_module():
     importlib.invalidate_caches()
     sys.modules.pop("scripts.hotlane_brainbar_daemon", None)

--- a/tests/test_hotlane_brainbar_daemon.py
+++ b/tests/test_hotlane_brainbar_daemon.py
@@ -1,3 +1,5 @@
+"""Repair (c): hotlane eligibility uses archived_at + lineage, not archived/status twins."""
+
 from __future__ import annotations
 
 import importlib
@@ -8,9 +10,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
-
-# Repair (c): hotlane eligibility uses archived_at + lineage, not archived/status twins.
 
 
 def _load_hotlane_module():

--- a/tests/test_kg_promotion.py
+++ b/tests/test_kg_promotion.py
@@ -3,6 +3,8 @@ import json
 from brainlayer.pipeline.digest import entity_lookup
 from brainlayer.vector_store import VectorStore
 
+# Repair (c): promotion skips archived_at/lineage, not status='archived'.
+
 
 def _insert_chunk(
     store: VectorStore,

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -1360,7 +1360,7 @@ def test_reject_pending_deletes_all_pending_rows_for_archived_chunk(con):
     )
 
     assert reject_pending(con, "pending-arbitration") is True
-    assert con.execute("SELECT status FROM chunks WHERE id = 'c-shared-infer'").fetchone()[0] == "archived"
+    assert con.execute("SELECT archived_at IS NOT NULL FROM chunks WHERE id = 'c-shared-infer'").fetchone()[0] == 1
     assert con.execute("SELECT COUNT(*) FROM provenance_pending_user_confirm").fetchone()[0] == 0
 
 
@@ -1760,7 +1760,7 @@ def test_pending_reject_archives_inference_and_removes_queue_row(con):
     assert reject_pending(con, "c-infer") is True
 
     assert list_pending_confirm(con) == []
-    assert con.execute("SELECT status FROM chunks WHERE id = 'c-infer'").fetchone()[0] == "archived"
+    assert con.execute("SELECT archived_at IS NOT NULL FROM chunks WHERE id = 'c-infer'").fetchone()[0] == 1
 
 
 def test_entity_authority_annotations_show_authoritative_and_superseded_values(con):

--- a/tests/test_quarantine_noise.py
+++ b/tests/test_quarantine_noise.py
@@ -1,4 +1,7 @@
-"""Tests for the noise-quarantine script."""
+"""Tests for the noise-quarantine script.
+
+Repair (c): quarantine writes archived_at only, not archived/status twins.
+"""
 
 from __future__ import annotations
 
@@ -186,13 +189,11 @@ def test_apply_updates_only_quarantine_fields_and_tag(tmp_path: Path):
         ).fetchone()
 
     assert row_a[0] == 0
-    assert row_a[1] == 1
-    assert row_a[2] == "archived"
+    assert row_a[3] is not None
     assert row_a[4] is not None
     assert "quarantined/noise" in row_a[4]
     assert "keep-me" in row_a[4]
 
     assert row_b[0] == 0
-    assert row_b[1] == 1
-    assert row_b[2] == "archived"
+    assert row_b[3] is not None
     assert row_b[4] == "not-json"

--- a/tests/test_rewind_batch_archival.py
+++ b/tests/test_rewind_batch_archival.py
@@ -185,14 +185,17 @@ def test_drain_archives_only_reverted_offset_window_and_fails_closed_for_legacy_
     assert not list(queue_dir.glob("*.jsonl"))
     with sqlite3.connect(db_path) as conn:
         rows = dict(conn.execute("SELECT id, archived_at IS NOT NULL FROM chunks"))
-        lifecycle = conn.execute("SELECT value_type, archived, status FROM chunks WHERE id = 'reverted-a'").fetchone()
+        lifecycle = conn.execute("SELECT archived_at IS NOT NULL, value_type, archived, status FROM chunks WHERE id = 'reverted-a'").fetchone()
 
     assert {chunk_id for chunk_id, archived in rows.items() if archived} == {
         "reverted-a",
         "reverted-b",
         "already-archived",
     }
-    assert lifecycle == ("ARCHIVED", 1, "archived")
+    assert lifecycle[0] == 1
+    assert (lifecycle[1] or "").lower() != "archived"
+    assert lifecycle[2] in (0, None)
+    assert lifecycle[3] != "archived"
 
 
 def test_watcher_offset_is_persisted_and_same_source_replay_reactivates_archived_chunk(

--- a/tests/test_rewind_batch_archival.py
+++ b/tests/test_rewind_batch_archival.py
@@ -185,7 +185,9 @@ def test_drain_archives_only_reverted_offset_window_and_fails_closed_for_legacy_
     assert not list(queue_dir.glob("*.jsonl"))
     with sqlite3.connect(db_path) as conn:
         rows = dict(conn.execute("SELECT id, archived_at IS NOT NULL FROM chunks"))
-        lifecycle = conn.execute("SELECT archived_at IS NOT NULL, value_type, archived, status FROM chunks WHERE id = 'reverted-a'").fetchone()
+        lifecycle = conn.execute(
+            "SELECT archived_at IS NOT NULL, value_type, archived, status FROM chunks WHERE id = 'reverted-a'"
+        ).fetchone()
 
     assert {chunk_id for chunk_id, archived in rows.items() if archived} == {
         "reverted-a",

--- a/tests/test_search_repo.py
+++ b/tests/test_search_repo.py
@@ -1,5 +1,7 @@
 """Default search lifecycle filter is archived_at + lineage, not flag/status twins."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from brainlayer.store import store_memory
@@ -23,12 +25,13 @@ def mock_embed():
     return _embed
 
 
-def _store_chunk(store, mock_embed, content):
+def _store_chunk(store, mock_embed, content, **kwargs):
     return store_memory(
         store=store,
         embed_fn=mock_embed,
         content=content,
-        memory_type="learning",
+        memory_type=kwargs.pop("memory_type", "learning"),
+        **kwargs,
     )
 
 
@@ -65,12 +68,81 @@ def test_status_archived_without_timestamp_is_not_lifecycle_managed(store, mock_
     assert result["id"] in ids
 
 
-def test_value_type_archived_without_timestamp_is_not_lifecycle_managed(store, mock_embed):
-    result = _store_chunk(store, mock_embed, "UniqueValueOnlyToken still searchable")
-    store.conn.cursor().execute(
-        "UPDATE chunks SET value_type = 'ARCHIVED', archived = 0, archived_at = NULL, status = 'active' WHERE id = ?",
-        (result["id"],),
+def _embed(text: str) -> list[float]:
+    seed = sum(ord(c) for c in text[:50]) % 100
+    return [float(seed + i) / 1000.0 for i in range(1024)]
+
+
+def test_value_type_archived_survives_store_reopen(tmp_path):
+    db = tmp_path / "t.db"
+    s = VectorStore(db)
+    cid = store_memory(store=s, embed_fn=_embed, content="ReopenProbeToken", memory_type="learning")["id"]
+    s.conn.cursor().execute(
+        "UPDATE chunks SET value_type='ARCHIVED', archived=0, archived_at=NULL, status='active' WHERE id=?", (cid,)
     )
-    results = store.search(query_text="UniqueValueOnlyToken")
-    ids = results["ids"][0] if results["ids"] else []
-    assert result["id"] in ids
+    s.close()
+    s2 = VectorStore(db)  # startup backfill runs here
+    row = list(s2.conn.cursor().execute("SELECT archived FROM chunks WHERE id=?", (cid,)))[0]
+    ids = s2.search(query_text="ReopenProbeToken")["ids"]
+    assert row[0] in (0, None)
+    assert cid in (ids[0] if ids else [])
+    s2.close()
+
+
+def test_hybrid_search_fts_hides_archived_at_and_include_archived_shows_it(store, mock_embed):
+    result = _store_chunk(store, mock_embed, "HybridFtsArchiveToken unique fts hide")
+    store.archive_chunk(result["id"])
+    hidden = store.hybrid_search(
+        query_embedding=None,
+        query_text="HybridFtsArchiveToken",
+        n_results=10,
+        filter_meta_noise=False,
+    )
+    shown = store.hybrid_search(
+        query_embedding=None,
+        query_text="HybridFtsArchiveToken",
+        n_results=10,
+        include_archived=True,
+        filter_meta_noise=False,
+    )
+    hidden_ids = hidden["ids"][0] if hidden["ids"] else []
+    shown_ids = shown["ids"][0] if shown["ids"] else []
+    assert result["id"] not in hidden_ids
+    assert result["id"] in shown_ids
+
+
+def test_hybrid_search_recent_fallback_hides_archived_at(store, mock_embed):
+    now = datetime.now(timezone.utc)
+    archived = _store_chunk(
+        store,
+        mock_embed,
+        "HybridRecentHiddenToken stays out of recency",
+        created_at=(now - timedelta(minutes=2)).strftime("%Y-%m-%d %H:%M:%S"),
+    )
+    active = _store_chunk(
+        store,
+        mock_embed,
+        "HybridRecentVisibleToken stays in recency",
+        created_at=(now - timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S"),
+    )
+    store.archive_chunk(archived["id"])
+    hidden = store.hybrid_search(
+        query_embedding=None,
+        query_text="today",
+        recency_rerank=True,
+        n_results=25,
+        filter_meta_noise=False,
+    )
+    shown = store.hybrid_search(
+        query_embedding=None,
+        query_text="today",
+        recency_rerank=True,
+        n_results=25,
+        include_archived=True,
+        filter_meta_noise=False,
+    )
+    hidden_ids = hidden["ids"][0] if hidden["ids"] else []
+    shown_ids = shown["ids"][0] if shown["ids"] else []
+    assert active["id"] in hidden_ids
+    assert archived["id"] not in hidden_ids
+    assert archived["id"] in shown_ids

--- a/tests/test_search_repo.py
+++ b/tests/test_search_repo.py
@@ -1,0 +1,76 @@
+"""Default search lifecycle filter is archived_at + lineage, not flag/status twins."""
+
+import pytest
+
+from brainlayer.store import store_memory
+from brainlayer.vector_store import VectorStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    db_path = tmp_path / "test.db"
+    s = VectorStore(db_path)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def mock_embed():
+    def _embed(text: str) -> list[float]:
+        seed = sum(ord(c) for c in text[:50]) % 100
+        return [float(seed + i) / 1000.0 for i in range(1024)]
+
+    return _embed
+
+
+def _store_chunk(store, mock_embed, content):
+    return store_memory(
+        store=store,
+        embed_fn=mock_embed,
+        content=content,
+        memory_type="learning",
+    )
+
+
+def test_archived_at_is_hidden_and_include_archived_shows_it(store, mock_embed):
+    result = _store_chunk(store, mock_embed, "UniqueCollapseToken archived_at hide")
+    store.archive_chunk(result["id"])
+    hidden = store.search(query_text="UniqueCollapseToken")
+    shown = store.search(query_text="UniqueCollapseToken", include_archived=True)
+    hidden_ids = hidden["ids"][0] if hidden["ids"] else []
+    shown_ids = shown["ids"][0] if shown["ids"] else []
+    assert result["id"] not in hidden_ids
+    assert result["id"] in shown_ids
+
+
+def test_flag_without_timestamp_is_not_lifecycle_managed(store, mock_embed):
+    result = _store_chunk(store, mock_embed, "UniqueFlagOnlyToken still searchable")
+    store.conn.cursor().execute(
+        "UPDATE chunks SET archived = 1, archived_at = NULL, status = 'active' WHERE id = ?",
+        (result["id"],),
+    )
+    results = store.search(query_text="UniqueFlagOnlyToken")
+    ids = results["ids"][0] if results["ids"] else []
+    assert result["id"] in ids
+
+
+def test_status_archived_without_timestamp_is_not_lifecycle_managed(store, mock_embed):
+    result = _store_chunk(store, mock_embed, "UniqueStatusOnlyToken still searchable")
+    store.conn.cursor().execute(
+        "UPDATE chunks SET status = 'archived', archived = 0, archived_at = NULL WHERE id = ?",
+        (result["id"],),
+    )
+    results = store.search(query_text="UniqueStatusOnlyToken")
+    ids = results["ids"][0] if results["ids"] else []
+    assert result["id"] in ids
+
+
+def test_value_type_archived_without_timestamp_is_not_lifecycle_managed(store, mock_embed):
+    result = _store_chunk(store, mock_embed, "UniqueValueOnlyToken still searchable")
+    store.conn.cursor().execute(
+        "UPDATE chunks SET value_type = 'ARCHIVED', archived = 0, archived_at = NULL, status = 'active' WHERE id = ?",
+        (result["id"],),
+    )
+    results = store.search(query_text="UniqueValueOnlyToken")
+    ids = results["ids"][0] if results["ids"] else []
+    assert result["id"] in ids

--- a/tests/test_stability_health_check.py
+++ b/tests/test_stability_health_check.py
@@ -13,6 +13,8 @@ from types import SimpleNamespace
 import pytest
 
 import brainlayer.health_check as health_check
+
+# Repair (c): health SQL uses archived_at + lineage only.
 from brainlayer.health_check import HealthCheckConfig, run_health_check
 from brainlayer.vector_store import VectorStore
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,7 @@
+"""embed_pending_chunks skips archived_at/lineage. See test_deferred_embedding.py."""
+
+from brainlayer.store import embed_pending_chunks
+
+
+def test_embed_pending_chunks_is_callable():
+    assert callable(embed_pending_chunks)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,4 +1,9 @@
-"""Tests for vector_store.py — date filtering, search metadata, schema."""
+"""Tests for vector_store.py — date filtering, search metadata, schema.
+
+Archive collapse (repair c): archive_chunk writes archived_at only. Behavior is
+covered by tests/test_archive_collapse.py and tests/test_chunk_lifecycle.py on
+temp DBs; this module stays the opt-in live-DB integration suite.
+"""
 
 import os
 

--- a/tests/test_vector_store_upsert_transactions.py
+++ b/tests/test_vector_store_upsert_transactions.py
@@ -161,7 +161,7 @@ def test_upsert_chunks_preserves_dedupe_and_repeat_upsert_shape(isolated_store, 
     assert isolated_store.upsert_chunks(chunks, [_embedding(1), _embedding(2), _embedding(3)]) == 3
 
     cursor = isolated_store.conn.cursor()
-    active_rows = cursor.execute("SELECT id FROM chunks WHERE COALESCE(archived, 0) = 0 ORDER BY id").fetchall()
+    active_rows = cursor.execute("SELECT id FROM chunks WHERE archived_at IS NULL ORDER BY id").fetchall()
     aliases = cursor.execute(
         "SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias ORDER BY old_chunk_id"
     ).fetchall()


### PR DESCRIPTION
## Summary
- Collapse the four overlapping chunk archive representations to **one**: `archived_at` is UTC time or NULL (Etan, 2026-08-16). Lineage `superseded_by` / `aggregated_into` stay. `status='superseded'` stays as the lineage companion; `status='archived'` and `value_type='ARCHIVED'` stop encoding archive; the integer `archived` flag is no longer read or written as archive.
- Default search after collapse: `archived_at IS NULL AND superseded_by IS NULL AND aggregated_into IS NULL` (`include_archived=True` still shows history).
- Data migration `scripts/repair_archive_collapse.py` follows the repair-b pattern: refuses the live DB unless `--allow-live`, dry-run default, pre-image table `archive_collapse_preimage`, batches + WAL checkpoints, stored-value spot-checks, aux-count invariants, `schema_migrations` name `2026_08_17_archive_collapse_archived_at` + git SHA.

### Truth table (chunks)

| Representation | Decision | Writers now | Readers now |
|---|---|---|---|
| `archived_at` TEXT | **KEEP** (canonical) | `archive_chunk`, drain rewind, decay, dedupe merge, quarantine, BrainBar `archiveChunk` | search / get_chunk / doctor / health / kg_promotion / drain / hotlane |
| `archived` INTEGER | migrate-then-clear; stop encoding archive | reactivation may zero leftover twins | ignored for hide/show |
| `status='archived'` | migrate-then-clear; `status` is `active`/`superseded` only | atomic-brick backfill remaps `archived` → `active` or `superseded` | ignored for hide/show |
| `value_type='ARCHIVED'` | migrate-then-clear; `value_type` is an importance band | archive writers no longer stamp it | ignored for hide/show |
| `superseded_by` / `aggregated_into` | **KEEP** (lineage, not archive) | unchanged | still exclude from default search |

kg_entities `status='archived'` is a different table and is out of scope.

### Pair-review fixes at `d2ca9368` (new commits only)

- **M1** lint: I001 module docstring in `tests/test_hotlane_brainbar_daemon.py`; ruff format on `tests/test_chunk_lifecycle.py` and `tests/test_rewind_batch_archival.py`. Local `ruff check src/ tests/` + `ruff format --check src/ tests/` at this SHA: All checks passed / 458 files already formatted. GitHub `lint` is claimed only after reading the check-run at this SHA (see test plan).
- **M2** `archive_collapse.py` DROP+CREATE `idx_chunks_decay_score` / `idx_chunks_last_retrieved` onto `WHERE archived_at IS NULL` inside the apply window (even when `updated==0`). VectorStore `CREATE INDEX IF NOT EXISTS` left for brand-new DBs.
- **S1** leak count in this runbook is **29** (22 `archived=1` + 7 status/value_type-only; all null lineage). Migrate-first order unchanged.
- **S2** toothless `value_type` test replaced with reviewer reopen-probe `test_value_type_archived_survives_store_reopen`.
- **S3** `hybrid_search()` lifecycle tests: FTS branch (`query_embedding=None`) and recent-fallback (`recency_rerank=True`, query `today`).
- **S4** rollback SQL in this runbook and as `ROLLBACK_SQL` in `archive_collapse.py`.

### Live-window plan (lead owns; do not run live from this PR)

**Migrate first, then bounce.** Main today already hides on `archived_at IS NULL` *and* the twins. After this PR, readers hide on `archived_at` only. If new code bounces first, the **29** twin-without-timestamp rows leak into default search (22 `archived=1` plus 7 status/value_type-only; all 29 have null lineage). If migrate runs first, those 29 get timestamps before the twins are cleared, so old readers keep hiding them.

1. Fence writers host-specifically (`lsof` the live DB; repair-b M1 needed `com.brainlayer.index` too). Record WAL size.
2. Rollback (if needed) before bounce, lossless against `archive_collapse_preimage`:

```sql
BEGIN IMMEDIATE;
UPDATE chunks SET
  archived_at = (SELECT p.archived_at FROM archive_collapse_preimage p WHERE p.id = chunks.id),
  archived    = (SELECT p.archived    FROM archive_collapse_preimage p WHERE p.id = chunks.id),
  status      = (SELECT p.status      FROM archive_collapse_preimage p WHERE p.id = chunks.id),
  value_type  = (SELECT p.value_type  FROM archive_collapse_preimage p WHERE p.id = chunks.id)
WHERE id IN (SELECT id FROM archive_collapse_preimage);
COMMIT;
```

3. `python scripts/repair_archive_collapse.py --db "$LIVE" --apply --allow-live --git-sha <merge SHA> --spot-check 50`
   Apply also `DROP INDEX` + `CREATE INDEX ... WHERE archived_at IS NULL` for `idx_chunks_decay_score` and `idx_chunks_last_retrieved`. `CREATE INDEX IF NOT EXISTS` cannot retarget the existing `archived=0` names.
4. Bounce Python + BrainBar so this PR's readers are what execute.
5. Unfence. Confirm twin count stays 0 with writers live.

### Rehearsal (copy only — not live)

Source: APFS clone of today's online backup `~/.local/share/brainlayer/backups/2026-08-17.db` → `~/.local/share/brainlayer/rehearsal-repair-c/brainlayer.db`. Git SHA recorded: `09d342b33b42970863c212c5fc60cf44db816191`.

| Metric | Before | After |
|---|---|---|
| chunks | 758,474 | 758,474 |
| `archived_at` set | 5,034 | 5,063 |
| `archived=1` | 5,056 | 0 |
| `status='archived'` | 934 | 0 |
| `value_type='ARCHIVED'` | 4,988 | 0 |
| any twin | 5,063 | 0 |
| twin without timestamp | 29 | 0 |
| flag without timestamp | 22 | 0 |
| pre-image rows | — | 5,063 |
| aux FTS/vec counts | unchanged | unchanged |

Apply: 3.91s wall, 2 batches, 2 checkpoints, `updated=5063`, `post_twin_count=0`, spot-checks **50/50 ok** against stored values. Dry-run `would_update=5063` in 3.38s. No `--allow-live`.

## Test plan
- [x] Focused pytest (original lane): archive collapse, search, lifecycle, drain/dedupe/rewind, provenance, decay, quarantine — **389 passed**, 1 deselected
- [x] Review-fix focused pytest (`test_archive_collapse*`, `test_search_repo`, lifecycle/rewind/hotlane): **105 passed**; reopen-probe + hybrid FTS + recency + index DROP/CREATE + rollback: **6 passed** after relative recency timestamps
- [x] Local `ruff check src/ tests/` + `ruff format --check src/ tests/` at `d2ca9368`: All checks passed / 458 files already formatted
- [ ] GitHub `lint` at `d2ca9368` — not claimed until the check-run at this SHA is read
- [ ] Remaining GitHub CI at `d2ca9368`
- [x] Lead-routed Claude pair review of `09d342b3` (GO + 2 MUST-FIX + 4 should-fix); re-review of `d2ca9368` pending
- [x] `@codex review` requested on the original head
- [ ] Live window only after merge + lead fence (not this worker)

Worker endpoint: PR + reviews. **Do not merge.**

— brainlayerCursor-a9e71fea (worker) · cursor/unknown
<!-- golem-id v1 {"seat":"brainlayerCursor-a9e71fea","role":"worker","harness":"cursor","model":"unknown","model_source":"unavailable","ts":"2026-08-17T20:50:43Z"} -->
