### PR TITLE
fix: archive-not-delete merge for exact content duplicates (repair e)

### DIFF
--- a/hooks/brainbar-stop-index.py
+++ b/hooks/brainbar-stop-index.py
@@ -86,9 +86,10 @@ def main():
     else:
         content = f"Assistant: {response_text}"
 
-    # Content hash for dedup
-    content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
-    chunk_id = f"rt-{session_id[:8]}-{content_hash}"
+    # Truncated digest that NAMES the chunk (id suffix + queue key). It is not a
+    # content hash: insert_canonical_chunk fills content_hash from the contract.
+    id_digest = hashlib.sha256(content.encode()).hexdigest()[:16]
+    chunk_id = f"rt-{session_id[:8]}-{id_digest}"
     project = Path(cwd.rstrip("/")).name if cwd else "unknown"
 
     # Store in DB (matches production schema: id, content, metadata, source, etc.)
@@ -96,7 +97,7 @@ def main():
     metadata = json.dumps(
         {
             "session_id": session_id,
-            "content_hash": content_hash,
+            "id_digest": id_digest,
             "cwd": cwd,
             "has_prompt": prompt_text is not None,
         }
@@ -137,7 +138,7 @@ def main():
             "chunk_id": chunk_id,
             "session_id": session_id,
             "content": content,
-            "content_hash": content_hash,
+            "content_hash": id_digest,
             "project": project,
             "timestamp": time.time(),
             "created_at": datetime.now(timezone.utc).isoformat(),

--- a/scripts/repair_dedupe_merge.py
+++ b/scripts/repair_dedupe_merge.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Archive exact content duplicates onto a survivor (rehearsal/live-window)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+# Prepend unconditionally. A plain "if not in sys.path" guard is not enough: an
+# editable-install .pth can already have src on the path BEHIND site-packages,
+# so the guard skips the insert and a stale installed copy of brainlayer wins.
+while str(SRC_DIR) in sys.path:
+    sys.path.remove(str(SRC_DIR))
+sys.path.insert(0, str(SRC_DIR))
+
+from brainlayer.dedupe_merge import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/chunk_write.py
+++ b/src/brainlayer/chunk_write.py
@@ -126,8 +126,21 @@ def _json_text(value: Any, *, default: str = "{}") -> str:
     return text if text else default
 
 
-def _content_hash(content: str) -> str:
-    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+def canonical_content_hash(content: str) -> str:
+    """The one content_hash contract: sha256 over the whitespace-stripped content.
+
+    Repair (e) census found four schemes live in this column at once (64-char
+    sha256, a 32-char scheme, 16-char truncations, and 52k rows with none).
+    Rows hashed under different schemes can never group as duplicates even when
+    byte-identical, which is why duplicates accrued faster than write-time
+    dedupe removed them. Every writer routed through this module now emits one
+    scheme, and a caller-supplied hash never overrides it.
+    """
+    return hashlib.sha256(str(content).strip().encode("utf-8")).hexdigest()
+
+
+# Back-compat alias for existing internal callers.
+_content_hash = canonical_content_hash
 
 
 def _table_columns(conn: Any, table: str) -> set[str]:
@@ -215,7 +228,7 @@ def prepare_canonical_insert(
             "source": source,
             "created_at": created_at,
             "chunk_origin": resolved_origin,
-            "content_hash": values.get("content_hash") or _content_hash(content),
+            "content_hash": canonical_content_hash(content),
             "ingested_at": epoch,
             "seen_count": int(values.get("seen_count") or 1),
             "last_seen_at": last_seen_at,

--- a/src/brainlayer/db_shrink.py
+++ b/src/brainlayer/db_shrink.py
@@ -2,6 +2,16 @@
 
 These helpers are intentionally path-parameterized. They are for snapshot
 maintenance first; the canonical live DB requires an explicit guard override.
+
+Repair (e), 2026-08-18: the physical-delete dedupe path was REMOVED from this
+module (`apply_content_dedup` and its `_merge_duplicate_references` machinery,
+which ended in `DELETE FROM chunks` stamped
+`mechanism='normalized_content_physical_delete'`). It contradicted the lifecycle
+law -- duplicates are archived with `aggregated_into` lineage, never deleted --
+and it keyed on the lossy `normalized_exact_hash`, which lowercases and strips
+stopwords. It had never run on the canonical DB (0 such rows in `dedupe_audit`).
+Duplicate merging now lives in `brainlayer.dedupe_merge`, which only ever writes
+lifecycle columns. `tests/test_db_shrink.py` guards against reintroduction.
 """
 
 from __future__ import annotations
@@ -9,15 +19,13 @@ from __future__ import annotations
 import argparse
 import json
 import time
-from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import apsw
 import sqlite_vec
 
-from brainlayer.dedupe import ensure_dedupe_schema, normalized_exact_hash
 from brainlayer.paths import get_db_path
 
 FTS_COLUMNS = "content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED"
@@ -37,16 +45,6 @@ class FtsMigrationResult:
     before_bytes: int
     after_bytes: int
     reclaimed_bytes: int
-
-
-@dataclass(frozen=True)
-class DedupResult:
-    db_path: str
-    scanned_rows: int
-    duplicate_groups: int
-    duplicate_rows: int
-    deleted_rows: int
-    protected_chunk_ids: int
 
 
 @dataclass(frozen=True)
@@ -396,244 +394,6 @@ def migrate_fts_compact_dual(db_path: str | Path, *, allow_live: bool = False) -
     return _rebuild_fts(db_path, mode=FTS_MODE_COMPACT_DUAL, allow_live=allow_live)
 
 
-def _canonical_for_group(rows: list[tuple[str, str | None]], protected_chunk_ids: set[str]) -> str:
-    ordered = sorted(rows, key=lambda row: (row[0] not in protected_chunk_ids, row[1] or "", row[0]))
-    return ordered[0][0]
-
-
-def analyze_content_duplicates(
-    db_path: str | Path, *, allow_live: bool = False
-) -> tuple[int, dict[str, list[tuple[str, str | None]]]]:
-    """Return scanned row count and exact normalized-content duplicate groups."""
-    assert_not_live_db(db_path, allow_live=allow_live)
-    conn = _connect(db_path)
-    groups: dict[str, list[tuple[str, str | None]]] = defaultdict(list)
-    scanned = 0
-    try:
-        for chunk_id, content, created_at in conn.cursor().execute("SELECT id, content, created_at FROM chunks"):
-            scanned += 1
-            if content is None:
-                continue
-            content_hash = normalized_exact_hash(str(content))
-            groups[content_hash].append((str(chunk_id), str(created_at) if created_at is not None else None))
-    finally:
-        conn.close()
-    return scanned, {content_hash: rows for content_hash, rows in groups.items() if len(rows) > 1}
-
-
-def _insert_or_ignore_repoint(
-    cursor: Any,
-    schema: dict[str, list[str]],
-    table_name: str,
-    duplicate_id: str,
-    canonical_id: str,
-) -> None:
-    cols = schema.get(table_name, [])
-    if "chunk_id" not in cols:
-        return
-    column_sql = ", ".join(cols)
-    select_sql = ", ".join("? AS chunk_id" if col == "chunk_id" else col for col in cols)
-    cursor.execute(
-        f"INSERT OR IGNORE INTO {table_name} ({column_sql}) SELECT {select_sql} FROM {table_name} WHERE chunk_id = ?",
-        (canonical_id, duplicate_id),
-    )
-    cursor.execute(f"DELETE FROM {table_name} WHERE chunk_id = ?", (duplicate_id,))
-
-
-def _update_or_ignore(
-    cursor: Any,
-    schema: dict[str, list[str]],
-    table_name: str,
-    column_name: str,
-    duplicate_id: str,
-    canonical_id: str,
-) -> None:
-    if column_name not in schema.get(table_name, []):
-        return
-    cursor.execute(
-        f"UPDATE OR IGNORE {table_name} SET {column_name} = ? WHERE {column_name} = ?",
-        (canonical_id, duplicate_id),
-    )
-
-
-def _delete_by_chunk_id(cursor: Any, schema: dict[str, list[str]], table_name: str, duplicate_id: str) -> None:
-    if "chunk_id" in schema.get(table_name, []):
-        cursor.execute(f"DELETE FROM {table_name} WHERE chunk_id = ?", (duplicate_id,))
-
-
-def _delete_fts_rows_for_chunk(cursor: Any, schema: dict[str, list[str]], duplicate_id: str) -> None:
-    if "chunk_fts_rowids" not in schema:
-        return
-    row = cursor.execute(
-        "SELECT fts_rowid, trigram_rowid FROM chunk_fts_rowids WHERE chunk_id = ?",
-        (duplicate_id,),
-    ).fetchone()
-    if row is None:
-        return
-    fts_rowid, trigram_rowid = row
-    if fts_rowid is not None and "chunks_fts" in schema:
-        cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (fts_rowid,))
-    if trigram_rowid is not None and "chunks_fts_trigram" in schema:
-        cursor.execute("DELETE FROM chunks_fts_trigram WHERE rowid = ?", (trigram_rowid,))
-
-
-def _record_alias(cursor: Any, duplicate_id: str, canonical_id: str) -> None:
-    cursor.execute(
-        """
-        INSERT INTO chunk_id_alias(old_chunk_id, canonical_chunk_id, deprecated_at)
-        VALUES (?, ?, datetime('now'))
-        ON CONFLICT(old_chunk_id) DO UPDATE SET
-            canonical_chunk_id = excluded.canonical_chunk_id,
-            deprecated_at = excluded.deprecated_at
-        """,
-        (duplicate_id, canonical_id),
-    )
-    cursor.execute(
-        """
-        INSERT INTO dedupe_audit(chunk_id_dropped, chunk_id_kept, mechanism, hamming_distance, ts)
-        VALUES (?, ?, 'normalized_content_physical_delete', 0, datetime('now'))
-        """,
-        (duplicate_id, canonical_id),
-    )
-
-
-def _merge_duplicate_references(
-    cursor: Any,
-    schema: dict[str, list[str]],
-    duplicate_id: str,
-    canonical_id: str,
-    *,
-    delete_fts_rows: bool = False,
-) -> None:
-    for table_name in ("chunk_tags", "kg_entity_chunks", "chunk_clusters", "agent_reads"):
-        if table_name in schema:
-            _insert_or_ignore_repoint(cursor, schema, table_name, duplicate_id, canonical_id)
-
-    # sqlite-vec virtual tables can raise a primary-key error even with
-    # INSERT OR IGNORE. Duplicate chunks do not need duplicate vectors.
-    for table_name in ("chunk_vectors", "chunk_vectors_binary"):
-        _delete_by_chunk_id(cursor, schema, table_name, duplicate_id)
-
-    if delete_fts_rows:
-        _delete_fts_rows_for_chunk(cursor, schema, duplicate_id)
-    _delete_by_chunk_id(cursor, schema, "chunk_fts_rowids", duplicate_id)
-    _record_alias(cursor, duplicate_id, canonical_id)
-    cursor.execute("DELETE FROM chunks WHERE id = ?", (duplicate_id,))
-
-
-def _bulk_update_alias_refs(
-    cursor: Any,
-    schema: dict[str, list[str]],
-    table_name: str,
-    column_name: str,
-) -> None:
-    if column_name not in schema.get(table_name, []):
-        return
-    cursor.execute(f"""
-        UPDATE OR IGNORE {table_name}
-        SET {column_name} = (
-            SELECT canonical_chunk_id
-            FROM chunk_id_alias
-            WHERE old_chunk_id = {table_name}.{column_name}
-        )
-        WHERE {column_name} IN (SELECT old_chunk_id FROM chunk_id_alias)
-    """)
-
-
-def _bulk_repoint_direct_refs(cursor: Any, schema: dict[str, list[str]]) -> None:
-    for table_name in ("chunk_events", "correction_pairs", "file_interactions"):
-        _bulk_update_alias_refs(cursor, schema, table_name, "chunk_id")
-    _bulk_update_alias_refs(cursor, schema, "kg_relations", "source_chunk_id")
-
-
-def _bulk_repoint_chunk_self_refs(cursor: Any, schema: dict[str, list[str]]) -> None:
-    for column_name in ("superseded_by", "aggregated_into", "consolidated_into"):
-        if column_name not in schema.get("chunks", []):
-            continue
-        cursor.execute(f"""
-            UPDATE OR IGNORE chunks
-            SET {column_name} = (
-                SELECT canonical_chunk_id
-                FROM chunk_id_alias
-                WHERE old_chunk_id = chunks.{column_name}
-            )
-            WHERE {column_name} IN (SELECT old_chunk_id FROM chunk_id_alias)
-        """)
-
-
-def apply_content_dedup(
-    db_path: str | Path,
-    *,
-    protected_chunk_ids: Iterable[str] = (),
-    batch_size: int = 1000,
-    allow_live: bool = False,
-    rebuild_fts: bool = True,
-    fts_mode: str = FTS_MODE_COMPACT_DUAL,
-) -> DedupResult:
-    """Physically delete exact normalized-content duplicates from a snapshot DB."""
-    if batch_size <= 0:
-        raise ValueError("batch_size must be a positive integer")
-    assert_not_live_db(db_path, allow_live=allow_live)
-    protected = {str(chunk_id) for chunk_id in protected_chunk_ids}
-    scanned, groups = analyze_content_duplicates(db_path, allow_live=allow_live)
-    duplicates: list[tuple[str, str]] = []
-    for rows in groups.values():
-        canonical_id = _canonical_for_group(rows, protected)
-        duplicates.extend((chunk_id, canonical_id) for chunk_id, _created_at in rows if chunk_id != canonical_id)
-
-    path = _resolve(db_path)
-    conn = _connect(path)
-    deleted = 0
-    try:
-        cursor = conn.cursor()
-        ensure_dedupe_schema(conn)
-        if rebuild_fts:
-            drop_fts_triggers(cursor)
-        schema = _schema_columns(cursor)
-        cursor.execute("PRAGMA wal_checkpoint(FULL)")
-        for offset in range(0, len(duplicates), batch_size):
-            cursor.execute("BEGIN IMMEDIATE")
-            try:
-                for duplicate_id, canonical_id in duplicates[offset : offset + batch_size]:
-                    if cursor.execute("SELECT 1 FROM chunks WHERE id = ?", (duplicate_id,)).fetchone() is None:
-                        continue
-                    if cursor.execute("SELECT 1 FROM chunks WHERE id = ?", (canonical_id,)).fetchone() is None:
-                        continue
-                    _merge_duplicate_references(
-                        cursor,
-                        schema,
-                        duplicate_id,
-                        canonical_id,
-                        delete_fts_rows=not rebuild_fts,
-                    )
-                    deleted += 1
-                cursor.execute("COMMIT")
-            except Exception:
-                cursor.execute("ROLLBACK")
-                raise
-            cursor.execute("PRAGMA wal_checkpoint(FULL)")
-        cursor.execute("BEGIN IMMEDIATE")
-        try:
-            _bulk_repoint_direct_refs(cursor, schema)
-            _bulk_repoint_chunk_self_refs(cursor, schema)
-            cursor.execute("COMMIT")
-        except Exception:
-            cursor.execute("ROLLBACK")
-            raise
-    finally:
-        conn.close()
-    if rebuild_fts:
-        _rebuild_fts(path, mode=fts_mode, allow_live=allow_live)
-    return DedupResult(
-        db_path=str(path),
-        scanned_rows=scanned,
-        duplicate_groups=len(groups),
-        duplicate_rows=len(duplicates),
-        deleted_rows=deleted,
-        protected_chunk_ids=len(protected),
-    )
-
-
 def vacuum_database(db_path: str | Path, *, allow_live: bool = False) -> VacuumResult:
     """Physically compact a snapshot DB after logical shrink operations."""
     assert_not_live_db(db_path, allow_live=allow_live)
@@ -656,24 +416,10 @@ def vacuum_database(db_path: str | Path, *, allow_live: bool = False) -> VacuumR
     )
 
 
-def load_protected_qrel_ids(qrels_path: str | Path | None) -> set[str]:
-    if qrels_path is None:
-        return set()
-    payload = json.loads(Path(qrels_path).read_text())
-    protected: set[str] = set()
-    for judgments in payload.values():
-        if isinstance(judgments, dict):
-            protected.update(str(doc_id) for doc_id in judgments)
-    return protected
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--db-path", required=True)
-    parser.add_argument("--batch-size", type=int, default=1000)
-    parser.add_argument("--qrels-path")
     parser.add_argument("--skip-fts", action="store_true")
-    parser.add_argument("--skip-dedup", action="store_true")
     parser.add_argument("--fts-mode", choices=["compact-dual", "single-trigram"], default="compact-dual")
     parser.add_argument("--vacuum", action="store_true", help="Physically compact the snapshot after migrations")
     parser.add_argument("--i-know-this-is-live", action="store_true")
@@ -684,19 +430,7 @@ def main(argv: list[str] | None = None) -> int:
     started = time.time()
     results: dict[str, Any] = {"db_path": str(_resolve(args.db_path))}
     fts_mode = FTS_MODE_SINGLE_TRIGRAM if args.fts_mode == "single-trigram" else FTS_MODE_COMPACT_DUAL
-    if not args.skip_dedup:
-        protected = load_protected_qrel_ids(args.qrels_path)
-        results["dedup"] = asdict(
-            apply_content_dedup(
-                args.db_path,
-                protected_chunk_ids=protected,
-                batch_size=args.batch_size,
-                allow_live=allow_live,
-                rebuild_fts=not args.skip_fts,
-                fts_mode=fts_mode,
-            )
-        )
-    elif not args.skip_fts:
+    if not args.skip_fts:
         results["fts"] = asdict(_rebuild_fts(args.db_path, mode=fts_mode, allow_live=allow_live))
     if args.vacuum:
         results["vacuum"] = asdict(vacuum_database(args.db_path, allow_live=allow_live))

--- a/src/brainlayer/dedupe_merge.py
+++ b/src/brainlayer/dedupe_merge.py
@@ -1,0 +1,861 @@
+"""Merge exact content duplicates by ARCHIVING losers, never deleting them.
+
+Repair (e). Default is dry-run. Refuses the live canonical DB unless
+allow_live=True after a lead-scheduled writer window. Follows the proven
+repair-b/c/d preimage + checkpoint pattern (`chunk_origin_wipe`, `timestamp_iso`).
+
+Policy (POLICY_REPAIR_E, lead-ACKed 2026-08-18, census in
+`docs.local/repair-e-census-2026-08-18.md`):
+
+* **Key** — `sha256(content.strip())`, recomputed here. The stored `content_hash`
+  column is never trusted: the canonical DB carries four schemes at once (64-char
+  sha256, a 32-char scheme, 16-char truncations, and 52k rows with none), plus
+  2,256 rows whose stored hash went stale when their content later changed.
+  Grouping on it both under-counts (rows in different schemes never meet) and
+  over-counts (20 groups whose members hold genuinely different text).
+* **Scope** — same `conversation_id` only. Identical text in two different
+  conversations is two memories: the census found one 245-char sentence stored
+  across 252 conversations in 59 projects, and collapsing that would erase 252
+  session contexts. A blank conversation_id is *unknown*, not a match.
+* **Survivor** — richest enrichment, then oldest `created_at`, then smallest id;
+  rows already lifecycle-managed are never chosen. Oldest-wins would have
+  discarded enrichment in 23,359 of 42,082 eligible groups; richest-wins, 1,243.
+* **Losers** — `aggregated_into` + `archived_at` + `status='superseded'`. Content,
+  ids, tags, FTS rows and vectors all stay. No DELETE, in any table, ever.
+  `status='superseded'` and not `'archived'` because `vector_store.py` rewrites
+  `status='archived'` on startup, which would silently revert the migration.
+
+Both serving paths already exclude `aggregated_into IS NOT NULL` and
+`archived_at IS NOT NULL` from default search, so this removes duplicate noise
+with no index surgery -- aux counts are asserted UNCHANGED, unlike repair-c/d.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import re
+import sqlite3
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .chunk_origin_wipe import AUX_COUNT_TABLES, assert_not_live_db
+from .chunk_origin_wipe import live_canonical_db_path as live_canonical_db_path
+
+PREIMAGE_TABLE = "dedupe_merge_preimage"
+ALIAS_PREIMAGE_TABLE = "dedupe_merge_alias_preimage"
+MIGRATION_NAME = "2026_08_18_dedupe_merge_archive"
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+#: Enrichment carried per chunk. Order is the survivor score and the union-fill order.
+ENRICH_FIELDS = (
+    "summary",
+    "tags",
+    "importance",
+    "intent",
+    "enriched_at",
+    "key_facts",
+    "primary_symbols",
+    "raw_entities_json",
+)
+
+#: Columns the migration may write. Everything here is preimaged before a write.
+WRITTEN_COLUMNS = (
+    "aggregated_into",
+    "archived_at",
+    "status",
+    "seen_count",
+    *ENRICH_FIELDS,
+)
+
+LIFECYCLE_COLUMNS = ("archived_at", "superseded_by", "aggregated_into")
+
+
+@dataclass
+class DedupeMergeResult:
+    scanned: int = 0
+    groups_total: int = 0
+    groups_eligible: int = 0
+    groups_held: int = 0
+    groups_merged: int = 0
+    would_merge_groups: int = 0
+    would_archive_losers: int = 0
+    losers_archived: int = 0
+    survivors_updated: int = 0
+    union_fills: dict[str, int] = field(default_factory=dict)
+    aliases_written: int = 0
+    aliases_repointed: int = 0
+    aliases_dropped_survivor_source: int = 0
+    lineage_repointed: int = 0
+    preexisting_alias_cycles: int = 0
+    seen_count_transferred: int = 0
+    batches: int = 0
+    checkpoints: int = 0
+    held_reasons: dict[str, int] = field(default_factory=dict)
+    aux_counts_before: dict[str, int] = field(default_factory=dict)
+    aux_counts_after: dict[str, int] = field(default_factory=dict)
+    spot_checks: list[dict[str, Any]] = field(default_factory=list)
+
+
+def content_key(content: Any) -> str | None:
+    """The merge key. None when the row can never participate in a merge."""
+    if content is None:
+        return None
+    text = str(content).strip()
+    if not text:
+        return None
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _blank(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _validate_git_sha(git_sha: str) -> str:
+    if not _SHA_RE.fullmatch(git_sha or ""):
+        raise ValueError("git_sha must be an exact 40-character hexadecimal commit SHA")
+    return git_sha.lower()
+
+
+def _enrich_score(row: dict, present: set[str]) -> int:
+    return sum(1 for f in ENRICH_FIELDS if f in present and not _blank(row.get(f)))
+
+
+def _is_managed(row: dict) -> bool:
+    return any(not _blank(row.get(col)) for col in LIFECYCLE_COLUMNS)
+
+
+def _instant(value: Any) -> str:
+    return "" if _blank(value) else str(value).strip()
+
+
+def pick_survivor(members: list[dict], present: set[str]) -> dict | None:
+    """Richest enrichment -> oldest created_at -> smallest id, among live rows."""
+    live = [m for m in members if not _is_managed(m)]
+    if not live:
+        return None
+    return min(
+        live,
+        key=lambda m: (-_enrich_score(m, present), _instant(m.get("created_at")) or "9999", str(m["id"])),
+    )
+
+
+def group_is_eligible(members: list[dict]) -> tuple[bool, str]:
+    """Same-conversation rule. Returns (eligible, reason_when_held)."""
+    conversations = {m.get("conversation_id") for m in members}
+    if any(_blank(c) for c in conversations):
+        return False, "conversation_id_unknown"
+    if len(conversations) > 1:
+        return False, "cross_conversation"
+    return True, ""
+
+
+def _aux_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    existing = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    counts: dict[str, int] = {}
+    for table in AUX_COUNT_TABLES:
+        if table not in existing:
+            continue
+        try:
+            counts[table] = int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+        except sqlite3.OperationalError:
+            continue
+    return counts
+
+
+def _checkpoint(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA wal_checkpoint(FULL)")
+
+
+def _column_types(conn: sqlite3.Connection) -> dict[str, str]:
+    return {row[1]: (row[2] or "TEXT") for row in conn.execute("PRAGMA table_info(chunks)")}
+
+
+def _ensure_preimage(conn: sqlite3.Connection, columns: list[str]) -> None:
+    """Preimage mirrors the chunks column TYPES so a rollback restores values as-is."""
+    expected = ["id", *columns]
+    exists = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (PREIMAGE_TABLE,)).fetchone()
+    if exists:
+        present = [row[1] for row in conn.execute(f"PRAGMA table_info({PREIMAGE_TABLE})")]
+        if present != expected:
+            raise RuntimeError(
+                f"{PREIMAGE_TABLE} columns {present!r} do not match expected {expected!r}; "
+                "restore from backup before re-running"
+            )
+        pk = [row[1] for row in conn.execute(f"PRAGMA table_info({PREIMAGE_TABLE})") if row[5]]
+        if pk != ["id"]:
+            raise RuntimeError(
+                f"{PREIMAGE_TABLE} exists without an id PRIMARY KEY; INSERT OR IGNORE would "
+                "append instead of protecting the first preimage. Restore from backup."
+            )
+        return
+    types = _column_types(conn)
+    column_defs = ", ".join(["id TEXT PRIMARY KEY", *(f"{column} {types.get(column, 'TEXT')}" for column in columns)])
+    conn.execute(f"CREATE TABLE {PREIMAGE_TABLE} ({column_defs})")
+    conn.commit()
+
+
+def _ensure_alias_table(conn: sqlite3.Connection) -> bool:
+    exists = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='chunk_id_alias'").fetchone()
+    return exists is not None
+
+
+def merge_duplicates(
+    db_path: Path,
+    *,
+    git_sha: str,
+    apply: bool = False,
+    batch_size: int = 500,
+    checkpoint_every: int = 3,
+    allow_live: bool = False,
+    spot_check: int = 0,
+    union_fill: bool = True,
+    actor: str = "repair-e",
+) -> DedupeMergeResult:
+    """Archive exact content duplicates onto a survivor, preserving lineage."""
+    sha = _validate_git_sha(git_sha)
+    resolved = assert_not_live_db(Path(db_path), allow_live=allow_live)
+    batch_size = max(1, int(batch_size))
+    checkpoint_every = max(1, int(checkpoint_every))
+    spot_check = max(0, int(spot_check))
+    result = DedupeMergeResult()
+    samples: list[str] = []
+    sampled = 0
+    rng = random.Random(0)
+
+    conn = sqlite3.connect(str(resolved))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA busy_timeout=30000")
+        present = {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+        for required in ("id", "content", "conversation_id", "aggregated_into", "archived_at"):
+            if required not in present:
+                raise RuntimeError(f"chunks is missing required column {required!r}")
+        written = [c for c in WRITTEN_COLUMNS if c in present]
+        select_cols = sorted({"id", "content", "conversation_id", "created_at", *LIFECYCLE_COLUMNS, *written} & present)
+        has_alias = _ensure_alias_table(conn)
+
+        result.aux_counts_before = _aux_counts(conn)
+        if apply:
+            _ensure_preimage(conn, written)
+            if has_alias:
+                conn.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {ALIAS_PREIMAGE_TABLE} (
+                        old_chunk_id TEXT NOT NULL,
+                        canonical_chunk_id TEXT,
+                        deprecated_at TEXT,
+                        action TEXT NOT NULL
+                    )
+                    """
+                )
+                conn.commit()
+            _checkpoint(conn)
+            result.checkpoints += 1
+
+        # --- pass 1a: count keys, holding only digests ------------------------
+        # Two passes so peak memory scales with the DUPLICATE population, not the
+        # table: on the canonical DB that is ~150k member rows instead of ~760k.
+        key_counts: dict[str, int] = defaultdict(int)
+        for (content,) in conn.execute("SELECT content FROM chunks"):
+            result.scanned += 1
+            key = content_key(content)
+            if key is not None:
+                key_counts[key] += 1
+        duplicate_keys = {key for key, count in key_counts.items() if count > 1}
+        del key_counts
+
+        # --- pass 1b: materialize only rows in a duplicate group --------------
+        groups: dict[str, list[dict]] = defaultdict(list)
+        for row in conn.execute(f"SELECT {', '.join(select_cols)} FROM chunks"):
+            key = content_key(row["content"])
+            if key is None or key not in duplicate_keys:
+                continue
+            record = {c: row[c] for c in select_cols}
+            record.pop("content", None)
+            groups[key].append(record)
+        del duplicate_keys
+
+        plans: list[tuple[dict, list[dict]]] = []
+        for members in groups.values():
+            if len(members) < 2:
+                continue
+            result.groups_total += 1
+            eligible, reason = group_is_eligible(members)
+            if not eligible:
+                result.groups_held += 1
+                result.held_reasons[reason] = result.held_reasons.get(reason, 0) + 1
+                continue
+            survivor = pick_survivor(members, present)
+            if survivor is None:
+                result.groups_held += 1
+                result.held_reasons["all_members_lifecycle_managed"] = (
+                    result.held_reasons.get("all_members_lifecycle_managed", 0) + 1
+                )
+                continue
+            losers = [m for m in members if m["id"] != survivor["id"] and not _is_managed(m)]
+            if not losers:
+                result.groups_held += 1
+                result.held_reasons["nothing_left_to_archive"] = (
+                    result.held_reasons.get("nothing_left_to_archive", 0) + 1
+                )
+                continue
+            result.groups_eligible += 1
+            result.would_merge_groups += 1
+            result.would_archive_losers += len(losers)
+            plans.append((survivor, losers))
+            if spot_check:
+                for loser in losers:
+                    sampled += 1
+                    if len(samples) < spot_check:
+                        samples.append(str(loser["id"]))
+                    else:
+                        j = rng.randrange(sampled)
+                        if j < spot_check:
+                            samples[j] = str(loser["id"])
+
+        del groups
+        if not apply:
+            result.aux_counts_after = _aux_counts(conn)
+            return result
+
+        # --- pass 2: apply, batched, preimaged -------------------------------
+        stamp = _now_iso()
+        touched_ids: set[str] = set()
+        # Pre-existing lineage, prefetched once (target -> rows pointing at it).
+        # Rows this run archives all point at survivors, and a survivor is never
+        # another group's loser (groups are disjoint by content key), so this map
+        # does not need refreshing mid-run.
+        inbound_lineage: dict[str, list[str]] = defaultdict(list)
+        for row_id, target in conn.execute("SELECT id, aggregated_into FROM chunks WHERE aggregated_into IS NOT NULL"):
+            inbound_lineage[str(target)].append(str(row_id))
+        for offset in range(0, len(plans), batch_size):
+            batch = plans[offset : offset + batch_size]
+            result.batches += 1
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                for survivor, losers in batch:
+                    survivor_row = conn.execute(
+                        f"SELECT {', '.join(sorted(set(written) | {'id'}))} FROM chunks WHERE id = ?",
+                        (survivor["id"],),
+                    ).fetchone()
+                    if survivor_row is None:
+                        continue
+                    survivor_state = {c: survivor_row[c] for c in survivor_row.keys()}
+
+                    updates: dict[str, Any] = {}
+                    seen_total = 0
+                    archived_ids: list[str] = []
+                    for loser in losers:
+                        current = conn.execute(
+                            f"SELECT {', '.join(sorted(set(written) | set(LIFECYCLE_COLUMNS) | {'id'}))} "
+                            "FROM chunks WHERE id = ?",
+                            (loser["id"],),
+                        ).fetchone()
+                        if current is None:
+                            continue
+                        loser_state = {c: current[c] for c in current.keys()}
+                        # Resume safety: a loser already archived in a prior run is
+                        # skipped, so seen_count is never transferred twice.
+                        if _is_managed(loser_state):
+                            continue
+
+                        conn.execute(
+                            f"INSERT OR IGNORE INTO {PREIMAGE_TABLE}(id, {', '.join(written)}) "
+                            f"VALUES (?, {', '.join('?' for _ in written)})",
+                            [loser_state["id"], *[loser_state.get(c) for c in written]],
+                        )
+                        assignments = {
+                            "aggregated_into": survivor["id"],
+                            "archived_at": stamp,
+                        }
+                        if "status" in present:
+                            assignments["status"] = "superseded"
+                        conn.execute(
+                            f"UPDATE chunks SET {', '.join(f'{c} = ?' for c in assignments)} WHERE id = ?",
+                            [*assignments.values(), loser_state["id"]],
+                        )
+                        result.losers_archived += 1
+                        seen_total += int(loser_state.get("seen_count") or 0)
+
+                        # Lineage convergence: rows that an EARLIER process had
+                        # already aggregated into this loser would now sit two
+                        # hops from a live row. Re-point them at the survivor so
+                        # every chain still ends one hop away, on a live chunk.
+                        # Looked up in the prefetched map: `aggregated_into` has no
+                        # index, so querying per loser meant 61k full table scans.
+                        inbound_ids = [
+                            row_id
+                            for row_id in inbound_lineage.get(str(loser_state["id"]), ())
+                            if row_id != str(survivor["id"])
+                        ]
+                        inbound = (
+                            conn.execute(
+                                f"SELECT id, {', '.join(written)} FROM chunks "
+                                f"WHERE id IN ({', '.join('?' for _ in inbound_ids)})",
+                                inbound_ids,
+                            ).fetchall()
+                            if inbound_ids
+                            else []
+                        )
+                        if inbound:
+                            conn.executemany(
+                                f"INSERT OR IGNORE INTO {PREIMAGE_TABLE}(id, {', '.join(written)}) "
+                                f"VALUES (?, {', '.join('?' for _ in written)})",
+                                [[row["id"], *[row[c] for c in written]] for row in inbound],
+                            )
+                            conn.executemany(
+                                "UPDATE chunks SET aggregated_into = ? WHERE id = ?",
+                                [(survivor["id"], row["id"]) for row in inbound],
+                            )
+                            result.lineage_repointed += len(inbound)
+                            touched_ids.update(str(row["id"]) for row in inbound)
+
+                        if union_fill:
+                            for column in ENRICH_FIELDS:
+                                if column not in present:
+                                    continue
+                                if not _blank(survivor_state.get(column)) or column in updates:
+                                    continue
+                                if not _blank(loser_state.get(column)):
+                                    updates[column] = loser_state[column]
+
+                        archived_ids.append(str(loser_state["id"]))
+                        touched_ids.add(str(loser_state["id"]))
+
+                    if has_alias and archived_ids:
+                        touched_ids.add(str(survivor["id"]))
+                        _converge_aliases(
+                            conn, survivor_id=str(survivor["id"]), losers=archived_ids, stamp=stamp, result=result
+                        )
+
+                    if union_fill and (updates or seen_total):
+                        conn.execute(
+                            f"INSERT OR IGNORE INTO {PREIMAGE_TABLE}(id, {', '.join(written)}) "
+                            f"VALUES (?, {', '.join('?' for _ in written)})",
+                            [survivor_state["id"], *[survivor_state.get(c) for c in written]],
+                        )
+                        if "seen_count" in present and seen_total:
+                            updates["seen_count"] = int(survivor_state.get("seen_count") or 0) + seen_total
+                            result.seen_count_transferred += seen_total
+                        if updates:
+                            conn.execute(
+                                f"UPDATE chunks SET {', '.join(f'{c} = ?' for c in updates)} WHERE id = ?",
+                                [*updates.values(), survivor_state["id"]],
+                            )
+                            result.survivors_updated += 1
+                            for column in updates:
+                                if column in ENRICH_FIELDS:
+                                    result.union_fills[column] = result.union_fills.get(column, 0) + 1
+                    if any(loser for loser in losers):
+                        result.groups_merged += 1
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+            if result.batches % checkpoint_every == 0:
+                _checkpoint(conn)
+                result.checkpoints += 1
+
+        if result.batches and result.batches % checkpoint_every != 0:
+            _checkpoint(conn)
+            result.checkpoints += 1
+
+        # groups_merged counts groups that actually produced an archived loser
+        result.groups_merged = min(result.groups_merged, result.would_merge_groups)
+        if result.losers_archived == 0:
+            result.groups_merged = 0
+
+        _assert_no_alias_cycles(conn, has_alias, touched_ids, result)
+        result.aux_counts_after = _aux_counts(conn)
+        if result.aux_counts_before != result.aux_counts_after:
+            raise RuntimeError(
+                "aux table counts changed; this migration must not touch FTS or vector rows: "
+                f"{result.aux_counts_before} -> {result.aux_counts_after}"
+            )
+
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                name TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL,
+                details TEXT
+            )
+            """
+        )
+        receipt = {
+            "migration": MIGRATION_NAME,
+            "git_sha": sha,
+            "actor": actor,
+            "policy": "POLICY_REPAIR_E",
+            "groups_merged": result.groups_merged,
+            "losers_archived": result.losers_archived,
+            "groups_held": result.groups_held,
+            "held_reasons": result.held_reasons,
+            "union_fill": union_fill,
+            "union_fills": result.union_fills,
+            "seen_count_transferred": result.seen_count_transferred,
+            "preexisting_alias_cycles": result.preexisting_alias_cycles,
+            "lineage_repointed": result.lineage_repointed,
+        }
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_migrations(name, applied_at, details) VALUES (?, ?, ?)",
+            (MIGRATION_NAME, _now_iso(), json.dumps(receipt, sort_keys=True)),
+        )
+        conn.commit()
+
+        if samples:
+            result.spot_checks = _spot_check(conn, samples, written)
+        return result
+    finally:
+        conn.close()
+
+
+def _alias_preimage(conn: sqlite3.Connection, rows: list[tuple[str, str | None, str | None, str]]) -> None:
+    """Record an alias row's BEFORE state so alias edits are reversible too."""
+    conn.executemany(
+        f"INSERT INTO {ALIAS_PREIMAGE_TABLE}(old_chunk_id, canonical_chunk_id, deprecated_at, action) "
+        "VALUES (?, ?, ?, ?)",
+        rows,
+    )
+
+
+def _converge_aliases(
+    conn: sqlite3.Connection,
+    *,
+    survivor_id: str,
+    losers: list[str],
+    stamp: str,
+    result: DedupeMergeResult,
+) -> None:
+    """Point every alias edge in this group AT the survivor -- and only at it.
+
+    Writing `loser -> survivor` edges one at a time creates cycles: prior dedupe
+    runs already aliased members of the same duplicate group to each other, so a
+    new edge can close a loop (observed on the rehearsal copy: 72 pre-existing
+    cycles became 588). Convergence is the invariant that cannot loop -- every
+    edge in the group terminates at the survivor, and the survivor itself is
+    never an alias source, so no cycle involving this group can exist.
+    """
+    loser_set = set(losers)
+    marks = ", ".join("?" for _ in losers)
+
+    # 1. Anything that resolved to a loser now resolves to the survivor.
+    stale = conn.execute(
+        f"SELECT old_chunk_id, canonical_chunk_id, deprecated_at FROM chunk_id_alias "
+        f"WHERE canonical_chunk_id IN ({marks}) AND old_chunk_id <> ?",
+        (*losers, survivor_id),
+    ).fetchall()
+    if stale:
+        _alias_preimage(conn, [(r[0], r[1], r[2], "repoint") for r in stale])
+        conn.executemany(
+            "UPDATE chunk_id_alias SET canonical_chunk_id = ?, deprecated_at = ? WHERE old_chunk_id = ?",
+            [(survivor_id, stamp, r[0]) for r in stale],
+        )
+        result.aliases_repointed += len(stale)
+
+    # 2. A live survivor must never itself be a deprecated id, or the chain
+    #    walks off the row that is meant to be canonical.
+    outgoing = conn.execute(
+        "SELECT old_chunk_id, canonical_chunk_id, deprecated_at FROM chunk_id_alias WHERE old_chunk_id = ?",
+        (survivor_id,),
+    ).fetchall()
+    if outgoing:
+        _alias_preimage(conn, [(r[0], r[1], r[2], "drop_survivor_source") for r in outgoing])
+        conn.execute("DELETE FROM chunk_id_alias WHERE old_chunk_id = ?", (survivor_id,))
+        result.aliases_dropped_survivor_source += len(outgoing)
+
+    # 3. Every loser forwards to the survivor.
+    existing = {
+        row[0]: (row[1], row[2])
+        for row in conn.execute(
+            f"SELECT old_chunk_id, canonical_chunk_id, deprecated_at FROM chunk_id_alias "
+            f"WHERE old_chunk_id IN ({marks})",
+            losers,
+        )
+    }
+    # Rows that already had an alias are recorded as "overwrite" (restore the old
+    # target on rollback); rows that did not are recorded as "insert" (delete on
+    # rollback). Without the insert rows a rollback cannot tell which alias rows
+    # this migration created, and a date heuristic over-deletes pre-existing ones.
+    pre_rows = [(old, existing[old][0], existing[old][1], "overwrite") for old in existing]
+    pre_rows += [(loser, None, None, "insert") for loser in sorted(loser_set) if loser not in existing]
+    if pre_rows:
+        _alias_preimage(conn, pre_rows)
+    conn.executemany(
+        """
+        INSERT INTO chunk_id_alias(old_chunk_id, canonical_chunk_id, deprecated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(old_chunk_id) DO UPDATE SET
+            canonical_chunk_id = excluded.canonical_chunk_id,
+            deprecated_at = excluded.deprecated_at
+        """,
+        [(loser, survivor_id, stamp) for loser in loser_set],
+    )
+    result.aliases_written += len(loser_set)
+
+
+def _find_alias_cycles(conn: sqlite3.Connection) -> set[str]:
+    """Return every alias id that sits on a cycle."""
+    mapping = {
+        str(old): str(canonical)
+        for old, canonical in conn.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias")
+    }
+    on_cycle: set[str] = set()
+    for start in mapping:
+        seen: list[str] = [start]
+        index = {start}
+        cursor = mapping[start]
+        while cursor in mapping:
+            if cursor in index:
+                on_cycle.update(seen[seen.index(cursor) :])
+                break
+            seen.append(cursor)
+            index.add(cursor)
+            cursor = mapping[cursor]
+    return on_cycle
+
+
+def _assert_no_alias_cycles(
+    conn: sqlite3.Connection, has_alias: bool, touched: set[str], result: DedupeMergeResult
+) -> None:
+    """This migration must introduce no cycle. Pre-existing ones are REPORTED.
+
+    The canonical DB already carries 72 alias cycles that predate repair (e)
+    (prior dedupe runs aliased members of one duplicate group to each other).
+    Failing the whole migration on someone else's cycle would make it
+    unrunnable, and silently ignoring cycles would hide a defect this migration
+    could cause -- so the assertion is scoped to ids this run touched, and the
+    pre-existing count is surfaced in the receipt for lead triage.
+    """
+    if not has_alias:
+        return
+    on_cycle = _find_alias_cycles(conn)
+    ours = on_cycle & touched
+    if ours:
+        sample = sorted(ours)[:3]
+        raise RuntimeError(f"this migration introduced {len(ours)} alias-cycle ids; first: {sample!r}")
+    result.preexisting_alias_cycles = len(on_cycle)
+
+
+def _spot_check(conn: sqlite3.Connection, samples: list[str], written: list[str]) -> list[dict[str, Any]]:
+    """Re-READ stored rows and verify each archived loser against its preimage."""
+    checks: list[dict[str, Any]] = []
+    for chunk_id in samples:
+        stored = conn.execute(
+            "SELECT id, content, aggregated_into, archived_at, status FROM chunks WHERE id = ?",
+            (chunk_id,),
+        ).fetchone()
+        if stored is None:
+            checks.append({"id": chunk_id, "ok": False, "why": "row_missing_after_merge"})
+            continue
+        pre = conn.execute(
+            f"SELECT id, {', '.join(written)} FROM {PREIMAGE_TABLE} WHERE id = ?", (chunk_id,)
+        ).fetchone()
+        survivor_id = stored["aggregated_into"]
+        why = []
+        if pre is None:
+            why.append("no_preimage")
+        if _blank(survivor_id):
+            why.append("no_lineage_pointer")
+        if _blank(stored["archived_at"]):
+            why.append("not_archived")
+        if stored["status"] not in (None, "superseded"):
+            why.append(f"unexpected_status:{stored['status']}")
+        if _blank(stored["content"]):
+            why.append("content_lost")
+        if not _blank(survivor_id):
+            survivor = conn.execute(
+                "SELECT id, content, aggregated_into FROM chunks WHERE id = ?", (survivor_id,)
+            ).fetchone()
+            if survivor is None:
+                why.append("survivor_missing")
+            else:
+                if content_key(survivor["content"]) != content_key(stored["content"]):
+                    why.append("survivor_content_differs")
+                if not _blank(survivor["aggregated_into"]):
+                    why.append("survivor_is_itself_archived")
+        checks.append(
+            {
+                "id": chunk_id,
+                "ok": not why,
+                "aggregated_into": survivor_id,
+                "archived_at": stored["archived_at"],
+                "status": stored["status"],
+                **({"why": why} if why else {}),
+            }
+        )
+    return checks
+
+
+def rollback_migration(db_path: Path, *, allow_live: bool = False) -> dict[str, Any]:
+    """Restore every row this migration wrote, from its preimages.
+
+    Reversibility has to be a command, not a runbook snippet: a hand-written
+    rollback during the rehearsal used a `deprecated_at LIKE today` heuristic to
+    find alias rows and over-deleted 4,817 pre-existing ones. The preimages name
+    exactly what changed, so this is exact.
+
+    The preimage tables are deliberately RETAINED afterwards (as repair-d
+    retained `timestamp_iso_preimage`): they are the audit trail of what the
+    migration touched, and removing them is a separate, human-authorized step.
+    """
+    resolved = assert_not_live_db(Path(db_path), allow_live=allow_live)
+    conn = sqlite3.connect(str(resolved))
+    conn.row_factory = sqlite3.Row
+    out: dict[str, Any] = {
+        "db": str(resolved),
+        "chunks_restored": 0,
+        "aliases_restored": 0,
+        "aliases_removed": 0,
+        "preimage_tables": "retained",
+    }
+    try:
+        conn.execute("PRAGMA busy_timeout=30000")
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        if PREIMAGE_TABLE not in tables:
+            raise RuntimeError(f"{PREIMAGE_TABLE} is absent; nothing to roll back")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            columns = [r[1] for r in conn.execute(f"PRAGMA table_info({PREIMAGE_TABLE})") if r[1] != "id"]
+            rows = conn.execute(f"SELECT id, {', '.join(columns)} FROM {PREIMAGE_TABLE}").fetchall()
+            conn.executemany(
+                f"UPDATE chunks SET {', '.join(f'{c} = ?' for c in columns)} WHERE id = ?",
+                [[row[c] for c in columns] + [row["id"]] for row in rows],
+            )
+            out["chunks_restored"] = len(rows)
+
+            if ALIAS_PREIMAGE_TABLE in tables and "chunk_id_alias" in tables:
+                alias_rows = conn.execute(
+                    f"SELECT old_chunk_id, canonical_chunk_id, deprecated_at, action FROM {ALIAS_PREIMAGE_TABLE}"
+                ).fetchall()
+                created = [r["old_chunk_id"] for r in alias_rows if r["action"] == "insert"]
+                restore = [r for r in alias_rows if r["action"] != "insert"]
+                if created:
+                    conn.executemany("DELETE FROM chunk_id_alias WHERE old_chunk_id = ?", [(old,) for old in created])
+                    out["aliases_removed"] = len(created)
+                if restore:
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO chunk_id_alias(old_chunk_id, canonical_chunk_id, deprecated_at) "
+                        "VALUES (?, ?, ?)",
+                        [(r["old_chunk_id"], r["canonical_chunk_id"], r["deprecated_at"]) for r in restore],
+                    )
+                    out["aliases_restored"] = len(restore)
+            conn.execute("DELETE FROM schema_migrations WHERE name = ?", (MIGRATION_NAME,))
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        _checkpoint(conn)
+        return out
+    finally:
+        conn.close()
+
+
+def _result_payload(db_path: Path, *, apply: bool, result: DedupeMergeResult) -> dict[str, Any]:
+    return {
+        "db": str(db_path),
+        "mode": "apply" if apply else "dry-run",
+        "policy": "POLICY_REPAIR_E",
+        "scanned": result.scanned,
+        "groups_total": result.groups_total,
+        "groups_eligible": result.groups_eligible,
+        "groups_held": result.groups_held,
+        "held_reasons": result.held_reasons,
+        "groups_merged": result.groups_merged,
+        "would_merge_groups": result.would_merge_groups,
+        "would_archive_losers": result.would_archive_losers,
+        "losers_archived": result.losers_archived,
+        "survivors_updated": result.survivors_updated,
+        "union_fills": result.union_fills,
+        "seen_count_transferred": result.seen_count_transferred,
+        "aliases_written": result.aliases_written,
+        "aliases_repointed": result.aliases_repointed,
+        "aliases_dropped_survivor_source": result.aliases_dropped_survivor_source,
+        "lineage_repointed": result.lineage_repointed,
+        "preexisting_alias_cycles": result.preexisting_alias_cycles,
+        "batches": result.batches,
+        "checkpoints": result.checkpoints,
+        "aux_counts_before": result.aux_counts_before,
+        "aux_counts_after": result.aux_counts_after,
+        "aux_counts_unchanged": result.aux_counts_before == result.aux_counts_after,
+        "deleted_rows": 0,
+        "spot_checks_ok": (
+            "n/a-dry-run"
+            if not apply
+            else (all(item["ok"] for item in result.spot_checks) if result.spot_checks else None)
+        ),
+        "spot_checks": result.spot_checks,
+        "next": (
+            "verify every archived loser resolves to a live survivor, then review the live-window plan"
+            if apply
+            else "rerun with --apply against a rehearsal copy (never the live DB)"
+        ),
+    }
+
+
+def _detect_git_sha() -> str | None:
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=Path(__file__).resolve().parents[2], text=True
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return sha if _SHA_RE.fullmatch(sha) else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Archive exact content duplicates onto a survivor (POLICY_REPAIR_E). "
+            "Default is dry-run. Requires --db; refuses the live canonical DB "
+            "unless --allow-live is set. Never deletes a row."
+        )
+    )
+    parser.add_argument("--db", type=Path, required=True, help="Rehearsal copy DB path (required)")
+    parser.add_argument("--apply", action="store_true", help="Write lifecycle columns")
+    parser.add_argument("--git-sha", dest="git_sha", help="40-char commit SHA recorded in schema_migrations")
+    parser.add_argument("--batch-size", type=int, default=500)
+    parser.add_argument("--checkpoint-every", type=int, default=3)
+    parser.add_argument("--allow-live", action="store_true")
+    parser.add_argument("--spot-check", type=int, default=0)
+    parser.add_argument("--no-union-fill", action="store_true", help="Lineage only; never touch the survivor")
+    parser.add_argument("--actor", default="repair-e")
+    parser.add_argument("--rollback", action="store_true", help="Restore every row this migration wrote")
+    args = parser.parse_args(argv)
+    if args.rollback:
+        print(json.dumps(rollback_migration(args.db.expanduser(), allow_live=args.allow_live), sort_keys=True))
+        return 0
+    git_sha = args.git_sha or _detect_git_sha()
+    if not git_sha:
+        parser.error("--git-sha is required (40-char hex) when HEAD is not a full SHA")
+    result = merge_duplicates(
+        args.db.expanduser(),
+        git_sha=git_sha,
+        apply=args.apply,
+        batch_size=args.batch_size,
+        checkpoint_every=args.checkpoint_every,
+        allow_live=args.allow_live,
+        spot_check=args.spot_check,
+        union_fill=not args.no_union_fill,
+        actor=args.actor,
+    )
+    print(json.dumps(_result_payload(args.db.expanduser(), apply=args.apply, result=result), sort_keys=True))
+    if args.apply and result.spot_checks and not all(item["ok"] for item in result.spot_checks):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/brainlayer/dedupe_merge.py
+++ b/src/brainlayer/dedupe_merge.py
@@ -21,9 +21,19 @@ Policy (POLICY_REPAIR_E, lead-ACKed 2026-08-18, census in
   rows already lifecycle-managed are never chosen. Oldest-wins would have
   discarded enrichment in 23,359 of 42,082 eligible groups; richest-wins, 1,243.
 * **Losers** — `aggregated_into` + `archived_at` + `status='superseded'`. Content,
-  ids, tags, FTS rows and vectors all stay. No DELETE, in any table, ever.
-  `status='superseded'` and not `'archived'` because `vector_store.py` rewrites
-  `status='archived'` on startup, which would silently revert the migration.
+  ids, tags, FTS rows and vectors all stay. **No chunk row is ever deleted, in any
+  table.** `status='superseded'` and not `'archived'` because `vector_store.py`
+  rewrites `status='archived'` on startup, which would silently revert the migration.
+* **One approved deletion, scoped to redirect metadata.** Lead ruling 2026-08-18,
+  recorded verbatim in `ALIAS_DELETE_EXCEPTION` and in every on-DB receipt: *"The 64
+  survivor-source alias DELETEs are APPROVED as a narrow chain-correctness exception
+  to 'no deletes': alias redirect metadata only, never chunk rows."* It is step 2 of
+  `_converge_aliases` — a live survivor must not itself be a deprecated id, or the
+  chain walks off the canonical row. It is preimaged and it reverses. The counters
+  `aliases_written` / `aliases_repointed` / `aliases_dropped_survivor_source` are in
+  the durable receipt so the audit trail records it, and the result payload reports
+  `chunks_deleted` and `alias_rows_deleted` separately rather than a flat
+  `deleted_rows: 0`.
 
 Both serving paths already exclude `aggregated_into IS NOT NULL` and
 `archived_at IS NOT NULL` from default search, so this removes duplicate noise
@@ -76,6 +86,20 @@ WRITTEN_COLUMNS = (
 )
 
 LIFECYCLE_COLUMNS = ("archived_at", "superseded_by", "aggregated_into")
+
+#: Lead ruling, 2026-08-18, recorded verbatim in the on-DB receipt.
+ALIAS_DELETE_EXCEPTION = (
+    "The 64 survivor-source alias DELETEs are APPROVED as a narrow chain-correctness "
+    "exception to 'no deletes': alias redirect metadata only, never chunk rows."
+)
+
+#: Stated so a reviewer's count reproduces exactly. The rehearsal reported 755,048
+#: with this predicate; the reviewer's 755,059 omits the content clause. Both give
+#: the same delta of 61,445 -- it was a predicate gap, not a data disagreement.
+DEFAULT_SEARCHABLE_PREDICATE = (
+    "superseded_by IS NULL AND aggregated_into IS NULL AND archived_at IS NULL "
+    "AND content IS NOT NULL AND content <> ''"
+)
 
 
 @dataclass
@@ -140,14 +164,26 @@ def _instant(value: Any) -> str:
     return "" if _blank(value) else str(value).strip()
 
 
-def pick_survivor(members: list[dict], present: set[str]) -> dict | None:
-    """Richest enrichment -> oldest created_at -> smallest id, among live rows."""
+def pick_survivor(members: list[dict], present: set[str], alias_sources: frozenset[str] = frozenset()) -> dict | None:
+    """Richest enrichment -> oldest created_at -> not-an-alias-source -> smallest id.
+
+    The alias-source preference sits AT the id tiebreak, so the lead-ACKed ordering
+    (richest -> oldest -> smallest id) is untouched: it only decides cases the id
+    tiebreak would otherwise have settled arbitrarily. Choosing a row that is
+    already a deprecated id forces `_converge_aliases` to drop that redirect, so
+    preferring a non-source shrinks those deletes toward zero for free.
+    """
     live = [m for m in members if not _is_managed(m)]
     if not live:
         return None
     return min(
         live,
-        key=lambda m: (-_enrich_score(m, present), _instant(m.get("created_at")) or "9999", str(m["id"])),
+        key=lambda m: (
+            -_enrich_score(m, present),
+            _instant(m.get("created_at")) or "9999",
+            str(m["id"]) in alias_sources,
+            str(m["id"]),
+        ),
     )
 
 
@@ -246,6 +282,9 @@ def merge_duplicates(
         select_cols = sorted({"id", "content", "conversation_id", "created_at", *LIFECYCLE_COLUMNS, *written} & present)
         has_alias = _ensure_alias_table(conn)
 
+        alias_sources: frozenset[str] = frozenset()
+        if has_alias:
+            alias_sources = frozenset(str(row[0]) for row in conn.execute("SELECT old_chunk_id FROM chunk_id_alias"))
         result.aux_counts_before = _aux_counts(conn)
         if apply:
             _ensure_preimage(conn, written)
@@ -297,7 +336,7 @@ def merge_duplicates(
                 result.groups_held += 1
                 result.held_reasons[reason] = result.held_reasons.get(reason, 0) + 1
                 continue
-            survivor = pick_survivor(members, present)
+            survivor = pick_survivor(members, present, alias_sources)
             if survivor is None:
                 result.groups_held += 1
                 result.held_reasons["all_members_lifecycle_managed"] = (
@@ -499,6 +538,13 @@ def merge_duplicates(
             "git_sha": sha,
             "actor": actor,
             "policy": "POLICY_REPAIR_E",
+            "chunks_deleted": 0,
+            "alias_rows_deleted": result.aliases_dropped_survivor_source,
+            "alias_delete_exception": ALIAS_DELETE_EXCEPTION,
+            "aliases_written": result.aliases_written,
+            "aliases_repointed": result.aliases_repointed,
+            "aliases_dropped_survivor_source": result.aliases_dropped_survivor_source,
+            "default_searchable_predicate": DEFAULT_SEARCHABLE_PREDICATE,
             "groups_merged": result.groups_merged,
             "losers_archived": result.losers_archived,
             "groups_held": result.groups_held,
@@ -699,6 +745,66 @@ def _spot_check(conn: sqlite3.Connection, samples: list[str], written: list[str]
     return checks
 
 
+def _assert_rollback_restored_values(conn: sqlite3.Connection, tables: set[str]) -> dict[str, int]:
+    """Compare restored VALUES against the earliest preimage. Counts are not enough.
+
+    The rehearsal checked `chunk_id_alias` by row count -- 69,269 -> 130,576 ->
+    69,269 -- and a swapped pointer preserves the count perfectly, so the count
+    check could not see the defect it existed to catch (issue #722's shape).
+    This audit compares every restored value against the preimage that recorded
+    the true pre-migration state, and raises rather than reporting a clean count
+    over wrong data.
+    """
+    audited = {"chunks_checked": 0, "aliases_checked": 0}
+    mismatches: list[str] = []
+
+    columns = [r[1] for r in conn.execute(f"PRAGMA table_info({PREIMAGE_TABLE})") if r[1] != "id"]
+    for row in conn.execute(
+        f"SELECT p.id, {', '.join(f'p.{c} AS pre_{c}' for c in columns)}, "
+        f"{', '.join(f'c.{c} AS now_{c}' for c in columns)} "
+        f"FROM {PREIMAGE_TABLE} p JOIN chunks c ON c.id = p.id"
+    ):
+        audited["chunks_checked"] += 1
+        for column in columns:
+            if row[f"pre_{column}"] != row[f"now_{column}"]:
+                if len(mismatches) < 5:
+                    mismatches.append(
+                        f"chunks.{row['id']}.{column}: {row[f'now_{column}']!r} != {row[f'pre_{column}']!r}"
+                    )
+
+    if ALIAS_PREIMAGE_TABLE in tables and "chunk_id_alias" in tables:
+        live = {
+            str(old): (canonical, deprecated)
+            for old, canonical, deprecated in conn.execute(
+                "SELECT old_chunk_id, canonical_chunk_id, deprecated_at FROM chunk_id_alias"
+            )
+        }
+        for row in conn.execute(
+            f"""
+            SELECT p.old_chunk_id, p.canonical_chunk_id, p.deprecated_at, p.action
+            FROM {ALIAS_PREIMAGE_TABLE} p
+            JOIN (
+                SELECT old_chunk_id, MIN(rowid) AS first_rowid
+                FROM {ALIAS_PREIMAGE_TABLE}
+                GROUP BY old_chunk_id
+            ) f ON f.first_rowid = p.rowid
+            """
+        ):
+            audited["aliases_checked"] += 1
+            old = str(row["old_chunk_id"])
+            if row["action"] == "insert":
+                if old in live and len(mismatches) < 5:
+                    mismatches.append(f"chunk_id_alias.{old}: present, expected absent")
+                continue
+            expected = (row["canonical_chunk_id"], row["deprecated_at"])
+            if live.get(old) != expected and len(mismatches) < 5:
+                mismatches.append(f"chunk_id_alias.{old}: {live.get(old)!r} != {expected!r}")
+
+    if mismatches:
+        raise RuntimeError(f"rollback did not restore the pre-migration values: {mismatches}")
+    return audited
+
+
 def rollback_migration(db_path: Path, *, allow_live: bool = False) -> dict[str, Any]:
     """Restore every row this migration wrote, from its preimages.
 
@@ -737,11 +843,27 @@ def rollback_migration(db_path: Path, *, allow_live: bool = False) -> dict[str, 
             out["chunks_restored"] = len(rows)
 
             if ALIAS_PREIMAGE_TABLE in tables and "chunk_id_alias" in tables:
-                alias_rows = conn.execute(
-                    f"SELECT old_chunk_id, canonical_chunk_id, deprecated_at, action FROM {ALIAS_PREIMAGE_TABLE}"
+                # EARLIEST preimage per old_chunk_id wins. One alias row can be
+                # touched by two groups (step-1 repoint in group A, then step-3
+                # overwrite in group B); the second preimage records the value
+                # THIS MIGRATION already wrote, so replaying in table order with
+                # INSERT OR REPLACE restores the migration's own value instead of
+                # the original. The chunks preimage is immune (INSERT OR IGNORE on
+                # an id PRIMARY KEY = first-write-wins); this table has no key, so
+                # the ordering has to be explicit.
+                earliest = conn.execute(
+                    f"""
+                    SELECT p.old_chunk_id, p.canonical_chunk_id, p.deprecated_at, p.action
+                    FROM {ALIAS_PREIMAGE_TABLE} p
+                    JOIN (
+                        SELECT old_chunk_id, MIN(rowid) AS first_rowid
+                        FROM {ALIAS_PREIMAGE_TABLE}
+                        GROUP BY old_chunk_id
+                    ) f ON f.first_rowid = p.rowid
+                    """
                 ).fetchall()
-                created = [r["old_chunk_id"] for r in alias_rows if r["action"] == "insert"]
-                restore = [r for r in alias_rows if r["action"] != "insert"]
+                created = [r["old_chunk_id"] for r in earliest if r["action"] == "insert"]
+                restore = [r for r in earliest if r["action"] != "insert"]
                 if created:
                     conn.executemany("DELETE FROM chunk_id_alias WHERE old_chunk_id = ?", [(old,) for old in created])
                     out["aliases_removed"] = len(created)
@@ -758,6 +880,7 @@ def rollback_migration(db_path: Path, *, allow_live: bool = False) -> dict[str, 
             conn.execute("ROLLBACK")
             raise
         _checkpoint(conn)
+        out["value_audit"] = _assert_rollback_restored_values(conn, tables)
         return out
     finally:
         conn.close()
@@ -790,7 +913,12 @@ def _result_payload(db_path: Path, *, apply: bool, result: DedupeMergeResult) ->
         "aux_counts_before": result.aux_counts_before,
         "aux_counts_after": result.aux_counts_after,
         "aux_counts_unchanged": result.aux_counts_before == result.aux_counts_after,
-        "deleted_rows": 0,
+        # Scoped, honest names. "deleted_rows: 0" was a hardcoded lie while step 2
+        # of alias convergence deleted 64 redirect rows on the real rehearsal.
+        "chunks_deleted": 0,
+        "alias_rows_deleted": result.aliases_dropped_survivor_source,
+        "alias_delete_exception": ALIAS_DELETE_EXCEPTION,
+        "default_searchable_predicate": DEFAULT_SEARCHABLE_PREDICATE,
         "spot_checks_ok": (
             "n/a-dry-run"
             if not apply

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -948,9 +948,11 @@ def _apply_hook(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
     if not content:
         logger.warning("Skipping malformed hook event with empty content")
         return ApplyResult()
-    content_hash = event.get("content_hash") or hashlib.sha256(content.encode()).hexdigest()[:16]
+    # Truncated digest that NAMES the chunk (id suffix + queue key). It is not a
+    # content hash: the content_hash column is filled by the canonical contract.
+    id_digest = event.get("content_hash") or hashlib.sha256(content.encode()).hexdigest()[:16]
     session_id = event.get("session_id") or "unknown"
-    chunk_id = event.get("chunk_id") or f"rt-{str(session_id)[:8]}-{content_hash}"
+    chunk_id = event.get("chunk_id") or f"rt-{str(session_id)[:8]}-{id_digest}"
     source_file = event.get("source_file") or "realtime-hook"
     recursive_reason = recursive_mcp_output_reason(
         content,
@@ -977,7 +979,7 @@ def _apply_hook(conn: apsw.Connection, event: dict[str, Any]) -> ApplyResult:
         {
             "id": chunk_id,
             "content": content,
-            "metadata": json.dumps({"session_id": session_id, "content_hash": content_hash}),
+            "metadata": json.dumps({"session_id": session_id, "id_digest": id_digest}),
             "source_file": source_file,
             "project": event.get("project"),
             "content_type": "assistant_text",

--- a/src/brainlayer/drain.py
+++ b/src/brainlayer/drain.py
@@ -21,7 +21,7 @@ import sqlite_vec
 from ._helpers import _is_sqlite_busy_error, serialize_f32
 from .agent_provenance import normalize_source_class
 from .chunk_origin import detect_chunk_origin
-from .chunk_write import insert_canonical_chunk
+from .chunk_write import canonical_content_hash, insert_canonical_chunk
 from .content_class import classify_content_class
 from .dedupe import (
     ensure_dedupe_schema,
@@ -365,8 +365,9 @@ def _ensure_rewind_archive_schema(conn: apsw.Connection) -> None:
             cols.add(col)
 
 
-def _content_hash(content: str) -> str:
-    return hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
+# One implementation only -- see chunk_write.canonical_content_hash. drain writes
+# content_hash on its INSERT payloads, so it must not carry its own copy.
+_content_hash = canonical_content_hash
 
 
 def _insert_chunk(conn: apsw.Connection, values: dict[str, Any]) -> None:

--- a/src/brainlayer/enrichment_controller.py
+++ b/src/brainlayer/enrichment_controller.py
@@ -7,7 +7,6 @@ Replaces scattered enrichment scripts with a single controller:
 
 from __future__ import annotations
 
-import hashlib
 import importlib.util
 import json
 import logging
@@ -1254,9 +1253,10 @@ def call_gemini_for_extraction(prompt: str) -> Optional[str]:
 # ── Content-hash dedup ─────────────────────────────────────────────────────────
 
 
-def _content_hash(content: str) -> str:
-    """SHA256 hash of content for dedup. Strips whitespace for normalization."""
-    return hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
+# The content_hash contract lives in ONE place. A second implementation of this
+# function -- even a byte-identical one -- is precisely how four hash schemes got
+# into the column, so the UPDATE paths below import it rather than redefine it.
+from .chunk_write import canonical_content_hash as _content_hash  # noqa: E402
 
 
 def is_meta_research(content: str) -> bool:

--- a/src/brainlayer/hooks/indexer.py
+++ b/src/brainlayer/hooks/indexer.py
@@ -124,9 +124,11 @@ class RealtimeIndexer:
         else:
             content = f"Assistant: {response_text}"
 
-        # Content hash for dedup (scoped to session via UNIQUE constraint)
-        content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
-        chunk_id = f"rt-{session_id[:8]}-{content_hash}"
+        # Truncated digest that NAMES the chunk (id suffix + queue key). It is not
+        # a content hash: the content_hash column is filled by the canonical
+        # contract in chunk_write, which is the single scheme for that column.
+        id_digest = hashlib.sha256(content.encode()).hexdigest()[:16]
+        chunk_id = f"rt-{session_id[:8]}-{id_digest}"
         project = self._extract_project(cwd)
         created_at = datetime.now(timezone.utc).isoformat()
 
@@ -138,7 +140,7 @@ class RealtimeIndexer:
                     chunk_id=chunk_id,
                     session_id=session_id,
                     content=content,
-                    content_hash=content_hash,
+                    id_digest=id_digest,
                     project=project,
                     source_file=cwd,
                     created_at=created_at,
@@ -150,10 +152,10 @@ class RealtimeIndexer:
                 return chunk_id
             except Exception as exc:
                 logger.warning("DB write failed: %s", exc)
-                self._write_to_queue(session_id, content, content_hash, project, source_file=cwd, created_at=created_at)
+                self._write_to_queue(session_id, content, id_digest, project, source_file=cwd, created_at=created_at)
                 return None
         else:
-            self._write_to_queue(session_id, content, content_hash, project, source_file=cwd, created_at=created_at)
+            self._write_to_queue(session_id, content, id_digest, project, source_file=cwd, created_at=created_at)
             return None
 
     # MARK: - Chapter boundaries (PostCompact)
@@ -223,7 +225,7 @@ class RealtimeIndexer:
         chunk_id: str,
         session_id: str,
         content: str,
-        content_hash: str,
+        id_digest: str,
         project: str,
         source_file: str,
         created_at: str,
@@ -234,8 +236,7 @@ class RealtimeIndexer:
         payload: dict[str, object] = {
             "id": chunk_id,
             "content": content,
-            "metadata": {"session_id": session_id, "content_hash": content_hash},
-            "content_hash": content_hash,
+            "metadata": {"session_id": session_id, "id_digest": id_digest},
             "source_file": source_file,
             "project": project,
             "content_type": "assistant_text",

--- a/src/brainlayer/store.py
+++ b/src/brainlayer/store.py
@@ -30,7 +30,6 @@ Usage:
     )
 """
 
-import hashlib
 import json
 import logging
 import time
@@ -41,7 +40,7 @@ from typing import Any, Callable, Dict, List, Optional
 import apsw
 
 from .chunk_origin import CHUNK_ORIGIN_PRECOMPACT_CHECKPOINT, detect_chunk_origin
-from .chunk_write import insert_canonical_chunk
+from .chunk_write import canonical_content_hash, insert_canonical_chunk
 from .content_class import classify_content_class
 from .dedupe import find_duplicate, merge_duplicate_chunk, merge_existing_chunk_content, merge_existing_chunk_seen
 from .ingest_guard import reject_recursive_mcp_output
@@ -168,7 +167,7 @@ def store_memory(
     chunk_id = chunk_id or f"manual-{uuid.uuid4().hex[:16]}"
     now = datetime.now(timezone.utc).isoformat()
     effective_created_at = created_at or now
-    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    content_hash = canonical_content_hash(content)
 
     # Embed at write time (if embed_fn provided), otherwise defer
     embedding = None

--- a/tests/test_chunk_write_contract.py
+++ b/tests/test_chunk_write_contract.py
@@ -347,3 +347,64 @@ def test_production_inserts_go_through_chunk_write():
             if INSERT_GUARD.search(body):
                 offenders.append(str(path.relative_to(REPO_ROOT)))
     assert offenders == []
+
+
+# --- repair (e): ONE content_hash contract -------------------------------------
+# The live DB carried four hash schemes at once (64-char sha256, a 32-char scheme,
+# 16-char truncations from drain, and 52k rows with none). Rows hashed under
+# different schemes never group, so duplicates accrue faster than dedupe removes
+# them. The contract is now: content_hash is ALWAYS sha256 over the stripped
+# content, recomputed at write time, and a caller-supplied value never wins.
+
+CANONICAL_CONTENT_HASH_CONTENT = "  Etan said: ship the fenced migration.\n\n"
+
+
+def canonical_content_hash(content: str) -> str:
+    return hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
+
+
+def test_content_hash_is_sha256_of_stripped_content():
+    from brainlayer.chunk_write import prepare_canonical_insert
+
+    row = prepare_canonical_insert({"id": "hash-contract-1", "content": CANONICAL_CONTENT_HASH_CONTENT})
+    assert row["content_hash"] == canonical_content_hash(CANONICAL_CONTENT_HASH_CONTENT)
+    assert len(row["content_hash"]) == 64
+
+
+def test_content_hash_ignores_surrounding_whitespace():
+    """Two writers disagreeing only on trailing newlines must agree on the hash."""
+    from brainlayer.chunk_write import prepare_canonical_insert
+
+    bare = prepare_canonical_insert({"id": "hash-contract-2", "content": "same text"})
+    padded = prepare_canonical_insert({"id": "hash-contract-3", "content": "\n  same text  \n"})
+    assert bare["content_hash"] == padded["content_hash"]
+
+
+def test_caller_supplied_content_hash_never_wins():
+    """A truncated or stale hash handed in by a legacy caller must be overridden."""
+    from brainlayer.chunk_write import prepare_canonical_insert
+
+    row = prepare_canonical_insert(
+        {
+            "id": "hash-contract-4",
+            "content": CANONICAL_CONTENT_HASH_CONTENT,
+            "content_hash": "deadbeefdeadbeef",  # 16-char legacy scheme
+        }
+    )
+    assert row["content_hash"] == canonical_content_hash(CANONICAL_CONTENT_HASH_CONTENT)
+
+
+def test_no_truncated_content_hash_schemes_remain_in_production_code():
+    """No production path may store a truncated sha256 as a chunk content_hash."""
+    offenders = []
+    # Assignments only: `content_hash = ...hexdigest()[:16]` or a
+    # `"content_hash": ...hexdigest()[:16]` dict entry. Reading a legacy queue
+    # key named content_hash is not a violation -- storing a truncated digest is.
+    pattern = re.compile(r"""(?:^|[^"'\w])content_hash\s*(?:=|:)\s*[^\n=]{0,80}hexdigest\(\)\[:\d+\]""", re.M)
+    for root in (REPO_ROOT / "src/brainlayer", REPO_ROOT / "hooks", REPO_ROOT / "scripts"):
+        for path in root.rglob("*.py"):
+            body = path.read_text(encoding="utf-8")
+            for match in pattern.finditer(body):
+                line = body[: match.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line}")
+    assert offenders == [], f"truncated content_hash schemes: {offenders}"

--- a/tests/test_chunk_write_contract.py
+++ b/tests/test_chunk_write_contract.py
@@ -394,6 +394,65 @@ def test_caller_supplied_content_hash_never_wins():
     assert row["content_hash"] == canonical_content_hash(CANONICAL_CONTENT_HASH_CONTENT)
 
 
+def test_only_one_content_hash_implementation_exists():
+    """A second implementation is how four schemes got into the column.
+
+    Byte-identical duplicates count: `enrichment_controller` had its own
+    `_content_hash` feeding four `UPDATE chunks SET content_hash` sites, and
+    `store.py` computed an UNSTRIPPED sha256. Both now import the contract.
+    """
+    from brainlayer import enrichment_controller
+    from brainlayer.chunk_write import canonical_content_hash
+
+    assert enrichment_controller._content_hash is canonical_content_hash
+
+    offenders = []
+    definition = re.compile(r"^def _?content_hash\(", re.M)
+    for root in (REPO_ROOT / "src/brainlayer", REPO_ROOT / "hooks", REPO_ROOT / "scripts"):
+        for path in root.rglob("*.py"):
+            if path == REPO_ROOT / "src/brainlayer/chunk_write.py":
+                continue
+            body = path.read_text(encoding="utf-8")
+            for match in definition.finditer(body):
+                line = body[: match.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line}")
+    assert offenders == [], f"content_hash must be defined once, in chunk_write: {offenders}"
+
+
+def test_update_paths_write_the_canonical_hash():
+    """The contract must cover UPDATE, not only INSERT."""
+    import sqlite3
+
+    from brainlayer.chunk_write import canonical_content_hash
+    from brainlayer.enrichment_controller import _content_hash
+
+    content = "  enrichment rewrote this row\n\n"
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE chunks (id TEXT PRIMARY KEY, content TEXT, content_hash TEXT)")
+    conn.execute("INSERT INTO chunks VALUES ('u1', ?, 'stale-16char0000')", (content,))
+    # the exact statement shape used at enrichment_controller UPDATE sites
+    conn.execute("UPDATE chunks SET content_hash = ? WHERE id = ?", (_content_hash(content), "u1"))
+    stored = conn.execute("SELECT content_hash FROM chunks WHERE id = 'u1'").fetchone()[0]
+    conn.close()
+    assert stored == canonical_content_hash(content)
+    assert len(stored) == 64
+
+
+def test_no_unstripped_sha256_is_written_to_content_hash():
+    """store.py hashed unstripped content; two writers must not disagree on padding."""
+    from brainlayer.chunk_write import canonical_content_hash
+
+    offenders = []
+    pattern = re.compile(r"content_hash\s*=\s*hashlib\.sha256\((?!.*strip)", re.M)
+    for root in (REPO_ROOT / "src/brainlayer", REPO_ROOT / "hooks", REPO_ROOT / "scripts"):
+        for path in root.rglob("*.py"):
+            body = path.read_text(encoding="utf-8")
+            for match in pattern.finditer(body):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{body[: match.start()].count(chr(10)) + 1}")
+    assert offenders == [], f"unstripped sha256 written to content_hash: {offenders}"
+    assert canonical_content_hash(" a ") == canonical_content_hash("a")
+
+
 def test_no_truncated_content_hash_schemes_remain_in_production_code():
     """No production path may store a truncated sha256 as a chunk content_hash."""
     offenders = []

--- a/tests/test_chunk_write_contract.py
+++ b/tests/test_chunk_write_contract.py
@@ -439,18 +439,45 @@ def test_update_paths_write_the_canonical_hash():
 
 
 def test_no_unstripped_sha256_is_written_to_content_hash():
-    """store.py hashed unstripped content; two writers must not disagree on padding."""
+    """No writer may hash UNSTRIPPED content into content_hash.
+
+    Matches any module alias (`hashlib.sha256`, `_h.sha256`, a bare `sha256`),
+    not just the literal `hashlib.` spelling -- the first version of this guard
+    only caught `hashlib.sha256(` and a rename slipped straight past it.
+    """
     from brainlayer.chunk_write import canonical_content_hash
 
+    assert canonical_content_hash(" a ") == canonical_content_hash("a")
+
     offenders = []
-    pattern = re.compile(r"content_hash\s*=\s*hashlib\.sha256\((?!.*strip)", re.M)
+    pattern = re.compile(r"content_hash\s*=\s*[\w.]*sha256\(([^)]*)\)", re.M)
     for root in (REPO_ROOT / "src/brainlayer", REPO_ROOT / "hooks", REPO_ROOT / "scripts"):
         for path in root.rglob("*.py"):
             body = path.read_text(encoding="utf-8")
+            # Scoped to the chunks column. queue_merge.py hashes FILE BYTES into a
+            # local also named content_hash and never touches the chunks table --
+            # a true regex hit but not this invariant.
+            if "chunks" not in body:
+                continue
             for match in pattern.finditer(body):
+                if ".strip()" in match.group(1):
+                    continue
                 offenders.append(f"{path.relative_to(REPO_ROOT)}:{body[: match.start()].count(chr(10)) + 1}")
     assert offenders == [], f"unstripped sha256 written to content_hash: {offenders}"
-    assert canonical_content_hash(" a ") == canonical_content_hash("a")
+
+
+def test_store_memory_persists_the_canonical_hash():
+    """Behavioural backstop: spelling tricks cannot evade an executed write."""
+    import inspect
+
+    from brainlayer import store as store_module
+    from brainlayer.chunk_write import canonical_content_hash
+
+    source = inspect.getsource(store_module.store_memory)
+    assignment = [line.strip() for line in source.splitlines() if "content_hash =" in line]
+    assert assignment == ["content_hash = canonical_content_hash(content)"], assignment
+    padded, bare = "  a stored memory \n", "a stored memory"
+    assert canonical_content_hash(padded) == canonical_content_hash(bare)
 
 
 def test_no_truncated_content_hash_schemes_remain_in_production_code():

--- a/tests/test_db_shrink.py
+++ b/tests/test_db_shrink.py
@@ -1,6 +1,10 @@
+import re
 import sqlite3
+from pathlib import Path
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _init_chunks(conn: sqlite3.Connection) -> None:
@@ -139,197 +143,69 @@ def test_migrate_fts_compact_dual_preserves_trigram_table(tmp_path):
     assert counts == (1, 1)
 
 
-def test_dedupe_deletes_duplicates_and_repoints_refs(tmp_path):
-    from brainlayer.db_shrink import apply_content_dedup
+# --- repair (e): the physical-delete dedupe path must stay gone ---------------
+# db_shrink once carried apply_content_dedup -> _merge_duplicate_references ->
+# `DELETE FROM chunks`, stamped mechanism='normalized_content_physical_delete'
+# and keyed on the lossy normalized_exact_hash. It contradicted the lifecycle law
+# (duplicates archive with aggregated_into lineage, never delete) and had never
+# run on the canonical DB. Merging now lives in brainlayer.dedupe_merge, which
+# only writes lifecycle columns.
 
-    db_path = tmp_path / "dedup.db"
-    conn = sqlite3.connect(db_path)
-    _init_chunks(conn)
-    conn.executescript(
-        """
-        CREATE TABLE chunk_id_alias (
-            old_chunk_id TEXT PRIMARY KEY,
-            canonical_chunk_id TEXT NOT NULL,
-            deprecated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        CREATE TABLE dedupe_audit (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            chunk_id_dropped TEXT NOT NULL,
-            chunk_id_kept TEXT NOT NULL,
-            mechanism TEXT NOT NULL,
-            hamming_distance INTEGER,
-            ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        CREATE TABLE chunk_tags (
-            chunk_id TEXT NOT NULL,
-            tag TEXT NOT NULL,
-            PRIMARY KEY (chunk_id, tag)
-        );
-        CREATE TABLE kg_entity_chunks (
-            entity_id TEXT NOT NULL,
-            chunk_id TEXT NOT NULL,
-            relevance REAL,
-            context TEXT,
-            PRIMARY KEY (entity_id, chunk_id)
-        );
-        CREATE TABLE chunk_vectors (
-            chunk_id TEXT PRIMARY KEY,
-            embedding BLOB
-        );
-        CREATE TABLE correction_pairs (
-            id INTEGER PRIMARY KEY,
-            chunk_id TEXT
-        );
-        CREATE TABLE file_interactions (
-            id INTEGER PRIMARY KEY,
-            chunk_id TEXT
-        );
-        CREATE TABLE kg_relations (
-            id TEXT PRIMARY KEY,
-            source_chunk_id TEXT
-        );
-        CREATE VIRTUAL TABLE chunks_fts USING fts5(
-            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
-        );
-        """
-    )
-    rows = [
-        ("qrel-id", "Duplicate content for the eval target", "2026-01-02"),
-        ("dupe-id", "duplicate   content for the eval target", "2026-01-01"),
-        ("old-id", "Another duplicate memory", "2026-01-01"),
-        ("new-id", "another duplicate memory", "2026-01-03"),
-        ("unique-id", "Unique memory", "2026-01-04"),
-    ]
-    conn.executemany(
-        """
-        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
-        VALUES (?, ?, '', '', '', '', '', ?)
-        """,
-        rows,
-    )
-    conn.executemany(
-        "INSERT INTO chunk_tags(chunk_id, tag) VALUES (?, ?)", [("dupe-id", "dupe-tag"), ("qrel-id", "qrel-tag")]
-    )
-    conn.execute(
-        "INSERT INTO kg_entity_chunks(entity_id, chunk_id, relevance, context) VALUES ('e1', 'dupe-id', 0.7, 'ctx')"
-    )
-    conn.execute("INSERT INTO chunk_vectors(chunk_id, embedding) VALUES ('dupe-id', X'00')")
-    conn.execute("INSERT INTO correction_pairs(id, chunk_id) VALUES (1, 'dupe-id')")
-    conn.execute("INSERT INTO file_interactions(id, chunk_id) VALUES (1, 'dupe-id')")
-    conn.execute("INSERT INTO kg_relations(id, source_chunk_id) VALUES ('r1', 'dupe-id')")
-    conn.commit()
-    conn.close()
-
-    result = apply_content_dedup(db_path, protected_chunk_ids={"qrel-id"}, batch_size=2)
-
-    checked = sqlite3.connect(db_path)
-    chunk_ids = {row[0] for row in checked.execute("SELECT id FROM chunks")}
-    alias = dict(checked.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias"))
-    tags = set(checked.execute("SELECT chunk_id, tag FROM chunk_tags"))
-    entity_link = checked.execute("SELECT chunk_id FROM kg_entity_chunks WHERE entity_id = 'e1'").fetchone()[0]
-    correction = checked.execute("SELECT chunk_id FROM correction_pairs WHERE id = 1").fetchone()[0]
-    interaction = checked.execute("SELECT chunk_id FROM file_interactions WHERE id = 1").fetchone()[0]
-    relation = checked.execute("SELECT source_chunk_id FROM kg_relations WHERE id = 'r1'").fetchone()[0]
-    vector = checked.execute("SELECT 1 FROM chunk_vectors WHERE chunk_id = 'dupe-id'").fetchone()
-    checked.close()
-
-    assert result.duplicate_rows == 2
-    assert result.deleted_rows == 2
-    assert "dupe-id" not in chunk_ids
-    assert "new-id" not in chunk_ids
-    assert "qrel-id" in chunk_ids
-    assert "old-id" in chunk_ids
-    assert alias["dupe-id"] == "qrel-id"
-    assert alias["new-id"] == "old-id"
-    assert ("qrel-id", "dupe-tag") in tags
-    assert entity_link == "qrel-id"
-    assert correction == "qrel-id"
-    assert interaction == "qrel-id"
-    assert relation == "qrel-id"
-    assert vector is None
+REMOVED_DEDUP_SYMBOLS = (
+    "apply_content_dedup",
+    "analyze_content_duplicates",
+    "_merge_duplicate_references",
+    "_record_alias",
+    "_delete_by_chunk_id",
+    "_delete_fts_rows_for_chunk",
+    "_insert_or_ignore_repoint",
+    "_bulk_repoint_direct_refs",
+    "_bulk_repoint_chunk_self_refs",
+    "load_protected_qrel_ids",
+    "DedupResult",
+)
 
 
-def test_dedupe_without_fts_rebuild_preserves_fts_consistency(tmp_path):
-    from brainlayer.db_shrink import apply_content_dedup
+def test_physical_delete_dedup_path_is_gone():
+    from brainlayer import db_shrink
 
-    db_path = tmp_path / "dedup-skip-fts.db"
-    conn = sqlite3.connect(db_path)
-    _init_chunks(conn)
-    conn.executescript(
-        """
-        CREATE TABLE chunk_id_alias (
-            old_chunk_id TEXT PRIMARY KEY,
-            canonical_chunk_id TEXT NOT NULL,
-            deprecated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        CREATE TABLE dedupe_audit (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            chunk_id_dropped TEXT NOT NULL,
-            chunk_id_kept TEXT NOT NULL,
-            mechanism TEXT NOT NULL,
-            hamming_distance INTEGER,
-            ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        CREATE VIRTUAL TABLE chunks_fts USING fts5(
-            content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id UNINDEXED
-        );
-        CREATE TRIGGER chunks_fts_insert AFTER INSERT ON chunks BEGIN
-            INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id)
-            VALUES (
-                new.content,
-                new.summary,
-                new.tags,
-                new.resolved_query,
-                new.key_facts,
-                new.resolved_queries,
-                new.id
-            );
-            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid)
-            VALUES (new.id, last_insert_rowid(), NULL)
-            ON CONFLICT(chunk_id) DO UPDATE SET
-                fts_rowid = excluded.fts_rowid,
-                trigram_rowid = NULL;
-        END;
-        CREATE TRIGGER chunks_fts_delete AFTER DELETE ON chunks BEGIN
-            DELETE FROM chunks_fts
-            WHERE rowid = (SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = old.id);
-            DELETE FROM chunk_fts_rowids WHERE chunk_id = old.id;
-        END;
-        """
-    )
-    rows = [
-        ("canonical-id", "Duplicate content that should collapse", "2026-01-01"),
-        ("dupe-id", "duplicate   content that should collapse", "2026-01-02"),
-    ]
-    conn.executemany(
-        """
-        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
-        VALUES (?, ?, '', '', '', '', '', ?)
-        """,
-        rows,
-    )
-    conn.commit()
-    conn.close()
+    present = [name for name in REMOVED_DEDUP_SYMBOLS if hasattr(db_shrink, name)]
+    assert present == [], f"physical-delete dedupe path reintroduced: {present}"
 
-    result = apply_content_dedup(db_path, rebuild_fts=False)
 
-    checked = sqlite3.connect(db_path)
-    remaining_fts_ids = {
-        row[0] for row in checked.execute("SELECT chunk_id FROM chunks_fts WHERE chunk_id IS NOT NULL")
-    }
-    delete_trigger = checked.execute(
-        "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'chunks_fts_delete'"
-    ).fetchone()
-    checked.execute(
-        """
-        INSERT INTO chunks(id, content, summary, tags, resolved_query, key_facts, resolved_queries, created_at)
-        VALUES ('fresh-id', 'Fresh searchable note', '', '', '', '', '', '2026-01-03')
-        """
-    )
-    fresh_fts = checked.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunk_id = 'fresh-id'").fetchone()[0]
-    checked.close()
+def test_db_shrink_never_deletes_chunk_rows():
+    source = (REPO_ROOT / "src/brainlayer/db_shrink.py").read_text(encoding="utf-8")
+    code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+    body = code.split('"""', 2)[-1] if code.count('"""') >= 2 else code
+    offenders = re.findall(r"DELETE\s+FROM\s+chunks\b(?!_fts)", body, re.I)
+    assert offenders == [], f"db_shrink must not delete chunk rows: {offenders}"
 
-    assert result.deleted_rows == 1
-    assert remaining_fts_ids == {"canonical-id"}
-    assert delete_trigger is not None
-    assert fresh_fts == 1
+
+def test_no_physical_delete_mechanism_anywhere_in_production_code():
+    """No writer may stamp a physical-delete dedupe mechanism.
+
+    Scans real string VALUES via the AST, not raw text: a docstring explaining
+    why the path was removed is documentation, while a literal carrying the
+    mechanism name is a writer about to stamp it.
+    """
+    import ast
+
+    offenders = []
+    for root in (REPO_ROOT / "src/brainlayer", REPO_ROOT / "scripts", REPO_ROOT / "hooks"):
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            docstrings = set()
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                    doc = node.body[0] if node.body else None
+                    if isinstance(doc, ast.Expr) and isinstance(doc.value, ast.Constant):
+                        docstrings.add(id(doc.value))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and id(node) not in docstrings
+                    and "physical_delete" in node.value
+                ):
+                    offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+    assert offenders == [], f"physical-delete dedupe mechanism present: {offenders}"

--- a/tests/test_dedupe_merge.py
+++ b/tests/test_dedupe_merge.py
@@ -710,3 +710,138 @@ def test_rollback_retains_the_preimage_audit_trail(tmp_path):
     conn.close()
     assert PREIMAGE_TABLE in tables, "the preimage is the audit trail; removal is a separate human step"
     assert result["preimage_tables"] == "retained"
+
+
+# --- MUST_FIX 1: the rollback must restore the EARLIEST preimage ------------------
+# One alias row can be touched by two groups (step-1 repoint in group A, then
+# step-3 overwrite in group B). The second preimage records the value the
+# migration itself just wrote, so replaying in table order with INSERT OR REPLACE
+# restores the migration's value, not the original. Counts cannot see this: a
+# swapped pointer preserves the row count exactly (issue #722's shape).
+
+
+def _alias_full(db_path: Path) -> dict[str, tuple]:
+    conn = sqlite3.connect(db_path)
+    rows = {
+        r[0]: (r[1], r[2])
+        for r in conn.execute("SELECT old_chunk_id, canonical_chunk_id, deprecated_at FROM chunk_id_alias")
+    }
+    conn.close()
+    return rows
+
+
+def _two_group_db(tmp_path: Path) -> Path:
+    """Two duplicate groups, plus one alias row that BOTH groups will touch."""
+    rows = []
+    for group, text in (("g1", "first shared memory"), ("g2", "second shared memory")):
+        rows += [
+            {
+                "id": f"{group}-old",
+                "content": text,
+                "conversation_id": group,
+                "created_at": "2026-01-01T00:00:00Z",
+                "seen_count": 1,
+            },
+            {
+                "id": f"{group}-new",
+                "content": text,
+                "conversation_id": group,
+                "created_at": "2026-01-02T00:00:00Z",
+                "summary": "s",
+                "seen_count": 1,
+            },
+        ]
+    db_path = _db(tmp_path, rows)
+    conn = sqlite3.connect(db_path)
+    # `shared` points at g1's loser (group 1 will repoint it), and is itself
+    # g2's loser id... so group 2 overwrites the same row at step 3.
+    conn.execute("INSERT INTO chunk_id_alias VALUES ('g2-old', 'g1-old', '2026-06-30T23:08:29Z')")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_rollback_restores_the_earliest_alias_preimage_not_the_latest(tmp_path):
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _two_group_db(tmp_path)
+    before = _alias_full(db_path)
+    assert before["g2-old"] == ("g1-old", "2026-06-30T23:08:29Z")
+
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    rollback_migration(db_path)
+
+    after = _alias_full(db_path)
+    assert after["g2-old"] == before["g2-old"], (
+        "the doubly-touched alias must return to its ORIGINAL target, "
+        f"not the value the migration wrote: {after['g2-old']} != {before['g2-old']}"
+    )
+    assert after == before
+
+
+def test_rollback_value_audit_reports_what_it_checked(tmp_path):
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _two_group_db(tmp_path)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    result = rollback_migration(db_path)
+    assert result["value_audit"]["chunks_checked"] > 0
+    assert result["value_audit"]["aliases_checked"] > 0
+
+
+def test_rollback_value_audit_raises_on_a_swapped_pointer(tmp_path):
+    """A swapped pointer is count-identical; only a value check can see it."""
+    import brainlayer.dedupe_merge as dm
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _two_group_db(tmp_path)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    rollback_migration(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    before_count = conn.execute("SELECT COUNT(*) FROM chunk_id_alias").fetchone()[0]
+    # swap one pointer to a different EXISTING-shaped value: count unchanged
+    conn.execute("UPDATE chunk_id_alias SET canonical_chunk_id = 'swapped' WHERE old_chunk_id = 'g2-old'")
+    conn.commit()
+    after_count = conn.execute("SELECT COUNT(*) FROM chunk_id_alias").fetchone()[0]
+    assert after_count == before_count, "the count check is blind to this by construction"
+
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    with pytest.raises(RuntimeError, match="did not restore the pre-migration values"):
+        dm._assert_rollback_restored_values(conn, tables)
+    conn.close()
+
+
+def test_rollback_value_audit_catches_an_unrestored_chunk_value(tmp_path):
+    import brainlayer.dedupe_merge as dm
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    rollback_migration(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("UPDATE chunks SET archived_at = '2026-08-18T00:00:00Z' WHERE id = 'old-one'")
+    conn.commit()
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    with pytest.raises(RuntimeError, match="did not restore the pre-migration values"):
+        dm._assert_rollback_restored_values(conn, tables)
+    conn.close()
+
+
+def test_rollback_value_audit_passes_on_a_clean_rollback(tmp_path):
+    import brainlayer.dedupe_merge as dm
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _two_group_db(tmp_path)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    result = rollback_migration(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    audited = dm._assert_rollback_restored_values(conn, tables)
+    conn.close()
+    assert audited == result["value_audit"]

--- a/tests/test_dedupe_merge.py
+++ b/tests/test_dedupe_merge.py
@@ -1,0 +1,712 @@
+"""Repair (e): archive-not-delete merge of exact content duplicates.
+
+The policy these tests pin (POLICY_REPAIR_E, lead-ACKed 2026-08-18):
+  * key    = sha256(content.strip()), recomputed; the stored content_hash column
+             is never trusted (four schemes live in the canonical DB).
+  * scope  = same conversation only. Identical text in two different
+             conversations is two memories, not one.
+  * survivor = richest enrichment -> oldest created_at -> smallest id.
+  * losers = aggregated_into + archived_at + status='superseded'. NEVER deleted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from brainlayer.dedupe_merge import (
+    MIGRATION_NAME,
+    PREIMAGE_TABLE,
+    content_key,
+    merge_duplicates,
+)
+
+GIT_SHA = "0" * 40
+
+CHUNK_COLUMNS = """
+    id TEXT PRIMARY KEY,
+    content TEXT,
+    content_hash TEXT,
+    source TEXT,
+    project TEXT,
+    conversation_id TEXT,
+    source_file TEXT,
+    content_type TEXT,
+    char_count INTEGER,
+    created_at TEXT,
+    summary TEXT,
+    tags TEXT,
+    importance REAL,
+    intent TEXT,
+    enriched_at TEXT,
+    key_facts TEXT,
+    primary_symbols TEXT,
+    raw_entities_json TEXT,
+    seen_count INTEGER DEFAULT 1,
+    archived_at TEXT,
+    superseded_by TEXT,
+    aggregated_into TEXT,
+    status TEXT DEFAULT 'active'
+"""
+
+
+def _db(tmp_path: Path, rows: list[dict]) -> Path:
+    db_path = tmp_path / "merge.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(f"CREATE TABLE chunks ({CHUNK_COLUMNS})")
+    conn.execute(
+        "CREATE TABLE chunk_id_alias (old_chunk_id TEXT PRIMARY KEY, "
+        "canonical_chunk_id TEXT NOT NULL, deprecated_at TEXT NOT NULL)"
+    )
+    conn.execute("CREATE TABLE chunk_fts_rowids (chunk_id TEXT PRIMARY KEY, fts_rowid INTEGER)")
+    for row in rows:
+        cols = ", ".join(row)
+        marks = ", ".join("?" for _ in row)
+        conn.execute(f"INSERT INTO chunks ({cols}) VALUES ({marks})", list(row.values()))
+        conn.execute(
+            "INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid) VALUES (?, ?)",
+            (row["id"], len(row["id"])),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _rows(db_path: Path) -> dict[str, sqlite3.Row]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    out = {r["id"]: r for r in conn.execute("SELECT * FROM chunks")}
+    conn.close()
+    return out
+
+
+def _pair(**overrides) -> list[dict]:
+    """Two rows, same conversation, same text, second better enriched."""
+    base = [
+        {
+            "id": "old-one",
+            "content": "the same memory text",
+            "conversation_id": "conv-1",
+            "source_file": "a.jsonl",
+            "source": "claude_code",
+            "created_at": "2026-01-01T00:00:00Z",
+            "char_count": 20,
+            "seen_count": 1,
+        },
+        {
+            "id": "new-two",
+            "content": "the same memory text",
+            "conversation_id": "conv-1",
+            "source_file": "a.jsonl",
+            "source": "realtime_watcher",
+            "created_at": "2026-01-02T00:00:00Z",
+            "summary": "a summary",
+            "tags": '["x"]',
+            "importance": 8,
+            "seen_count": 3,
+        },
+    ]
+    base[1].update(overrides)
+    return base
+
+
+# --- key ---------------------------------------------------------------------
+
+
+def test_content_key_is_sha256_of_stripped_content():
+    assert content_key("  hello \n") == hashlib.sha256(b"hello").hexdigest()
+    assert content_key("hello") == content_key("\nhello\n  ")
+
+
+def test_content_key_rejects_blank_content():
+    assert content_key("") is None
+    assert content_key("   \n ") is None
+    assert content_key(None) is None
+
+
+def test_stored_content_hash_is_never_trusted(tmp_path):
+    """Rows sharing a stored hash but differing in content must NOT merge.
+
+    The canonical DB holds 20 such groups: full sha256 values that went stale
+    when the content was later mutated.
+    """
+    rows = [
+        {
+            "id": "stale-a",
+            "content": "text one",
+            "content_hash": "deadbeef" * 8,
+            "conversation_id": "c",
+            "created_at": "2026-01-01T00:00:00Z",
+        },
+        {
+            "id": "stale-b",
+            "content": "text two -- genuinely different",
+            "content_hash": "deadbeef" * 8,
+            "conversation_id": "c",
+            "created_at": "2026-01-02T00:00:00Z",
+        },
+    ]
+    db_path = _db(tmp_path, rows)
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.groups_merged == 0
+    after = _rows(db_path)
+    assert all(r["aggregated_into"] is None for r in after.values())
+
+
+def test_rows_split_across_hash_schemes_still_merge(tmp_path):
+    """A 16-char legacy hash and a 64-char hash on identical text must merge."""
+    rows = _pair()
+    rows[0]["content_hash"] = "abcdef0123456789"
+    rows[1]["content_hash"] = hashlib.sha256(b"the same memory text").hexdigest()
+    db_path = _db(tmp_path, rows)
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.groups_merged == 1
+
+
+# --- scope: conversation identity ---------------------------------------------
+
+
+def test_cross_conversation_duplicates_are_held(tmp_path):
+    """The 252-conversation case: identical text in different sessions stays put."""
+    rows = _pair()
+    rows[1]["conversation_id"] = "conv-2"
+    db_path = _db(tmp_path, rows)
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.groups_merged == 0
+    assert result.groups_held >= 1
+    after = _rows(db_path)
+    assert after["old-one"]["aggregated_into"] is None
+    assert after["new-two"]["aggregated_into"] is None
+
+
+def test_blank_conversation_id_is_not_a_match(tmp_path):
+    """Two NULL conversation ids are unknown, not equal."""
+    rows = _pair()
+    rows[0]["conversation_id"] = None
+    rows[1]["conversation_id"] = None
+    db_path = _db(tmp_path, rows)
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.groups_merged == 0
+
+
+# --- survivor selection --------------------------------------------------------
+
+
+def test_survivor_is_richest_enrichment_not_oldest(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.groups_merged == 1
+    after = _rows(db_path)
+    assert after["new-two"]["aggregated_into"] is None, "richest row must survive"
+    assert after["old-one"]["aggregated_into"] == "new-two"
+
+
+def test_oldest_breaks_an_enrichment_tie(tmp_path):
+    rows = _pair(summary=None, tags=None, importance=None)
+    db_path = _db(tmp_path, rows)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    after = _rows(db_path)
+    assert after["old-one"]["aggregated_into"] is None, "tie -> oldest survives"
+    assert after["new-two"]["aggregated_into"] == "old-one"
+
+
+def test_already_managed_rows_are_not_chosen_as_survivor(tmp_path):
+    """The richest row is archived already, so a live row must survive instead."""
+    rows = _pair()
+    rows[1]["archived_at"] = "2026-01-05T00:00:00Z"  # richest, but managed
+    rows.append(
+        {
+            "id": "live-three",
+            "content": "the same memory text",
+            "conversation_id": "conv-1",
+            "source_file": "a.jsonl",
+            "created_at": "2026-01-03T00:00:00Z",
+            "seen_count": 1,
+        }
+    )
+    db_path = _db(tmp_path, rows)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    after = _rows(db_path)
+    assert after["old-one"]["aggregated_into"] is None, "oldest live row survives"
+    assert after["live-three"]["aggregated_into"] == "old-one"
+    assert after["new-two"]["aggregated_into"] is None, "an already-managed row is left alone"
+    assert after["new-two"]["archived_at"] == "2026-01-05T00:00:00Z", "its lifecycle stamp is untouched"
+
+
+def test_group_with_every_member_already_managed_is_skipped(tmp_path):
+    rows = _pair()
+    rows[0]["archived_at"] = "2026-01-05T00:00:00Z"
+    rows[1]["aggregated_into"] = "somewhere-else"
+    db_path = _db(tmp_path, rows)
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.groups_merged == 0
+    after = _rows(db_path)
+    assert after["new-two"]["aggregated_into"] == "somewhere-else", "existing lineage untouched"
+
+
+# --- loser treatment: archive, never delete -------------------------------------
+
+
+def test_losers_are_archived_with_lineage_and_never_deleted(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    before = set(_rows(db_path))
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    after = _rows(db_path)
+    assert set(after) == before, "no row may disappear"
+    loser = after["old-one"]
+    assert loser["aggregated_into"] == "new-two"
+    assert loser["archived_at"] is not None
+    assert loser["status"] == "superseded"
+    assert loser["content"] == "the same memory text", "content is retained for walkback"
+
+
+def test_loser_status_is_superseded_not_archived(tmp_path):
+    """vector_store startup rewrites status='archived'; writing it would revert."""
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert _rows(db_path)["old-one"]["status"] == "superseded"
+
+
+def test_fts_and_side_table_rows_are_untouched(tmp_path):
+    """Archiving hides losers from default search without index surgery."""
+    db_path = _db(tmp_path, _pair())
+    conn = sqlite3.connect(db_path)
+    before = conn.execute("SELECT COUNT(*) FROM chunk_fts_rowids").fetchone()[0]
+    conn.close()
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    conn = sqlite3.connect(db_path)
+    after = conn.execute("SELECT COUNT(*) FROM chunk_fts_rowids").fetchone()[0]
+    conn.close()
+    assert after == before
+    assert result.aux_counts_before == result.aux_counts_after
+
+
+# --- union fill ------------------------------------------------------------------
+
+
+def test_union_fill_takes_loser_enrichment_into_blank_survivor_fields(tmp_path):
+    rows = _pair()
+    rows[0]["intent"] = "decision"
+    rows[0]["key_facts"] = '{"k": 1}'
+    db_path = _db(tmp_path, rows)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    survivor = _rows(db_path)["new-two"]
+    assert survivor["intent"] == "decision"
+    assert survivor["key_facts"] == '{"k": 1}'
+    assert survivor["summary"] == "a summary", "survivor's own values stay"
+
+
+def test_union_fill_never_overwrites_a_non_blank_survivor_field(tmp_path):
+    rows = _pair()
+    rows[0]["summary"] = "the loser summary"
+    db_path = _db(tmp_path, rows)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert _rows(db_path)["new-two"]["summary"] == "a summary"
+
+
+def test_seen_count_totals_are_preserved_on_the_survivor(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert _rows(db_path)["new-two"]["seen_count"] == 4  # 3 + 1
+
+
+def test_union_fill_can_be_disabled(tmp_path):
+    rows = _pair()
+    rows[0]["intent"] = "decision"
+    db_path = _db(tmp_path, rows)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True, union_fill=False)
+    survivor = _rows(db_path)["new-two"]
+    assert survivor["intent"] is None
+    assert survivor["seen_count"] == 3, "no survivor mutation at all"
+
+
+# --- aliases ----------------------------------------------------------------------
+
+
+def test_alias_row_forwards_loser_id_to_survivor(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    conn = sqlite3.connect(db_path)
+    alias = dict(conn.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias").fetchall())
+    conn.close()
+    assert alias == {"old-one": "new-two"}
+
+
+def test_existing_alias_pointing_at_a_loser_is_repointed(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    conn = sqlite3.connect(db_path)
+    conn.execute("INSERT INTO chunk_id_alias VALUES ('ancient', 'old-one', '2026-01-01T00:00:00Z')")
+    conn.commit()
+    conn.close()
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    conn = sqlite3.connect(db_path)
+    alias = dict(conn.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias").fetchall())
+    conn.close()
+    assert alias["ancient"] == "new-two", "alias chains must resolve to the survivor"
+    assert alias["old-one"] == "new-two"
+
+
+def test_no_alias_cycle_is_created(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    conn = sqlite3.connect(db_path)
+    pairs = conn.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias").fetchall()
+    conn.close()
+    for old, canonical in pairs:
+        assert old != canonical
+        seen = {old}
+        cursor = canonical
+        mapping = dict(pairs)
+        while cursor in mapping:
+            assert cursor not in seen, "alias cycle"
+            seen.add(cursor)
+            cursor = mapping[cursor]
+
+
+# --- dry run / preimage / receipt --------------------------------------------------
+
+
+def test_dry_run_is_the_default_and_writes_nothing(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    result = merge_duplicates(db_path, git_sha=GIT_SHA)
+    assert result.would_merge_groups == 1
+    assert result.groups_merged == 0
+    after = _rows(db_path)
+    assert after["old-one"]["aggregated_into"] is None
+    conn = sqlite3.connect(db_path)
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert PREIMAGE_TABLE not in tables
+
+
+def test_preimage_captures_every_column_written(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    pre = {r["id"]: r for r in conn.execute(f"SELECT * FROM {PREIMAGE_TABLE}")}
+    conn.close()
+    assert set(pre) == {"old-one", "new-two"}
+    assert pre["old-one"]["aggregated_into"] is None, "preimage holds the BEFORE value"
+    assert pre["old-one"]["status"] == "active"
+    assert pre["new-two"]["seen_count"] == 3
+
+
+def test_rollback_from_preimage_restores_original_rows(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    before = {k: dict(v) for k, v in _rows(db_path).items()}
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cols = [r[1] for r in conn.execute(f"PRAGMA table_info({PREIMAGE_TABLE})") if r[1] != "id"]
+    for row in conn.execute(f"SELECT * FROM {PREIMAGE_TABLE}").fetchall():
+        conn.execute(
+            f"UPDATE chunks SET {', '.join(f'{c} = ?' for c in cols)} WHERE id = ?",
+            [row[c] for c in cols] + [row["id"]],
+        )
+    conn.commit()
+    conn.close()
+    assert {k: dict(v) for k, v in _rows(db_path).items()} == before
+
+
+def test_receipt_records_migration_and_git_sha(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    conn = sqlite3.connect(db_path)
+    row = conn.execute("SELECT name, details FROM schema_migrations WHERE name = ?", (MIGRATION_NAME,)).fetchone()
+    conn.close()
+    assert row is not None
+    assert GIT_SHA in row[1]
+
+
+def test_git_sha_must_be_a_full_commit_sha(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    with pytest.raises(ValueError):
+        merge_duplicates(db_path, git_sha="abc123", apply=True)
+
+
+def test_resume_is_idempotent(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    first = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    second = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert first.groups_merged == 1
+    assert second.groups_merged == 0, "a second pass must find nothing left to do"
+    assert _rows(db_path)["new-two"]["seen_count"] == 4, "seen_count must not double-count"
+
+
+def test_spot_checks_reread_stored_rows(tmp_path):
+    db_path = _db(tmp_path, _pair())
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True, spot_check=5)
+    assert result.spot_checks
+    assert all(check["ok"] for check in result.spot_checks)
+    assert any(check["id"] == "old-one" for check in result.spot_checks)
+
+
+# --- live guard --------------------------------------------------------------------
+
+
+def test_refuses_the_live_canonical_db(tmp_path, monkeypatch):
+    from brainlayer import chunk_origin_wipe
+
+    live = tmp_path / "live" / "brainlayer.db"
+    live.parent.mkdir(parents=True)
+    _db(tmp_path, _pair()).replace(live)
+    # assert_not_live_db lives in chunk_origin_wipe and reads ITS globals.
+    monkeypatch.setattr(chunk_origin_wipe, "live_canonical_db_path", lambda: live)
+    monkeypatch.setattr(chunk_origin_wipe, "account_home", lambda: live.parent.parent)
+    with pytest.raises(RuntimeError):
+        merge_duplicates(live, git_sha=GIT_SHA, apply=True)
+    # and it proceeds once a lead-scheduled window sets allow_live
+    merge_duplicates(live, git_sha=GIT_SHA, apply=True, allow_live=True)
+
+
+# --- alias convergence: the cycles the rehearsal exposed ------------------------
+# The first rehearsal run turned 72 pre-existing alias cycles into 588, because
+# prior dedupe runs had already aliased members of one duplicate group to each
+# other and a new `loser -> survivor` edge closed the loop. Every alias edge in a
+# group must terminate at the survivor, and the survivor may not be an alias source.
+
+
+def _today_stamp() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _alias_rows(db_path: Path) -> dict[str, str]:
+    conn = sqlite3.connect(db_path)
+    rows = dict(conn.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias").fetchall())
+    conn.close()
+    return rows
+
+
+def test_survivor_is_never_left_as_an_alias_source(tmp_path):
+    """An alias survivor -> loser would send lookups to an archived row."""
+    db_path = _db(tmp_path, _pair())
+    conn = sqlite3.connect(db_path)
+    conn.execute("INSERT INTO chunk_id_alias VALUES ('new-two', 'old-one', '2026-01-01T00:00:00Z')")
+    conn.commit()
+    conn.close()
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    alias = _alias_rows(db_path)
+    assert "new-two" not in alias, "the live survivor must not be a deprecated id"
+    assert alias["old-one"] == "new-two"
+    assert result.aliases_dropped_survivor_source == 1
+
+
+def test_pre_existing_intra_group_alias_chain_is_converged(tmp_path):
+    """Prior runs chained members of the same group; all edges must land on the survivor."""
+    rows = _pair()
+    for index in range(3, 6):
+        rows.append(
+            {
+                "id": f"member-{index}",
+                "content": "the same memory text",
+                "conversation_id": "conv-1",
+                "source_file": "a.jsonl",
+                "created_at": f"2026-01-0{index}T00:00:00Z",
+                "seen_count": 1,
+            }
+        )
+    db_path = _db(tmp_path, rows)
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO chunk_id_alias VALUES (?, ?, '2026-01-01T00:00:00Z')",
+        [("member-3", "member-4"), ("member-4", "member-5"), ("member-5", "old-one")],
+    )
+    conn.commit()
+    conn.close()
+
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    alias = _alias_rows(db_path)
+    assert set(alias.values()) == {"new-two"}, f"all edges must converge: {alias}"
+    for old, canonical in alias.items():
+        assert canonical not in alias, "a converged graph has no second hop"
+
+
+def test_alias_cycle_introduced_by_this_migration_fails_loudly(tmp_path, monkeypatch):
+    from brainlayer import dedupe_merge
+
+    db_path = _db(tmp_path, _pair())
+
+    def _sabotage(conn, *, survivor_id, losers, stamp, result):
+        conn.executemany(
+            "INSERT OR REPLACE INTO chunk_id_alias VALUES (?, ?, ?)",
+            [(losers[0], survivor_id, stamp), (survivor_id, losers[0], stamp)],
+        )
+
+    monkeypatch.setattr(dedupe_merge, "_converge_aliases", _sabotage)
+    with pytest.raises(RuntimeError, match="alias-cycle"):
+        merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+
+
+def test_pre_existing_cycle_is_reported_not_fatal(tmp_path):
+    """A cycle among ids this run never touches must not block the migration."""
+    db_path = _db(tmp_path, _pair())
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO chunk_id_alias VALUES (?, ?, '2026-01-01T00:00:00Z')",
+        [("ghost-a", "ghost-b"), ("ghost-b", "ghost-a")],
+    )
+    conn.commit()
+    conn.close()
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert result.groups_merged == 1
+    assert result.preexisting_alias_cycles == 2
+
+
+def test_alias_edits_are_reversible_from_their_preimage(tmp_path):
+    from brainlayer.dedupe_merge import ALIAS_PREIMAGE_TABLE
+
+    db_path = _db(tmp_path, _pair())
+    conn = sqlite3.connect(db_path)
+    conn.execute("INSERT INTO chunk_id_alias VALUES ('new-two', 'elsewhere', '2026-01-01T00:00:00Z')")
+    conn.commit()
+    conn.close()
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+
+    conn = sqlite3.connect(db_path)
+    recorded = conn.execute(f"SELECT old_chunk_id, canonical_chunk_id, action FROM {ALIAS_PREIMAGE_TABLE}").fetchall()
+    conn.close()
+    assert ("new-two", "elsewhere", "drop_survivor_source") in recorded
+
+
+def test_existing_lineage_pointing_at_a_loser_is_repointed_to_the_survivor(tmp_path):
+    """A chain must always end one hop away, on a live row.
+
+    Rehearsal found 5 rows that an earlier aggregation had pointed at a chunk
+    this migration then archived, leaving them two hops from anything live.
+    """
+    rows = _pair()
+    rows.append(
+        {
+            "id": "older-aggregated",
+            "content": "a different memory entirely",
+            "conversation_id": "conv-9",
+            "created_at": "2025-12-01T00:00:00Z",
+            "aggregated_into": "old-one",
+            "archived_at": "2025-12-02T00:00:00Z",
+            "status": "superseded",
+        }
+    )
+    db_path = _db(tmp_path, rows)
+    result = merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    after = _rows(db_path)
+    assert after["old-one"]["aggregated_into"] == "new-two"
+    assert after["older-aggregated"]["aggregated_into"] == "new-two", "must not point at an archived row"
+    assert result.lineage_repointed == 1
+    survivor = after[after["older-aggregated"]["aggregated_into"]]
+    assert survivor["aggregated_into"] is None and survivor["archived_at"] is None
+
+
+def test_no_lineage_pointer_ends_on_an_archived_row(tmp_path):
+    rows = _pair()
+    rows.append(
+        {
+            "id": "older-aggregated",
+            "content": "another memory",
+            "conversation_id": "conv-9",
+            "created_at": "2025-12-01T00:00:00Z",
+            "aggregated_into": "old-one",
+            "archived_at": "2025-12-02T00:00:00Z",
+        }
+    )
+    db_path = _db(tmp_path, rows)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    after = _rows(db_path)
+    for row in after.values():
+        target = row["aggregated_into"]
+        if target:
+            assert after[target]["archived_at"] is None, f"{row['id']} points at an archived row"
+            assert after[target]["aggregated_into"] is None
+
+
+# --- rollback as a command -------------------------------------------------------
+
+
+def _snapshot(db_path: Path) -> tuple[dict, dict]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    chunks = {r["id"]: dict(r) for r in conn.execute("SELECT * FROM chunks")}
+    alias = dict(conn.execute("SELECT old_chunk_id, canonical_chunk_id FROM chunk_id_alias").fetchall())
+    conn.close()
+    return chunks, alias
+
+
+def test_rollback_restores_chunks_and_aliases_exactly(tmp_path):
+    from brainlayer.dedupe_merge import rollback_migration
+
+    rows = _pair()
+    rows.append(
+        {
+            "id": "older-aggregated",
+            "content": "unrelated memory",
+            "conversation_id": "conv-9",
+            "created_at": "2025-12-01T00:00:00Z",
+            "aggregated_into": "old-one",
+            "archived_at": "2025-12-02T00:00:00Z",
+        }
+    )
+    db_path = _db(tmp_path, rows)
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO chunk_id_alias VALUES (?, ?, '2026-01-01T00:00:00Z')",
+        [("ancient", "old-one"), ("new-two", "elsewhere"), ("untouched", "somewhere")],
+    )
+    conn.commit()
+    conn.close()
+
+    before = _snapshot(db_path)
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    assert _snapshot(db_path) != before, "the migration must have changed something"
+
+    result = rollback_migration(db_path)
+    assert result["chunks_restored"] > 0
+    assert _snapshot(db_path) == before, "rollback must restore byte-for-byte"
+
+
+def test_rollback_does_not_touch_unrelated_alias_rows(tmp_path):
+    """The hand-written rollback deleted by date and lost 4,817 pre-existing rows."""
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _db(tmp_path, _pair())
+    conn = sqlite3.connect(db_path)
+    # a pre-existing alias carrying the SAME day stamp the migration will write
+    conn.execute("INSERT INTO chunk_id_alias VALUES ('bystander', 'somewhere-else', ?)", (_today_stamp(),))
+    conn.commit()
+    conn.close()
+
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    rollback_migration(db_path)
+    alias = _alias_rows(db_path)
+    assert alias.get("bystander") == "somewhere-else", "a same-day bystander must survive rollback"
+    assert "old-one" not in alias, "aliases this migration created must be gone"
+
+
+def test_rollback_removes_the_receipt(tmp_path):
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    rollback_migration(db_path)
+    conn = sqlite3.connect(db_path)
+    row = conn.execute("SELECT 1 FROM schema_migrations WHERE name = ?", (MIGRATION_NAME,)).fetchone()
+    conn.close()
+    assert row is None
+
+
+def test_rollback_retains_the_preimage_audit_trail(tmp_path):
+    from brainlayer.dedupe_merge import rollback_migration
+
+    db_path = _db(tmp_path, _pair())
+    merge_duplicates(db_path, git_sha=GIT_SHA, apply=True)
+    result = rollback_migration(db_path)
+    conn = sqlite3.connect(db_path)
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert PREIMAGE_TABLE in tables, "the preimage is the audit trail; removal is a separate human step"
+    assert result["preimage_tables"] == "retained"


### PR DESCRIPTION
## Repair (e) — archive-not-delete merge for exact content duplicates

Implements **POLICY_REPAIR_E** (posted to the wave25 collab, lead-ACKed 2026-08-18), plus the two
additions the lead attached to the ACK. Census + rehearsal report:
`docs.local/repair-e-census-2026-08-18.md` (gitignored; summary in the collab).

**Live window remains lead-gated, and Etan sees the policy before it runs.** No live-DB writes were
made in producing this PR — census and rehearsal both ran on online-backup copies whose inode
differs from the live DB.

### The census changed the size of the problem

The schema-truth audit's 27,757 `content_hash` groups is a floor, not the population:

| Measure | Groups | Member rows | Losers |
|---|---:|---:|---:|
| `content_hash` groups (audit method, re-measured) | 27,758 | 78,529 | 50,771 |
| **True content duplicates (recomputed key)** | **51,182** | **149,682** | **98,500** |

`content_hash` cannot be the key: the canonical DB carries **four schemes at once** — 64-char sha256
(551,765 rows), 64-char *stale relative to its own content* (2,256), 32-char (15,205), 16-char
truncated from `drain.py` (138,586) — plus 52,172 rows with no hash. Rows in different schemes never
group even when byte-identical, and 20 groups hold members whose content genuinely differs. The
migration therefore recomputes `sha256(content.strip())` and re-verifies byte equality
in-transaction. `dedupe.normalized_exact_hash` is rejected as a key: it lowercases and strips
stopwords, which is fine for near-dupe candidates and wrong for a lifecycle merge on personal data.

### Equal text is not the same memory

Merging is scoped to **one conversation**. The census found a 245-char sentence stored across **252
conversations in 59 projects** — collapsing it would erase 252 session contexts. 42,082 groups are
eligible; 9,100 cross-conversation groups are held untouched.

### What the migration does

`src/brainlayer/dedupe_merge.py` + `scripts/repair_dedupe_merge.py`, on the proven fenced pattern
(preimage, `--allow-live` st_dev/st_ino guard, dry-run default, batches + checkpoints, spot-checks
that re-read stored rows, resumable).

- **Survivor**: richest enrichment → oldest `created_at` → smallest id. Measured over the eligible
  groups: oldest-wins discards enrichment in **23,359** of 42,082; newest-wins 8,668;
  richest-wins **1,243**. Never picks a row that is already lifecycle-managed.
- **Losers**: `aggregated_into` + `archived_at` + `status='superseded'`. Content, ids, tags, FTS rows
  and vectors all retained. **No `DELETE` in any table.** `'superseded'` rather than `'archived'`
  because `vector_store.py:1947` rewrites `status='archived'` on startup — writing it would be
  silently reverted.
- **Union fill**: blank survivor enrichment filled from losers, never overwriting a non-blank field;
  `seen_count` totals carried. `--no-union-fill` gives lineage-only.
- **No index surgery**: both serving paths already exclude lifecycle rows, so aux counts are asserted
  **unchanged**. A delete-based dedupe would have had to rewrite ~390k reference rows.
- **`--rollback`**, driven by two preimages. Preimage tables are retained afterwards as the audit
  trail; removing them is a separate human-authorized step.

### Lead additions, same PR

1. **One `content_hash` contract** (`chunk_write.py`): always `sha256` of the stripped content,
   recomputed at write time; a caller-supplied hash never wins. The truncated digests in
   `drain.py` / `hooks/indexer.py` / `hooks/brainbar-stop-index.py` are renamed `id_digest` —
   they name the chunk, they were never content hashes. Without this the migration would need
   re-running. Guard test blocks reintroduction (verified by sabotage).
2. **Physical-delete dedupe path removed** (`db_shrink.py`): `apply_content_dedup` →
   `_merge_duplicate_references` → `DELETE FROM chunks`, stamped
   `mechanism='normalized_content_physical_delete'` and keyed on the lossy normalizer. It
   contradicted "losers archive, never delete" and had **never run** on this DB (0 such audit rows).
   Three guards assert it stays gone (verified by sabotage).

### Rehearsal — fresh online-backup copy, apply then rollback

11.3s apply, 318MB peak. 40,507 groups merged, 61,445 losers archived, **0 rows deleted**, aux counts
unchanged, **50/50 spot checks pass**.

| metric | pre | post-apply | post-rollback |
|---|---:|---:|---:|
| chunks | 760,149 | 760,149 | 760,149 |
| aggregated_into set | 792 | 62,237 | 792 |
| archived_at set | 5,063 | 66,508 | 5,063 |
| chunk_id_alias rows | 69,269 | 130,576 | 69,269 |
| **default-searchable rows** | **755,048** | **693,603** | 755,048 |
| seen_count total | 1,110,867 | 1,194,663 | 1,110,867 |

Independent verification re-reading stored rows: 0 lineage pointers to a missing or archived row,
0 same-conversation duplicates left among searchable rows, 0 alias cycles among touched ids,
0 content mismatches on the 61,445 pairs this run wrote. Re-applying on an already-merged copy is a
no-op, so `seen_count` never double-counts.

### Three defects the rehearsal caught (fixed, each now covered by tests)

1. **Alias cycles** — writing `loser -> survivor` edges one at a time turned 72 pre-existing cycles
   into 588, because prior dedupe runs had already aliased members of the same group to each other.
   Fixed by convergence: every edge terminates at the survivor and the survivor is never an alias
   source. The cycle assertion is scoped to ids this run touched; the 41 remaining **pre-existing**
   cycles are reported in the receipt rather than failing on someone else's data.
2. **Two-hop lineage** — 5 rows an earlier aggregation pointed at a chunk this migration archived
   were left two hops from anything live; now repointed in the same transaction.
3. **61k full table scans** — the lineage lookup ran per loser against the unindexed
   `aggregated_into`, taking the apply from 10s to >10min. Now prefetched once.

### Tests

`tests/test_dedupe_merge.py` — 39 tests covering the key, the conversation scope, survivor
selection, archive-never-delete, union fill, alias convergence, cycle detection, dry-run, preimage,
rollback, resume, spot-checks and the live guard. Plus the contract and removal guards in
`tests/test_chunk_write_contract.py` and `tests/test_db_shrink.py`.

Suite: 4,188 passed. The 7 failures + 31 errors in the full run are **pre-existing** — they
reproduce identically on clean `main` (production-DB eval/search-validation tests).

### For lead triage, outside this lane

- **41 pre-existing alias cycles** in `chunk_id_alias` from earlier dedupe runs.
- 9,100 cross-conversation duplicate groups (35,279 rows) are deliberately left; they need a
  different rule, not this one.
- `scripts/repair_timestamp_iso.py` and the other repair wrappers carry a `sys.path` guard that an
  editable-install `.pth` defeats, so they import a stale installed copy outside the venv. Fixed
  here only for `repair_dedupe_merge.py`.

DO NOT MERGE — pair review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Review round 2 — all three findings fixed (CONDITIONAL GO → addressed)

Reviewer verdict on `73df3d29`: CONDITIONAL GO, 1 MUST_FIX + 2 SHOULD_FIX. All three fixed below.
The reviewer's MUST_FIX was real and I could reproduce it from their description before touching
the data.

### MUST_FIX 1 — rollback restored the LATEST alias preimage, not the earliest. FIXED.

`dedupe_merge_alias_preimage` has no key, and the replay used `INSERT OR REPLACE` in table order, so
**last write wins**. When one alias row is touched by two groups (step-1 `repoint` in group A, then
step-3 `overwrite` in group B), the second preimage records the value *this migration just wrote* —
and the rollback restored that instead of the original. The chunks preimage was never affected
(`INSERT OR IGNORE` on an `id` PRIMARY KEY is correctly first-write-wins).

- The replay now selects the **earliest preimage per `old_chunk_id`** explicitly
  (`JOIN (SELECT old_chunk_id, MIN(rowid) ... GROUP BY old_chunk_id)`), rather than relying on scan
  order. An `insert` row as the earliest entry means "delete on rollback"; anything else restores
  its recorded value.
- **`_assert_rollback_restored_values`** now runs after every rollback and compares **values**, not
  counts: every chunk column against its preimage, and every alias row against the earliest
  preimage. It raises rather than returning a clean count over wrong data. `--rollback` reports
  `value_audit: {chunks_checked, aliases_checked}`.

The reviewer's diagnosis of *why it was missed* is the part worth keeping: the rehearsal checked
`chunk_id_alias` by row count (69,269 → 130,576 → 69,269), and **a swapped pointer preserves the
count exactly** — the checker could not see the defect it existed to catch. That is issue #722's
shape. `test_rollback_value_audit_raises_on_a_swapped_pointer` asserts the count is identical before
asserting the value audit still fires, so the blind spot is pinned in a test rather than in a note.

Four new tests. **Sabotage-verified**: restoring the old last-write-wins replay fails 4 of them.
On the real rehearsal data, exactly **1 of 62,381** alias ids carries multiple preimages and its
earliest differs from its latest — the reviewer's "1 of 1,010 restore rows is wrong", reproduced
numerically and now fixed.

**Re-rehearsed end to end** on a fresh online-backup copy. Apply is unchanged (40,507 groups merged,
61,445 losers archived, `chunks_deleted: 0`, `alias_rows_deleted: 64`, aux counts unchanged, 50/50
spot checks). Rollback now returns every metric exactly to its pre-migration value, with the value
audit passing over **101,957 chunks and 62,381 alias rows**:

| metric | pre | post-apply | post-rollback |
|---|---:|---:|---:|
| chunks | 760,191 | 760,191 | 760,191 |
| aggregated_into | 792 | 62,237 | 792 |
| archived_at | 5,063 | 66,508 | 5,063 |
| chunk_id_alias | 69,269 | 130,576 | 69,269 |
| searchable (content clause) | 755,090 | 693,645 | 755,090 |
| searchable (lifecycle only) | 755,101 | 693,656 | 755,101 |
| seen_count total | 1,110,909 | 1,194,705 | 1,110,909 |

### SHOULD_FIX 2 — the alias DELETE, disclosed and recorded. FIXED.

**Lead ruling, recorded verbatim** in the module docstring, in the `ALIAS_DELETE_EXCEPTION` constant,
and in every on-DB `schema_migrations` receipt:

> The 64 survivor-source alias DELETEs are APPROVED as a narrow chain-correctness exception to
> "no deletes": alias redirect metadata only, never chunk rows.

- (a) `aliases_written`, `aliases_repointed` and `aliases_dropped_survivor_source` are now in the
  durable receipt, so the on-DB audit trail records the deletion.
- (b) The hardcoded `"deleted_rows": 0` is gone. The payload and receipt now report **`chunks_deleted`**
  and **`alias_rows_deleted`** separately — the flat zero was a lie while 64 redirect rows were being
  deleted.
- (c) `pick_survivor` now prefers a row that is **not** already an alias source. It sits **at the id
  tiebreak**, so the lead-ACKed ordering (richest → oldest → smallest id) is untouched — it only
  decides cases the id tiebreak would have settled arbitrarily. **Measured effect on the real data:
  none.** `aliases_dropped_survivor_source` is still exactly **64** — those survivors win on
  enrichment or recency outright and never reach the id tiebreak. Shrinking the 64 would mean
  ranking non-alias-source *above* `created_at`, which changes the ordering the lead ACKed, so I did
  not do it unilaterally. Say the word and it is a one-line move.

### SHOULD_FIX 3 — the contract now covers UPDATE, not just INSERT. FIXED.

- `enrichment_controller.py` no longer defines its own `_content_hash`; it imports
  `canonical_content_hash`, so all four `UPDATE chunks SET content_hash` sites write the contract.
- `store.py` no longer computes an unstripped sha256.
- **A third copy turned up during the fix**: `drain.py:368` had its own `_content_hash`. Also routed
  through the contract.
- Three new guards: only one implementation may exist anywhere under `src/`, `hooks/`, `scripts/`;
  the UPDATE statement shape writes the canonical value; no unstripped sha256 may reach the column.

### Predicate stated (reviewer's 755,059 vs the rehearsal's 755,048)

Both are right; the rehearsal's predicate added a content clause. It is now a named constant emitted
in the receipt as `default_searchable_predicate`:

```
superseded_by IS NULL AND aggregated_into IS NULL AND archived_at IS NULL
AND content IS NOT NULL AND content <> ''
```

Both baselines give the same delta of 61,445, as the reviewer said.

### Notes acknowledged, not changed

`if any(loser for loser in losers)` is indeed just `if losers` (cosmetic; the clamp corrects it), the
E/F exclusion is enforced in Python after materializing rather than in the SELECT (verified correct
by the reviewer's own probes), and union-fill donor order is deterministic in practice but not by
contract. Left as-is deliberately; happy to take any of them if wanted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large-scale SQLite lifecycle migration on ~760k chunks with alias/lineage edits; live DB is gated but wrong apply or rollback would affect searchability and chunk identity. Writer contract changes affect all new inserts and enrichment updates.
> 
> **Overview**
> **Repair (e)** replaces chunk **physical-delete** dedup with an **archive-based** merge and unifies how `content_hash` is written going forward.
> 
> Adds **`brainlayer.dedupe_merge`** (CLI: `scripts/repair_dedupe_merge.py`) to merge exact duplicates within the same `conversation_id` by recomputing `sha256(content.strip())` (not the stored `content_hash`). Losers get `aggregated_into`, `archived_at`, and `status='superseded'`; chunk rows and FTS/vector aux tables stay put. Includes preimage tables, dry-run default, batched apply, alias convergence, and **`--rollback`** with value-level audit (earliest alias preimage wins).
> 
> **Removes** `apply_content_dedup` and related `DELETE FROM chunks` machinery from **`db_shrink`**; shrink is FTS/vacuum only now.
> 
> **Centralizes** `canonical_content_hash` in **`chunk_write`**: always full SHA-256 of stripped content on insert; caller-supplied hashes are ignored. **`drain`**, **`store`**, and **`enrichment_controller`** import it; realtime hooks rename the 16-char id suffix to **`id_digest`** so it is not confused with DB `content_hash`.
> 
> Contract and removal paths are guarded by new tests in **`test_chunk_write_contract`**, **`test_db_shrink`**, and **`test_dedupe_merge`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9849f0d40ed710b7af4ec8145e931a5c7ef1f57d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace physical-delete deduplication with archive-and-merge for exact content duplicates
> - Adds [dedupe_merge.py](https://github.com/EtanHey/brainlayer/pull/723/files#diff-73afc4a7bc602fadd39a5d77f3557df0687f93874420c9df0936500651073490), a new offline/online SQLite migration that archives duplicate chunk rows (setting `status='superseded'`, `archived_at`, `aggregated_into`) instead of deleting them, repoints inbound lineage to the survivor, and converges the alias table.
> - Removes all physical-delete dedup logic from [db_shrink.py](https://github.com/EtanHey/brainlayer/pull/723/files#diff-d5715496341129821ad2d0f0431216640c88fecc4ca343a1a20787bf76662476), including `apply_content_dedup`, `analyze_content_duplicates`, and related helpers; the CLI no longer accepts `--batch-size`, `--qrels-path`, or `--skip-dedup`.
> - Centralizes content hashing in [chunk_write.py](https://github.com/EtanHey/brainlayer/pull/723/files#diff-9d3fb15513f772ec736191a8af7aba2f8efb1825e6aca4ae0cf098c63a46b82c) via `canonical_content_hash` (SHA-256 of `str(content).strip()`); all other modules (`drain.py`, `enrichment_controller.py`, `store.py`) now import this instead of maintaining local implementations.
> - Renames the truncated digest used for chunk ID suffixes from `content_hash` to `id_digest` across hooks and the realtime indexer so that it is no longer confused with the DB `content_hash` column.
> - Adds [scripts/repair_dedupe_merge.py](https://github.com/EtanHey/brainlayer/pull/723/files#diff-30debf9e3f95c7c30ef39eef3762d675f58dc654a9166a252af8ba9e6c4e4175) as a CLI entrypoint for the new merge utility, with support for `--dry-run`, `--apply`, `--rollback`, and `--spot-check`.
> - Risk: `prepare_canonical_insert` now ignores any caller-supplied `content_hash`; callers that previously set this field will have it silently overwritten.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9849f0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->