### PR TITLE
fix: rebuild the lexical rows history lost, and make the gap detectable (repair f)

### DIFF
--- a/scripts/repair_index_completeness.py
+++ b/scripts/repair_index_completeness.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Rebuild missing/duplicated/misrouted FTS rows and realign pointers (repair f)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+# Prepend unconditionally. A plain "if not in sys.path" guard is not enough: an
+# editable-install .pth can already have src on the path BEHIND site-packages,
+# so the guard skips the insert and a stale installed copy of brainlayer wins.
+while str(SRC_DIR) in sys.path:
+    sys.path.remove(str(SRC_DIR))
+sys.path.insert(0, str(SRC_DIR))
+
+from brainlayer.index_completeness import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -665,17 +665,47 @@ def run_doctor(
                 # BOTH directions, and never a count comparison: a surplus aux
                 # row hides a missing one, which is how 3,536 chunks went
                 # unfindable while fts5_health reported the index in sync.
-                if completeness["chunk_to_aux"]["total"] > 0:
+                #
+                # The fatal gates are LEXICAL only. Ordinary embed lag is always
+                # non-zero on a live DB, so folding it in here would leave doctor
+                # permanently red and make "completeness codes silent" an exit
+                # criterion no repair run could ever satisfy. Missing vectors
+                # already have an owner and a check of their own
+                # (`vector_parity_gap` above, `brainlayer reembed-backfill`).
+                if completeness["lexical_chunk_to_aux"] > 0:
                     fatal(
                         "index_completeness_chunk_to_aux",
-                        "active chunks are missing the lexical or vector rows their class routes to",
+                        "active chunks are missing the lexical rows their class routes to",
                         **completeness["chunk_to_aux"],
                     )
-                if completeness["aux_to_chunk"]["total"] > 0:
+                if completeness["lexical_aux_to_chunk"] > 0:
                     fatal(
                         "index_completeness_aux_to_chunk",
-                        "aux index rows or pointers do not resolve back to a live chunk",
+                        "lexical index rows or pointers do not resolve back to a live chunk",
                         **completeness["aux_to_chunk"],
+                    )
+                # A phantom vector IS worth a fatal: the pointer exists, so
+                # `vector_parity_gap` counts the chunk as embedded while
+                # semantic search can never return it. Nothing else looks.
+                if completeness["phantom_vectors"] > 0:
+                    fatal(
+                        "index_completeness_phantom_vectors",
+                        "chunk_vectors_rowids rows whose vec0 payload is dead (invalid bit, missing blob, or all-zero)",
+                        count=completeness["phantom_vectors"],
+                        checked=completeness["aux_to_chunk"]["vector_payload_checked"],
+                        remediation="re-embed these chunks via brainlayer reembed-backfill",
+                    )
+                orphan_vectors = completeness["aux_to_chunk"]["orphan_vector_rowids"]
+                orphan_binary = completeness["aux_to_chunk"]["orphan_binary_rowids"]
+                if orphan_vectors or orphan_binary:
+                    # Warning, not fatal: no code path in this repo removes a
+                    # vec0 rowid row, so fataling would paint doctor permanently
+                    # red with no owner able to clear it.
+                    warning(
+                        "index_completeness_orphan_vector_rowids",
+                        "vec0 rowid rows point at chunks that no longer exist; no automated repair owns these",
+                        orphan_vector_rowids=orphan_vectors,
+                        orphan_binary_rowids=orphan_binary,
                     )
             except Exception as exc:
                 fatal("index_completeness_failed", f"could not check index completeness: {exc}")

--- a/src/brainlayer/doctor.py
+++ b/src/brainlayer/doctor.py
@@ -224,6 +224,11 @@ class DoctorConfig:
     spotlight_check_enabled: bool = field(default_factory=lambda: sys.platform == "darwin")
     mcp_config_paths: tuple[Path, ...] | None = None
     mcp_config_check_enabled: bool = True
+    index_completeness_enabled: bool = True
+    #: Decoding every vector's payload reads the whole vec0 blob store (~3GB on
+    #: the canonical DB). Doctor decodes the validity bitmaps only, which is
+    #: cheap; the full payload sweep belongs to the census script.
+    index_completeness_verify_payload: bool = False
 
 
 @dataclass
@@ -235,6 +240,7 @@ class DoctorResult:
     chunk_count: int | None = None
     recent_unvectored_chunks: int | None = None
     missing_vectors: int | None = None
+    index_completeness: dict[str, Any] | None = None
     enrichment_backlog: int | None = None
     queue_count: int | None = None
     queue_bytes: int | None = None
@@ -272,6 +278,29 @@ def _recent_unvectored_chunks(db_path: Path, now: datetime, window_hours: int) -
             (cutoff,),
         ).fetchone()
     return int(row[0] if row else 0)
+
+
+def _index_completeness(db_path: Path, *, verify_payload: bool = False) -> dict[str, Any]:
+    """Set-difference completeness in both directions (repair f).
+
+    chunk -> aux: an active chunk with no row in the FTS index its content_class
+    routes to, or with no vector rowid.
+    aux -> chunk: an index row, pointer, or vector rowid that does not resolve
+    back to a live chunk -- including a pointer aimed at a row owned by a
+    different chunk, which turns the next delete on this chunk into silent
+    collateral damage against that one.
+    """
+    from .index_completeness import census as index_census
+
+    # Not `_ro_conn`: the census stages its working set in TEMP tables, and
+    # `PRAGMA query_only` refuses writes to the temp database too. `mode=ro` is
+    # the guarantee that matters -- the main DB stays physically read-only.
+    conn = sqlite3.connect(f"file:{db_path.expanduser()}?mode=ro", uri=True, timeout=30)
+    conn.isolation_level = None
+    try:
+        return index_census(conn, verify_vector_payload=verify_payload, collect_ids=False).summary()
+    finally:
+        conn.close()
 
 
 def _enrichment_backlog(db_path: Path) -> int:
@@ -625,6 +654,31 @@ def run_doctor(
                 )
         except Exception as exc:
             fatal("vector_parity_failed", f"could not check vector parity: {exc}")
+
+        if config.index_completeness_enabled:
+            try:
+                completeness = _index_completeness(
+                    config.db_path,
+                    verify_payload=config.index_completeness_verify_payload,
+                )
+                result.index_completeness = completeness
+                # BOTH directions, and never a count comparison: a surplus aux
+                # row hides a missing one, which is how 3,536 chunks went
+                # unfindable while fts5_health reported the index in sync.
+                if completeness["chunk_to_aux"]["total"] > 0:
+                    fatal(
+                        "index_completeness_chunk_to_aux",
+                        "active chunks are missing the lexical or vector rows their class routes to",
+                        **completeness["chunk_to_aux"],
+                    )
+                if completeness["aux_to_chunk"]["total"] > 0:
+                    fatal(
+                        "index_completeness_aux_to_chunk",
+                        "aux index rows or pointers do not resolve back to a live chunk",
+                        **completeness["aux_to_chunk"],
+                    )
+            except Exception as exc:
+                fatal("index_completeness_failed", f"could not check index completeness: {exc}")
 
         if config.roundtrip_probe_enabled:
             ok, latency, reason = _roundtrip_probe(config.db_path, config.roundtrip_timeout_seconds)

--- a/src/brainlayer/index_completeness.py
+++ b/src/brainlayer/index_completeness.py
@@ -543,9 +543,21 @@ def _ensure_preimage(conn: sqlite3.Connection) -> None:
 
 
 def _new_run_id(conn: sqlite3.Connection) -> str:
-    """A monotonic id for this apply, derived from the DB's own clock."""
+    """A unique id for this apply, derived from the DB's own clock.
+
+    The stamp is millisecond-resolution, which is ample for a ~1-minute apply
+    but not a guarantee: two applies scripted back to back could land in the
+    same millisecond, and sharing a run_id would fuse them into one rollback
+    unit. So collisions are resolved rather than assumed away.
+    """
     stamp = conn.execute("SELECT strftime('%Y%m%dT%H%M%f','now')").fetchone()[0]
-    return f"run-{stamp}"
+    base = f"run-{stamp}"
+    candidate = base
+    suffix = 1
+    while conn.execute(f"SELECT 1 FROM {PREIMAGE_TABLE} WHERE run_id = ? LIMIT 1", (candidate,)).fetchone():
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+    return candidate
 
 
 def _rollback_marker(run_id: str) -> str:

--- a/src/brainlayer/index_completeness.py
+++ b/src/brainlayer/index_completeness.py
@@ -105,10 +105,6 @@ def route_of(content_class: str | None) -> str:
     return KNOWLEDGE_ROUTE
 
 
-def tables_for_route(route: str) -> tuple[str, ...]:
-    return tuple(table for table, wanted in ROUTED_TABLES.items() if wanted == route)
-
-
 @dataclass
 class CompletenessCensus:
     """Both-direction completeness, as chunk-id sets rather than counts."""
@@ -775,23 +771,22 @@ def repair_index_completeness(
             "phantom_sample": before.phantom_vectors[:10],
         }
 
-        # Chunks needing lexical work, and what to do with each.
-        work: dict[str, dict[str, list[int] | None]] = {}
-        for table, ids in before.missing_index_rows.items():
-            for chunk_id in ids:
-                work.setdefault(chunk_id, {}).setdefault(table, None)
-        for table, ids in before.duplicate_index_rows.items():
-            for chunk_id in ids:
-                work.setdefault(chunk_id, {}).setdefault(table, None)
-        for table, ids in before.misrouted_index_rows.items():
-            for chunk_id in ids:
-                work.setdefault(chunk_id, {}).setdefault(table, None)
-        for table, ids in before.dangling_pointers.items():
-            for chunk_id in ids:
-                work.setdefault(chunk_id, {}).setdefault(table, None)
-        for table, ids in before.mismatched_pointers.items():
-            for chunk_id in ids:
-                work.setdefault(chunk_id, {}).setdefault(table, None)
+        # Chunks needing lexical work. Every chunk the census named for any
+        # lexical defect gets its full routed set rebuilt, rather than a
+        # per-defect patch: the rebuild is deterministic from `chunks`, and
+        # patching one index while trusting the others is how the pointers got
+        # out of step in the first place. (Orphans have no chunk to key on and
+        # are handled separately, after the batches.)
+        work: set[str] = set()
+        for defect in (
+            before.missing_index_rows,
+            before.duplicate_index_rows,
+            before.misrouted_index_rows,
+            before.dangling_pointers,
+            before.mismatched_pointers,
+        ):
+            for ids in defect.values():
+                work.update(ids)
 
         result.chunks_touched = len(work)
         if not apply:
@@ -844,11 +839,19 @@ def repair_index_completeness(
                             pointer_updates[POINTER_COLUMN[table]] = None
                         else:
                             # Lifecycle-managed chunk sitting in an index its class
-                            # does not route to. The census does not report this --
+                            # does not route to. The census does not report that --
                             # its misroute check is scoped to active chunks -- and a
-                            # migration must not delete more than it reported. Leave
-                            # the rows and just re-aim the pointer at one of them, so
-                            # the delete trigger can still find it.
+                            # migration must not delete more than it reported, so the
+                            # row stays and the pointer is re-aimed at it, keeping
+                            # the delete trigger able to find it.
+                            #
+                            # A duplicate here IS reported (the duplicate check spans
+                            # every chunk), so the surplus copies still go: dropping
+                            # a second copy is not unindexing the chunk, and leaving
+                            # them would mean the migration never converges to zero.
+                            for rowid in existing[1:]:
+                                if _delete_index_row(conn, table, rowid, chunk_id, "dedupe", run_id):
+                                    result.deleted_rows += 1
                             pointer_updates[POINTER_COLUMN[table]] = existing[0] if existing else None
                     if _rewrite_pointer(conn, chunk_id, pointer_updates, run_id):
                         result.pointers_rewritten += 1
@@ -983,7 +986,7 @@ def rollback_repair(db_path: Path, *, allow_live: bool = False, run_id: str | No
                     if found is not None and str(found[0]) == chunk_id:
                         conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid_value,))
                         stats["removed_rows"] += 1
-                elif action in {"rebuild", "misroute", "orphan"}:
+                elif action in {"rebuild", "misroute", "orphan", "dedupe"}:
                     # Restore at the ORIGINAL rowid, not wherever FTS5 would put
                     # a fresh row. The pointer preimages restore the old rowid
                     # numbers, so a row that comes back at a different rowid
@@ -1096,6 +1099,9 @@ def main(argv: list[str] | None = None) -> int:
         json.dumps(
             {
                 "apply": result.apply,
+                # Printed so an operator can name this run to --rollback-run
+                # without going digging in the preimage table.
+                "run_id": result.run_id,
                 "chunks_touched": result.chunks_touched,
                 "inserted_rows": result.inserted_rows,
                 "deleted_rows": result.deleted_rows,

--- a/src/brainlayer/index_completeness.py
+++ b/src/brainlayer/index_completeness.py
@@ -474,16 +474,26 @@ class RepairResult:
     pointers_rewritten: int = 0
     orphans_deleted: int = 0
     chunks_touched: int = 0
+    run_id: str | None = None
     vector_debt: dict[str, Any] = field(default_factory=dict)
     spot_checks: list[dict[str, Any]] = field(default_factory=list)
     batches: int = 0
 
 
 def _ensure_preimage(conn: sqlite3.Connection) -> None:
+    """Create (or migrate) the preimage table.
+
+    `run_id` is what makes a second rollback safe. Preimages accumulate -- they
+    are the retained audit trail, per the repair-b/d/e precedent -- so a rollback
+    that replayed the whole table would try to undo runs already undone, and on
+    an apply/rollback/apply cycle it aborts on a rowid collision. Rollback is
+    therefore scoped to one run: the newest that has not already been reversed.
+    """
     conn.execute(
         f"""
         CREATE TABLE IF NOT EXISTS {PREIMAGE_TABLE} (
             seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL DEFAULT 'legacy',
             chunk_id TEXT NOT NULL,
             table_name TEXT NOT NULL,
             action TEXT NOT NULL,
@@ -493,7 +503,21 @@ def _ensure_preimage(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    columns = {row[1] for row in conn.execute(f"PRAGMA table_info({PREIMAGE_TABLE})")}
+    if "run_id" not in columns:
+        conn.execute(f"ALTER TABLE {PREIMAGE_TABLE} ADD COLUMN run_id TEXT NOT NULL DEFAULT 'legacy'")
     conn.execute(f"CREATE INDEX IF NOT EXISTS idx_{PREIMAGE_TABLE}_chunk ON {PREIMAGE_TABLE}(chunk_id)")
+    conn.execute(f"CREATE INDEX IF NOT EXISTS idx_{PREIMAGE_TABLE}_run ON {PREIMAGE_TABLE}(run_id)")
+
+
+def _new_run_id(conn: sqlite3.Connection) -> str:
+    """A monotonic id for this apply, derived from the DB's own clock."""
+    stamp = conn.execute("SELECT strftime('%Y%m%dT%H%M%f','now')").fetchone()[0]
+    return f"run-{stamp}"
+
+
+def _rollback_marker(run_id: str) -> str:
+    return f"rolled_back:{run_id}"
 
 
 def _chunk_payload(conn: sqlite3.Connection, chunk_id: str) -> tuple[Any, ...] | None:
@@ -507,7 +531,9 @@ def _chunk_payload(conn: sqlite3.Connection, chunk_id: str) -> tuple[Any, ...] |
     return tuple(row) if row else None
 
 
-def _delete_index_row(conn: sqlite3.Connection, table: str, rowid: int, chunk_id: str, action: str) -> bool:
+def _delete_index_row(
+    conn: sqlite3.Connection, table: str, rowid: int, chunk_id: str, action: str, run_id: str
+) -> bool:
     """Delete one aux index row after re-verifying it belongs to chunk_id.
 
     The verification is the whole point: a rowid recorded during the census is
@@ -519,8 +545,8 @@ def _delete_index_row(conn: sqlite3.Connection, table: str, rowid: int, chunk_id
     if row is None or str(row[6]) != chunk_id:
         return False
     conn.execute(
-        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?)",
-        (chunk_id, table, action, rowid, json.dumps(list(row), default=str)),
+        f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?,?)",
+        (run_id, chunk_id, table, action, rowid, json.dumps(list(row), default=str)),
     )
     conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
     return True
@@ -563,7 +589,9 @@ def _existing_index_rows(
     return rows, next_rowid
 
 
-def _insert_index_row(conn: sqlite3.Connection, table: str, payload: Sequence[Any], chunk_id: str, rowid: int) -> int:
+def _insert_index_row(
+    conn: sqlite3.Connection, table: str, payload: Sequence[Any], chunk_id: str, rowid: int, run_id: str
+) -> int:
     """Insert one FTS row at an explicitly chosen rowid.
 
     The rowid is assigned by the caller rather than read back afterwards. Two
@@ -579,13 +607,13 @@ def _insert_index_row(conn: sqlite3.Connection, table: str, payload: Sequence[An
     placeholders = ", ".join("?" for _ in range(len(FTS_INSERT_COLUMNS) + 1))
     conn.execute(f"INSERT INTO {table}({columns}) VALUES ({placeholders})", [rowid, *payload])
     conn.execute(
-        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?)",
-        (chunk_id, table, "insert", rowid, None),
+        f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?,?)",
+        (run_id, chunk_id, table, "insert", rowid, None),
     )
     return rowid
 
 
-def _rewrite_pointer(conn: sqlite3.Connection, chunk_id: str, updates: dict[str, int | None]) -> bool:
+def _rewrite_pointer(conn: sqlite3.Connection, chunk_id: str, updates: dict[str, int | None], run_id: str) -> bool:
     if not updates:
         return False
     before = conn.execute(
@@ -601,8 +629,9 @@ def _rewrite_pointer(conn: sqlite3.Connection, chunk_id: str, updates: dict[str,
     if before is not None and tuple(desired.values()) == tuple(before):
         return False
     conn.execute(
-        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?)",
+        f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?,?)",
         (
+            run_id,
             chunk_id,
             "chunk_fts_rowids",
             "pointer",
@@ -770,6 +799,8 @@ def repair_index_completeness(
             return result
 
         _ensure_preimage(conn)
+        run_id = _new_run_id(conn)
+        result.run_id = run_id
         touched: list[str] = sorted(work)
         # One scan per FTS table to find the touched chunks' existing rows.
         # `c6` (chunk_id) carries no index, so asking per chunk would be one
@@ -780,10 +811,15 @@ def repair_index_completeness(
             conn.execute("BEGIN IMMEDIATE")
             try:
                 for chunk_id in batch:
-                    row = conn.execute("SELECT content_class FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+                    row = conn.execute(
+                        f"SELECT content_class, CASE WHEN {ACTIVE_CHUNK_SQL.strip()} THEN 1 ELSE 0 END "
+                        "FROM chunks WHERE id = ?",
+                        (chunk_id,),
+                    ).fetchone()
                     if row is None:
                         continue
                     route = route_of(row[0])
+                    is_active = bool(row[1])
                     payload = _chunk_payload(conn, chunk_id)
                     pointer_updates: dict[str, int | None] = {}
                     for table, wanted_route in ROUTED_TABLES.items():
@@ -793,20 +829,28 @@ def repair_index_completeness(
                         if wanted_route == route and payload is not None and payload[0]:
                             # Rebuild to exactly one row carrying current content.
                             for rowid in existing:
-                                if _delete_index_row(conn, table, rowid, chunk_id, "rebuild"):
+                                if _delete_index_row(conn, table, rowid, chunk_id, "rebuild", run_id):
                                     result.deleted_rows += 1
                             new_rowid = next_rowid[table]
                             next_rowid[table] += 1
-                            _insert_index_row(conn, table, payload, chunk_id, new_rowid)
+                            _insert_index_row(conn, table, payload, chunk_id, new_rowid, run_id)
                             result.inserted_rows += 1
                             pointer_updates[POINTER_COLUMN[table]] = new_rowid
-                        else:
+                        elif is_active:
                             # Wrong index for this class: drop the leaked rows.
                             for rowid in existing:
-                                if _delete_index_row(conn, table, rowid, chunk_id, "misroute"):
+                                if _delete_index_row(conn, table, rowid, chunk_id, "misroute", run_id):
                                     result.deleted_rows += 1
                             pointer_updates[POINTER_COLUMN[table]] = None
-                    if _rewrite_pointer(conn, chunk_id, pointer_updates):
+                        else:
+                            # Lifecycle-managed chunk sitting in an index its class
+                            # does not route to. The census does not report this --
+                            # its misroute check is scoped to active chunks -- and a
+                            # migration must not delete more than it reported. Leave
+                            # the rows and just re-aim the pointer at one of them, so
+                            # the delete trigger can still find it.
+                            pointer_updates[POINTER_COLUMN[table]] = existing[0] if existing else None
+                    if _rewrite_pointer(conn, chunk_id, pointer_updates, run_id):
                         result.pointers_rewritten += 1
                 conn.execute("COMMIT")
             except Exception:
@@ -831,7 +875,7 @@ def repair_index_completeness(
                         still_gone = conn.execute("SELECT 1 FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
                         if still_gone is not None:
                             continue
-                        if _delete_index_row(conn, table, rowid, chunk_id, "orphan"):
+                        if _delete_index_row(conn, table, rowid, chunk_id, "orphan", run_id):
                             result.orphans_deleted += 1
                 for chunk_id in before.orphan_pointer_rows:
                     if conn.execute("SELECT 1 FROM chunks WHERE id = ?", (chunk_id,)).fetchone() is not None:
@@ -841,9 +885,16 @@ def repair_index_completeness(
                         (chunk_id,),
                     ).fetchone()
                     conn.execute(
-                        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) "
-                        "VALUES (?,?,?,?,?)",
-                        (chunk_id, "chunk_fts_rowids", "orphan_pointer", None, json.dumps(list(row) if row else None)),
+                        f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) "
+                        "VALUES (?,?,?,?,?,?)",
+                        (
+                            run_id,
+                            chunk_id,
+                            "chunk_fts_rowids",
+                            "orphan_pointer",
+                            None,
+                            json.dumps(list(row) if row else None),
+                        ),
                     )
                     conn.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = ?", (chunk_id,))
                     result.orphans_deleted += 1
@@ -877,23 +928,54 @@ def repair_index_completeness(
         conn.close()
 
 
-def rollback_repair(db_path: Path, *, allow_live: bool = False) -> dict[str, Any]:
-    """Undo the lexical repair from its preimages, newest write first.
+def _rollbackable_run(conn: sqlite3.Connection) -> str | None:
+    """The newest apply that has not already been reversed."""
+    reversed_runs = {
+        str(row[0]).split(":", 1)[1]
+        for row in conn.execute(f"SELECT action FROM {PREIMAGE_TABLE} WHERE action LIKE 'rolled_back:%'")
+    }
+    for (run_id,) in conn.execute(
+        f"SELECT run_id FROM {PREIMAGE_TABLE} WHERE action NOT LIKE 'rolled_back:%' "
+        "GROUP BY run_id ORDER BY MAX(seq) DESC"
+    ):
+        if str(run_id) not in reversed_runs:
+            return str(run_id)
+    return None
 
-    Inserted rows are deleted; deleted rows are re-inserted with their recorded
-    text; pointer rows are restored to their recorded triple. The preimage table
-    is retained afterwards as the audit trail (repair-b/d/e precedent).
+
+def rollback_repair(db_path: Path, *, allow_live: bool = False, run_id: str | None = None) -> dict[str, Any]:
+    """Undo ONE apply from its preimages, newest write first.
+
+    Inserted rows are deleted; deleted rows are re-inserted at their original
+    rowid with their recorded text; pointer rows are restored to their recorded
+    triple. The preimage table is retained afterwards as the audit trail
+    (repair-b/d/e precedent), so the scope has to be a single run: replaying the
+    whole table would try to undo applies already undone, and on an
+    apply/rollback/apply cycle it aborts on a rowid collision instead.
     """
     resolved = assert_not_live_db(Path(db_path), allow_live=allow_live)
     conn = sqlite3.connect(resolved, timeout=60)
-    stats = {"restored_rows": 0, "removed_rows": 0, "restored_pointers": 0, "preimage_tables": "retained"}
+    conn.isolation_level = None
+    stats: dict[str, Any] = {
+        "restored_rows": 0,
+        "removed_rows": 0,
+        "restored_pointers": 0,
+        "preimage_tables": "retained",
+    }
     try:
         if PREIMAGE_TABLE not in _table_names(conn):
             return {**stats, "preimage": "absent"}
+        _ensure_preimage(conn)
+        target = run_id or _rollbackable_run(conn)
+        stats["run_id"] = target
+        if target is None:
+            return {**stats, "preimage": "nothing left to roll back"}
         conn.execute("BEGIN IMMEDIATE")
         try:
             rows = conn.execute(
-                f"SELECT seq, chunk_id, table_name, action, rowid_value, payload FROM {PREIMAGE_TABLE} ORDER BY seq DESC"
+                f"SELECT seq, chunk_id, table_name, action, rowid_value, payload FROM {PREIMAGE_TABLE} "
+                "WHERE run_id = ? AND action NOT LIKE 'rolled_back:%' ORDER BY seq DESC",
+                (target,),
             ).fetchall()
             for _seq, chunk_id, table, action, rowid_value, payload in rows:
                 if action == "insert":
@@ -908,6 +990,9 @@ def rollback_repair(db_path: Path, *, allow_live: bool = False) -> dict[str, Any
                     # leaves every restored pointer dangling -- a rollback that
                     # reports success while breaking what it claimed to fix.
                     values = json.loads(payload)
+                    # Clear the slot first: this run may have inserted its own
+                    # row at that rowid, and FTS5 has no upsert.
+                    conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid_value,))
                     columns = ", ".join(("rowid", *FTS_INSERT_COLUMNS))
                     marks = ", ".join("?" for _ in range(len(FTS_INSERT_COLUMNS) + 1))
                     conn.execute(f"INSERT INTO {table}({columns}) VALUES ({marks})", [rowid_value, *values])
@@ -938,6 +1023,13 @@ def rollback_repair(db_path: Path, *, allow_live: bool = False) -> dict[str, Any
                             (chunk_id, *before),
                         )
                         stats["restored_pointers"] += 1
+            # Mark the run reversed so a second --rollback moves on to the run
+            # before it instead of replaying this one.
+            conn.execute(
+                f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) "
+                "VALUES (?,?,?,?,?,?)",
+                (target, "", "", _rollback_marker(target), None, json.dumps(stats, sort_keys=True)),
+            )
             conn.execute("COMMIT")
         except Exception:
             conn.execute("ROLLBACK")
@@ -964,12 +1056,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--spot-check", type=int, default=0)
     parser.add_argument("--keep-orphans", action="store_true", help="Do not delete orphan aux index rows")
     parser.add_argument("--actor", default="repair-f")
-    parser.add_argument("--rollback", action="store_true")
+    parser.add_argument("--rollback", action="store_true", help="Undo the newest apply not yet reversed")
+    parser.add_argument("--rollback-run", dest="rollback_run", help="Undo this run_id instead of the newest")
     parser.add_argument("--census-only", action="store_true", help="Print the census and exit")
     args = parser.parse_args(argv)
 
-    if args.rollback:
-        print(json.dumps(rollback_repair(args.db.expanduser(), allow_live=args.allow_live), sort_keys=True))
+    if args.rollback or args.rollback_run:
+        print(
+            json.dumps(
+                rollback_repair(args.db.expanduser(), allow_live=args.allow_live, run_id=args.rollback_run),
+                sort_keys=True,
+            )
+        )
         return 0
 
     if args.census_only:

--- a/src/brainlayer/index_completeness.py
+++ b/src/brainlayer/index_completeness.py
@@ -36,6 +36,7 @@ is reported for the embed pipeline rather than surgically patched here.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sqlite3
 import subprocess
@@ -118,6 +119,7 @@ class CompletenessCensus:
     # aux -> chunk
     orphan_index_rows: dict[str, list[int]] = field(default_factory=dict)
     orphan_vector_rowids: list[str] = field(default_factory=list)
+    orphan_binary_rowids: list[str] = field(default_factory=list)
     orphan_pointer_rows: list[str] = field(default_factory=list)
     dangling_pointers: dict[str, list[str]] = field(default_factory=dict)
     mismatched_pointers: dict[str, list[str]] = field(default_factory=dict)
@@ -132,6 +134,7 @@ class CompletenessCensus:
             + sum(len(ids) for ids in self.duplicate_index_rows.values())
             + sum(len(ids) for ids in self.misrouted_index_rows.values())
             + len(self.missing_vector_rowid)
+            + len(self.missing_binary_vector)
         )
 
     @property
@@ -139,6 +142,7 @@ class CompletenessCensus:
         return (
             sum(len(ids) for ids in self.orphan_index_rows.values())
             + len(self.orphan_vector_rowids)
+            + len(self.orphan_binary_rowids)
             + len(self.orphan_pointer_rows)
             + sum(len(ids) for ids in self.dangling_pointers.values())
             + sum(len(ids) for ids in self.mismatched_pointers.values())
@@ -146,22 +150,39 @@ class CompletenessCensus:
         )
 
     @property
-    def lexical_total(self) -> int:
-        """Gaps this migration can close: everything deterministic from chunks.content."""
+    def lexical_chunk_to_aux(self) -> int:
+        """Lexical defects a chunk has against the indexes it routes to."""
         return (
             sum(len(ids) for ids in self.missing_index_rows.values())
             + sum(len(ids) for ids in self.duplicate_index_rows.values())
             + sum(len(ids) for ids in self.misrouted_index_rows.values())
-            + sum(len(ids) for ids in self.orphan_index_rows.values())
+        )
+
+    @property
+    def lexical_aux_to_chunk(self) -> int:
+        """Lexical index rows and pointers that do not resolve back to a live chunk."""
+        return (
+            sum(len(ids) for ids in self.orphan_index_rows.values())
             + len(self.orphan_pointer_rows)
             + sum(len(ids) for ids in self.dangling_pointers.values())
             + sum(len(ids) for ids in self.mismatched_pointers.values())
         )
 
     @property
+    def lexical_total(self) -> int:
+        """Gaps this migration can close: everything deterministic from chunks.content."""
+        return self.lexical_chunk_to_aux + self.lexical_aux_to_chunk
+
+    @property
     def vector_total(self) -> int:
         """Gaps only the embed pipeline can close. Never repaired in a migration."""
-        return len(self.missing_vector_rowid) + len(self.orphan_vector_rowids) + len(self.phantom_vectors)
+        return (
+            len(self.missing_vector_rowid)
+            + len(self.missing_binary_vector)
+            + len(self.orphan_vector_rowids)
+            + len(self.orphan_binary_rowids)
+            + len(self.phantom_vectors)
+        )
 
     @property
     def total(self) -> int:
@@ -180,6 +201,7 @@ class CompletenessCensus:
             "aux_to_chunk": {
                 "orphan_index_rows": {k: len(v) for k, v in self.orphan_index_rows.items()},
                 "orphan_vector_rowids": len(self.orphan_vector_rowids),
+                "orphan_binary_rowids": len(self.orphan_binary_rowids),
                 "orphan_pointer_rows": len(self.orphan_pointer_rows),
                 "dangling_pointers": {k: len(v) for k, v in self.dangling_pointers.items()},
                 "mismatched_pointers": {k: len(v) for k, v in self.mismatched_pointers.items()},
@@ -187,7 +209,10 @@ class CompletenessCensus:
                 "vector_payload_checked": self.vector_payload_checked,
                 "total": self.aux_to_chunk_total,
             },
+            "lexical_chunk_to_aux": self.lexical_chunk_to_aux,
+            "lexical_aux_to_chunk": self.lexical_aux_to_chunk,
             "lexical_total": self.lexical_total,
+            "phantom_vectors": len(self.phantom_vectors),
             "vector_total": self.vector_total,
             "total": self.total,
         }
@@ -358,6 +383,17 @@ def census(
                 WHERE r.active = 1
                   AND NOT EXISTS (SELECT 1 FROM chunk_vectors_binary_rowids v WHERE v.id = r.chunk_id)
                 ORDER BY r.chunk_id
+                """,
+                collect=collect_ids,
+            )
+            # Symmetry with the float index: without this, binary-side drift is
+            # only ever visible in one direction.
+            result.orphan_binary_rowids = _ids(
+                conn,
+                """
+                SELECT v.id FROM chunk_vectors_binary_rowids v
+                WHERE NOT EXISTS (SELECT 1 FROM temp._ic_route r WHERE r.chunk_id = v.id)
+                ORDER BY v.id
                 """,
                 collect=collect_ids,
             )
@@ -554,13 +590,16 @@ def _next_rowid(conn: sqlite3.Connection, table: str) -> int:
 
 
 def _existing_index_rows(
-    conn: sqlite3.Connection, chunk_ids: Sequence[str]
-) -> tuple[dict[str, dict[str, list[int]]], dict[str, int]]:
-    """Every existing FTS rowid for the chunks about to be repaired, in one scan each.
+    conn: sqlite3.Connection, chunk_ids: Sequence[str], *, include_text: bool = False
+) -> tuple[dict[str, dict[str, list[Any]]], dict[str, int]]:
+    """Every existing FTS rowid for the given chunks, in one scan per index.
 
     Also returns the first free rowid per index. New rows are appended above
     the current maximum and rowids freed by a delete are never reused, so a
     pointer written in this run can never collide with a row this run removed.
+
+    `include_text=True` also pulls the indexed content, which is what lets the
+    spot-check compare stored VALUES without paying a scan per chunk.
     """
     present = _table_names(conn)
     conn.execute("PRAGMA temp_store = FILE")
@@ -572,14 +611,15 @@ def _existing_index_rows(
     for table in ROUTED_TABLES:
         if table not in present:
             continue
-        found: dict[str, list[int]] = {}
-        for rowid, chunk_id in conn.execute(
+        found: dict[str, list[Any]] = {}
+        columns = "c.id, c.c6, c.c0" if include_text else "c.id, c.c6, NULL"
+        for rowid, chunk_id, text in conn.execute(
             f"""
-            SELECT c.id, c.c6 FROM {table}_content c
+            SELECT {columns} FROM {table}_content c
             JOIN temp._ic_touched t ON t.chunk_id = c.c6
             """
         ):
-            found.setdefault(str(chunk_id), []).append(int(rowid))
+            found.setdefault(str(chunk_id), []).append((int(rowid), text) if include_text else int(rowid))
         rows[table] = found
         next_rowid[table] = _next_rowid(conn, table)
     return rows, next_rowid
@@ -623,6 +663,11 @@ def _rewrite_pointer(conn: sqlite3.Connection, chunk_id: str, updates: dict[str,
     }
     desired.update(updates)
     if before is not None and tuple(desired.values()) == tuple(before):
+        return False
+    if before is None and not any(value is not None for value in desired.values()):
+        # Nothing to point at and no row to correct. Writing an all-NULL pointer
+        # row would leave behind a row that never existed -- invisible to the
+        # census, but still a row this migration invented.
         return False
     conn.execute(
         f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?,?)",
@@ -695,17 +740,38 @@ def _record_migration(conn: sqlite3.Connection, *, git_sha: str, actor: str, pay
 def _spot_check(conn: sqlite3.Connection, chunk_ids: Iterable[str]) -> list[dict[str, Any]]:
     """Re-read repaired chunks and verify VALUES, not counts.
 
-    For each sampled chunk: exactly one row in every index its class routes to,
-    the indexed text byte-equal to `chunks.content`, no row in any index it
-    does not route to, and a pointer that resolves back to this same chunk.
+    The gate has to assert what the migration actually promises, and that
+    differs by lifecycle:
+
+    * Routed index, either lifecycle: exactly one row, indexed text byte-equal
+      to `chunks.content`, pointer resolving back to that row.
+    * Non-routed index, ACTIVE chunk: no row -- the leak was deleted.
+    * Non-routed index, lifecycle-managed chunk: at most one row, pointer
+      resolving to it. The row is deliberately kept (the census never reported
+      it), so demanding its absence would make this gate fail the migration's
+      own correct behaviour -- and `main()` exits non-zero on a failed
+      spot-check, which would send a live operator to `--rollback` on a good
+      run. Measured population where that would bite: 1 chunk in 10,478, so a
+      50-sample stride hits it about half a percent of the time -- a trap that
+      only springs during the live window.
     """
+    sample = list(chunk_ids)
+    # One scan per index for the whole sample, not one per chunk: `c6` carries
+    # no index, so the per-chunk form costs a full scan of a multi-GB content
+    # table every time -- fine for 50 samples off a warm cache, hours if the
+    # live window ever asks to spot-check everything it touched.
+    indexed_rows, _ = _existing_index_rows(conn, sample, include_text=True)
     checks: list[dict[str, Any]] = []
-    for chunk_id in chunk_ids:
-        row = conn.execute("SELECT content, content_class FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+    for chunk_id in sample:
+        row = conn.execute(
+            f"SELECT content, content_class, CASE WHEN {ACTIVE_CHUNK_SQL.strip()} THEN 1 ELSE 0 END "
+            "FROM chunks WHERE id = ?",
+            (chunk_id,),
+        ).fetchone()
         if row is None:
             checks.append({"chunk_id": chunk_id, "ok": False, "why": ["chunk_missing"]})
             continue
-        content, content_class = row
+        content, content_class, is_active = row[0], row[1], bool(row[2])
         route = route_of(content_class)
         why: list[str] = []
         pointers = conn.execute(
@@ -716,8 +782,8 @@ def _spot_check(conn: sqlite3.Connection, chunk_ids: Iterable[str]) -> list[dict
             zip(("chunks_fts", "chunks_fts_trigram", "chunks_fts_operational"), pointers or (None, None, None))
         )
         for table, wanted_route in ROUTED_TABLES.items():
-            rows = conn.execute(f"SELECT id, c0 FROM {table}_content WHERE c6 = ?", (chunk_id,)).fetchall()
-            if wanted_route == route:
+            rows = sorted(indexed_rows.get(table, {}).get(chunk_id, ()))
+            if wanted_route == route and content:
                 if len(rows) != 1:
                     why.append(f"{table}:expected_1_row_got_{len(rows)}")
                     continue
@@ -726,9 +792,17 @@ def _spot_check(conn: sqlite3.Connection, chunk_ids: Iterable[str]) -> list[dict
                     why.append(f"{table}:indexed_text_differs_from_chunk_content")
                 if pointer_by_table.get(table) != rowid:
                     why.append(f"{table}:pointer_does_not_resolve_to_this_row")
+            elif wanted_route != route and is_active:
+                if rows:
+                    why.append(f"{table}:present_but_class_routes_to_{route}")
             elif rows:
-                why.append(f"{table}:present_but_class_routes_to_{route}")
-        checks.append({"chunk_id": chunk_id, "route": route, "ok": not why, "why": why})
+                # Lifecycle-managed chunk in an index its class does not route
+                # to: kept on purpose, but deduped and pointed at.
+                if len(rows) != 1:
+                    why.append(f"{table}:lifecycle_row_not_deduped_got_{len(rows)}")
+                elif pointer_by_table.get(table) != rows[0][0]:
+                    why.append(f"{table}:lifecycle_pointer_does_not_resolve_to_this_row")
+        checks.append({"chunk_id": chunk_id, "route": route, "active": is_active, "ok": not why, "why": why})
     return checks
 
 
@@ -931,6 +1005,60 @@ def repair_index_completeness(
         conn.close()
 
 
+def fingerprint(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Content-addressed identity of every structure this migration can write.
+
+    Counts cannot answer "did the rollback put it back": a pointer aimed at a
+    different chunk, text altered in place, or two chunk_ids swapped all leave
+    row counts untouched. This hashes the VALUES instead -- every
+    `(rowid, chunk_id, indexed text)` triple in each index, plus the pointer
+    triples, plus a `chunks` digest that must never move at all.
+
+    It ships rather than living in a rehearsal script because the live window
+    has to be able to prove its own before/after identity, and a claim only the
+    author can reproduce is not evidence.
+    """
+    present = _table_names(conn)
+    out: dict[str, Any] = {}
+    for table in ROUTED_TABLES:
+        if table not in present:
+            continue
+        digest = hashlib.blake2b(digest_size=16)
+        rows = 0
+        for rowid, chunk_id, content in conn.execute(f"SELECT id, c6, c0 FROM {table}_content ORDER BY id"):
+            rows += 1
+            digest.update(f"{rowid}\x1f{chunk_id}\x1f{content}\x1e".encode(errors="replace"))
+        out[table] = {"rows": rows, "digest": digest.hexdigest()}
+
+    if "chunk_fts_rowids" in present:
+        digest = hashlib.blake2b(digest_size=16)
+        rows = 0
+        for row in conn.execute(
+            "SELECT chunk_id, fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids ORDER BY chunk_id"
+        ):
+            rows += 1
+            digest.update(("\x1f".join("" if value is None else str(value) for value in row) + "\x1e").encode())
+        out["chunk_fts_rowids"] = {"rows": rows, "digest": digest.hexdigest()}
+
+    # The migration writes no chunk data, so this digest is the claim's teeth:
+    # it must be identical before and after every run.
+    digest = hashlib.blake2b(digest_size=16)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+    wanted = [
+        c
+        for c in ("id", "content_hash", "content_class", "archived_at", "superseded_by", "aggregated_into")
+        if c in columns
+    ]
+    for row in conn.execute(f"SELECT {', '.join(wanted)} FROM chunks ORDER BY id"):
+        digest.update(("\x1f".join("" if value is None else str(value) for value in row) + "\x1e").encode())
+    out["chunks"] = {
+        "rows": conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0],
+        "digest": digest.hexdigest(),
+        "columns": wanted,
+    }
+    return out
+
+
 def _rollbackable_run(conn: sqlite3.Connection) -> str | None:
     """The newest apply that has not already been reversed."""
     reversed_runs = {
@@ -946,15 +1074,27 @@ def _rollbackable_run(conn: sqlite3.Connection) -> str | None:
     return None
 
 
-def rollback_repair(db_path: Path, *, allow_live: bool = False, run_id: str | None = None) -> dict[str, Any]:
-    """Undo ONE apply from its preimages, newest write first.
+def rollback_repair(
+    db_path: Path,
+    *,
+    allow_live: bool = False,
+    run_id: str | None = None,
+    all_runs: bool = False,
+) -> dict[str, Any]:
+    """Undo applies from their preimages, newest write first.
 
     Inserted rows are deleted; deleted rows are re-inserted at their original
     rowid with their recorded text; pointer rows are restored to their recorded
     triple. The preimage table is retained afterwards as the audit trail
-    (repair-b/d/e precedent), so the scope has to be a single run: replaying the
-    whole table would try to undo applies already undone, and on an
+    (repair-b/d/e precedent), so each undo is scoped to a single run: replaying
+    the whole table would try to reverse applies already reversed, and on an
     apply/rollback/apply cycle it aborts on a rowid collision instead.
+
+    One run is not always the whole story. Batches commit individually, so an
+    interrupted window leaves run A partly applied and the re-run becomes run B
+    -- and undoing only B lands on an intermediate state, not the pre-apply one.
+    `all_runs=True` keeps going until nothing is left to reverse, which is what
+    an exit path on a personal-memory DB has to mean.
     """
     resolved = assert_not_live_db(Path(db_path), allow_live=allow_live)
     conn = sqlite3.connect(resolved, timeout=60)
@@ -964,82 +1104,94 @@ def rollback_repair(db_path: Path, *, allow_live: bool = False, run_id: str | No
         "removed_rows": 0,
         "restored_pointers": 0,
         "preimage_tables": "retained",
+        "runs": [],
     }
     try:
         if PREIMAGE_TABLE not in _table_names(conn):
-            return {**stats, "preimage": "absent"}
+            return {**stats, "run_id": None, "preimage": "absent"}
         _ensure_preimage(conn)
-        target = run_id or _rollbackable_run(conn)
-        stats["run_id"] = target
-        if target is None:
+        while True:
+            target = run_id or _rollbackable_run(conn)
+            if target is None:
+                break
+            _undo_one_run(conn, target, stats)
+            stats["runs"].append(target)
+            if run_id is not None or not all_runs:
+                break
+        stats["run_id"] = stats["runs"][-1] if stats["runs"] else None
+        if not stats["runs"]:
             return {**stats, "preimage": "nothing left to roll back"}
-        conn.execute("BEGIN IMMEDIATE")
-        try:
-            rows = conn.execute(
-                f"SELECT seq, chunk_id, table_name, action, rowid_value, payload FROM {PREIMAGE_TABLE} "
-                "WHERE run_id = ? AND action NOT LIKE 'rolled_back:%' ORDER BY seq DESC",
-                (target,),
-            ).fetchall()
-            for _seq, chunk_id, table, action, rowid_value, payload in rows:
-                if action == "insert":
-                    found = conn.execute(f"SELECT c6 FROM {table}_content WHERE id = ?", (rowid_value,)).fetchone()
-                    if found is not None and str(found[0]) == chunk_id:
-                        conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid_value,))
-                        stats["removed_rows"] += 1
-                elif action in {"rebuild", "misroute", "orphan", "dedupe"}:
-                    # Restore at the ORIGINAL rowid, not wherever FTS5 would put
-                    # a fresh row. The pointer preimages restore the old rowid
-                    # numbers, so a row that comes back at a different rowid
-                    # leaves every restored pointer dangling -- a rollback that
-                    # reports success while breaking what it claimed to fix.
-                    values = json.loads(payload)
-                    # Clear the slot first: this run may have inserted its own
-                    # row at that rowid, and FTS5 has no upsert.
-                    conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid_value,))
-                    columns = ", ".join(("rowid", *FTS_INSERT_COLUMNS))
-                    marks = ", ".join("?" for _ in range(len(FTS_INSERT_COLUMNS) + 1))
-                    conn.execute(f"INSERT INTO {table}({columns}) VALUES ({marks})", [rowid_value, *values])
-                    stats["restored_rows"] += 1
-                elif action == "pointer":
-                    before = json.loads(payload).get("before")
-                    if before is None:
-                        conn.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = ?", (chunk_id,))
-                    else:
-                        conn.execute(
-                            """
-                            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid, operational_rowid)
-                            VALUES (?,?,?,?)
-                            ON CONFLICT(chunk_id) DO UPDATE SET
-                                fts_rowid = excluded.fts_rowid,
-                                trigram_rowid = excluded.trigram_rowid,
-                                operational_rowid = excluded.operational_rowid
-                            """,
-                            (chunk_id, *before),
-                        )
-                    stats["restored_pointers"] += 1
-                elif action == "orphan_pointer":
-                    before = json.loads(payload)
-                    if before:
-                        conn.execute(
-                            "INSERT OR REPLACE INTO chunk_fts_rowids"
-                            "(chunk_id, fts_rowid, trigram_rowid, operational_rowid) VALUES (?,?,?,?)",
-                            (chunk_id, *before),
-                        )
-                        stats["restored_pointers"] += 1
-            # Mark the run reversed so a second --rollback moves on to the run
-            # before it instead of replaying this one.
-            conn.execute(
-                f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) "
-                "VALUES (?,?,?,?,?,?)",
-                (target, "", "", _rollback_marker(target), None, json.dumps(stats, sort_keys=True)),
-            )
-            conn.execute("COMMIT")
-        except Exception:
-            conn.execute("ROLLBACK")
-            raise
         return stats
     finally:
         conn.close()
+
+
+def _undo_one_run(conn: sqlite3.Connection, target: str, stats: dict[str, Any]) -> None:
+    """Reverse exactly one apply, in one transaction."""
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        rows = conn.execute(
+            f"SELECT seq, chunk_id, table_name, action, rowid_value, payload FROM {PREIMAGE_TABLE} "
+            "WHERE run_id = ? AND action NOT LIKE 'rolled_back:%' ORDER BY seq DESC",
+            (target,),
+        ).fetchall()
+        for _seq, chunk_id, table, action, rowid_value, payload in rows:
+            if action == "insert":
+                found = conn.execute(f"SELECT c6 FROM {table}_content WHERE id = ?", (rowid_value,)).fetchone()
+                if found is not None and str(found[0]) == chunk_id:
+                    conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid_value,))
+                    stats["removed_rows"] += 1
+            elif action in {"rebuild", "misroute", "orphan", "dedupe"}:
+                # Restore at the ORIGINAL rowid, not wherever FTS5 would put
+                # a fresh row. The pointer preimages restore the old rowid
+                # numbers, so a row that comes back at a different rowid
+                # leaves every restored pointer dangling -- a rollback that
+                # reports success while breaking what it claimed to fix.
+                values = json.loads(payload)
+                # Clear the slot first: this run may have inserted its own
+                # row at that rowid, and FTS5 has no upsert.
+                conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid_value,))
+                columns = ", ".join(("rowid", *FTS_INSERT_COLUMNS))
+                marks = ", ".join("?" for _ in range(len(FTS_INSERT_COLUMNS) + 1))
+                conn.execute(f"INSERT INTO {table}({columns}) VALUES ({marks})", [rowid_value, *values])
+                stats["restored_rows"] += 1
+            elif action == "pointer":
+                before = json.loads(payload).get("before")
+                if before is None:
+                    conn.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = ?", (chunk_id,))
+                else:
+                    conn.execute(
+                        """
+                        INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid, operational_rowid)
+                        VALUES (?,?,?,?)
+                        ON CONFLICT(chunk_id) DO UPDATE SET
+                            fts_rowid = excluded.fts_rowid,
+                            trigram_rowid = excluded.trigram_rowid,
+                            operational_rowid = excluded.operational_rowid
+                        """,
+                        (chunk_id, *before),
+                    )
+                stats["restored_pointers"] += 1
+            elif action == "orphan_pointer":
+                before = json.loads(payload)
+                if before:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO chunk_fts_rowids"
+                        "(chunk_id, fts_rowid, trigram_rowid, operational_rowid) VALUES (?,?,?,?)",
+                        (chunk_id, *before),
+                    )
+                    stats["restored_pointers"] += 1
+        # Mark the run reversed so a second --rollback moves on to the run
+        # before it instead of replaying this one.
+        conn.execute(
+            f"INSERT INTO {PREIMAGE_TABLE}(run_id, chunk_id, table_name, action, rowid_value, payload) "
+            "VALUES (?,?,?,?,?,?)",
+            (target, "", "", _rollback_marker(target), None, json.dumps(stats, sort_keys=True)),
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1060,17 +1212,41 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--keep-orphans", action="store_true", help="Do not delete orphan aux index rows")
     parser.add_argument("--actor", default="repair-f")
     parser.add_argument("--rollback", action="store_true", help="Undo the newest apply not yet reversed")
+    parser.add_argument(
+        "--rollback-all",
+        dest="rollback_all",
+        action="store_true",
+        help="Undo every apply still on record — the exit path after an interrupted window",
+    )
     parser.add_argument("--rollback-run", dest="rollback_run", help="Undo this run_id instead of the newest")
     parser.add_argument("--census-only", action="store_true", help="Print the census and exit")
+    parser.add_argument(
+        "--fingerprint",
+        action="store_true",
+        help="Print the content-addressed fingerprint and exit (run before and after a live window)",
+    )
     args = parser.parse_args(argv)
 
-    if args.rollback or args.rollback_run:
+    if args.rollback or args.rollback_all or args.rollback_run:
         print(
             json.dumps(
-                rollback_repair(args.db.expanduser(), allow_live=args.allow_live, run_id=args.rollback_run),
+                rollback_repair(
+                    args.db.expanduser(),
+                    allow_live=args.allow_live,
+                    run_id=args.rollback_run,
+                    all_runs=args.rollback_all,
+                ),
                 sort_keys=True,
             )
         )
+        return 0
+
+    if args.fingerprint:
+        conn = sqlite3.connect(f"file:{args.db.expanduser()}?mode=ro", uri=True)
+        try:
+            print(json.dumps(fingerprint(conn), indent=2, sort_keys=True))
+        finally:
+            conn.close()
         return 0
 
     if args.census_only:

--- a/src/brainlayer/index_completeness.py
+++ b/src/brainlayer/index_completeness.py
@@ -1,0 +1,1021 @@
+"""Repair (f): FTS/vector completeness — census, invariant, and repair.
+
+Every active chunk must be findable BOTH ways: the lexical row its content_class
+routes to, and a semantic vector. Historical drift left gaps that count-based
+health checks cannot see, because a surplus row hides a missing one.
+
+Two rules shape this module.
+
+**Counts are blind (#722, PR723).** `check_fts5_health` compares
+`COUNT(chunks WHERE knowledge-class)` against `COUNT(chunks_fts)` and calls the
+index synced when the two agree. On the canonical DB they nearly agree while
+3,536 active chunks have no `chunks_fts` row at all -- 4,551 chunks carry a
+duplicate row and 2,508 rows leak in from classes that route elsewhere, and the
+surplus masks the deficit. So every check here is set-difference on chunk ids,
+in BOTH directions, never a count comparison.
+
+**Vectors are the embed pipeline's work, not a migration's.** Missing FTS rows
+are deterministic from `chunks.content` and rebuild in place. A missing vector
+is not: producing one means running the embedding model. This migration never
+embeds. It reports vector debt and hands it to `brainlayer reembed-backfill`,
+which already owns that queue (`reembed_backfill.fetch_unvectored_batch`).
+
+**What may be deleted.** Only aux INDEX rows -- `chunks_fts`,
+`chunks_fts_trigram`, `chunks_fts_operational` entries, and `chunk_fts_rowids`
+pointers. Every one of them is reproducible byte-for-byte from `chunks`, which
+is why a delete here is not data loss. No row in `chunks` is ever written,
+archived, or deleted by this migration. An orphan aux row (its chunk_id absent
+from `chunks`) is deleted only after that absence is re-verified inside the
+write transaction.
+
+The vec0 tables are never written: `chunk_vectors` and its shadow tables are
+owned by sqlite-vec, and a phantom vector (rowid present, validity bit clear)
+is reported for the embed pipeline rather than surgically patched here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from .chunk_origin_wipe import assert_not_live_db
+
+MIGRATION_NAME = "repair_f_index_completeness"
+PREIMAGE_TABLE = "index_completeness_preimage"
+
+#: Mirrors the FTS trigger predicates in vector_store.py. Kept as literals here
+#: so the migration reads the same routing law the write path enforces; the
+#: contract test asserts the two never drift apart.
+NO_FTS_CLASSES = ("test", "benchmark", "cold")
+OPERATIONAL_CLASS = "operational"
+
+KNOWLEDGE_ROUTE = "knowledge"
+OPERATIONAL_ROUTE = "operational"
+NO_FTS_ROUTE = "none"
+
+#: index table -> the route whose chunks belong in it.
+ROUTED_TABLES = {
+    "chunks_fts": KNOWLEDGE_ROUTE,
+    "chunks_fts_trigram": KNOWLEDGE_ROUTE,
+    "chunks_fts_operational": OPERATIONAL_ROUTE,
+}
+
+#: chunk_fts_rowids pointer column per index table.
+POINTER_COLUMN = {
+    "chunks_fts": "fts_rowid",
+    "chunks_fts_trigram": "trigram_rowid",
+    "chunks_fts_operational": "operational_rowid",
+}
+
+FTS_INSERT_COLUMNS = (
+    "content",
+    "summary",
+    "tags",
+    "resolved_query",
+    "key_facts",
+    "resolved_queries",
+    "chunk_id",
+)
+
+ACTIVE_CHUNK_SQL = """
+    content IS NOT NULL
+    AND content != ''
+    AND archived_at IS NULL
+    AND superseded_by IS NULL
+    AND aggregated_into IS NULL
+"""
+
+VECTOR_DIM = 1024
+VECTOR_BYTES = VECTOR_DIM * 4
+
+
+def route_of(content_class: str | None) -> str:
+    """Which FTS index a chunk's class routes it into."""
+    cls = content_class or "knowledge"
+    if cls == OPERATIONAL_CLASS:
+        return OPERATIONAL_ROUTE
+    if cls in NO_FTS_CLASSES:
+        return NO_FTS_ROUTE
+    return KNOWLEDGE_ROUTE
+
+
+def tables_for_route(route: str) -> tuple[str, ...]:
+    return tuple(table for table, wanted in ROUTED_TABLES.items() if wanted == route)
+
+
+@dataclass
+class CompletenessCensus:
+    """Both-direction completeness, as chunk-id sets rather than counts."""
+
+    # chunk -> aux
+    missing_index_rows: dict[str, list[str]] = field(default_factory=dict)
+    duplicate_index_rows: dict[str, list[str]] = field(default_factory=dict)
+    misrouted_index_rows: dict[str, list[str]] = field(default_factory=dict)
+    missing_vector_rowid: list[str] = field(default_factory=list)
+    missing_binary_vector: list[str] = field(default_factory=list)
+    # aux -> chunk
+    orphan_index_rows: dict[str, list[int]] = field(default_factory=dict)
+    orphan_vector_rowids: list[str] = field(default_factory=list)
+    orphan_pointer_rows: list[str] = field(default_factory=list)
+    dangling_pointers: dict[str, list[str]] = field(default_factory=dict)
+    mismatched_pointers: dict[str, list[str]] = field(default_factory=dict)
+    # vector payload (VALUE, not pointer)
+    phantom_vectors: list[str] = field(default_factory=list)
+    vector_payload_checked: int = 0
+
+    @property
+    def chunk_to_aux_total(self) -> int:
+        return (
+            sum(len(ids) for ids in self.missing_index_rows.values())
+            + sum(len(ids) for ids in self.duplicate_index_rows.values())
+            + sum(len(ids) for ids in self.misrouted_index_rows.values())
+            + len(self.missing_vector_rowid)
+        )
+
+    @property
+    def aux_to_chunk_total(self) -> int:
+        return (
+            sum(len(ids) for ids in self.orphan_index_rows.values())
+            + len(self.orphan_vector_rowids)
+            + len(self.orphan_pointer_rows)
+            + sum(len(ids) for ids in self.dangling_pointers.values())
+            + sum(len(ids) for ids in self.mismatched_pointers.values())
+            + len(self.phantom_vectors)
+        )
+
+    @property
+    def lexical_total(self) -> int:
+        """Gaps this migration can close: everything deterministic from chunks.content."""
+        return (
+            sum(len(ids) for ids in self.missing_index_rows.values())
+            + sum(len(ids) for ids in self.duplicate_index_rows.values())
+            + sum(len(ids) for ids in self.misrouted_index_rows.values())
+            + sum(len(ids) for ids in self.orphan_index_rows.values())
+            + len(self.orphan_pointer_rows)
+            + sum(len(ids) for ids in self.dangling_pointers.values())
+            + sum(len(ids) for ids in self.mismatched_pointers.values())
+        )
+
+    @property
+    def vector_total(self) -> int:
+        """Gaps only the embed pipeline can close. Never repaired in a migration."""
+        return len(self.missing_vector_rowid) + len(self.orphan_vector_rowids) + len(self.phantom_vectors)
+
+    @property
+    def total(self) -> int:
+        return self.chunk_to_aux_total + self.aux_to_chunk_total
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "chunk_to_aux": {
+                "missing_index_rows": {k: len(v) for k, v in self.missing_index_rows.items()},
+                "duplicate_index_rows": {k: len(v) for k, v in self.duplicate_index_rows.items()},
+                "misrouted_index_rows": {k: len(v) for k, v in self.misrouted_index_rows.items()},
+                "missing_vector_rowid": len(self.missing_vector_rowid),
+                "missing_binary_vector": len(self.missing_binary_vector),
+                "total": self.chunk_to_aux_total,
+            },
+            "aux_to_chunk": {
+                "orphan_index_rows": {k: len(v) for k, v in self.orphan_index_rows.items()},
+                "orphan_vector_rowids": len(self.orphan_vector_rowids),
+                "orphan_pointer_rows": len(self.orphan_pointer_rows),
+                "dangling_pointers": {k: len(v) for k, v in self.dangling_pointers.items()},
+                "mismatched_pointers": {k: len(v) for k, v in self.mismatched_pointers.items()},
+                "phantom_vectors": len(self.phantom_vectors),
+                "vector_payload_checked": self.vector_payload_checked,
+                "total": self.aux_to_chunk_total,
+            },
+            "lexical_total": self.lexical_total,
+            "vector_total": self.vector_total,
+            "total": self.total,
+        }
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+
+
+def _bit_set(validity: bytes, offset: int) -> bool:
+    index = offset // 8
+    if index >= len(validity):
+        return False
+    return bool(validity[index] & (1 << (offset % 8)))
+
+
+ROUTE_CASE_SQL = """
+    CASE
+        WHEN COALESCE(content_class, 'knowledge') = 'operational' THEN 'operational'
+        WHEN COALESCE(content_class, 'knowledge') IN ('test', 'benchmark', 'cold') THEN 'none'
+        ELSE 'knowledge'
+    END
+"""
+
+
+def _build_scratch(conn: sqlite3.Connection, present: set[str]) -> list[str]:
+    """Stage routing and index membership in TEMP tables, not in Python.
+
+    The dict version of this census peaked at 1.1GB of RSS on the canonical
+    corpus, which is not a price doctor can pay on every run. TEMP tables live
+    in SQLite's own temp database -- writable even when the main DB is opened
+    `mode=ro` -- so the working set spills to disk and memory stays flat.
+    """
+    conn.execute("PRAGMA temp_store = FILE")
+    conn.execute("CREATE TEMP TABLE _ic_route (chunk_id TEXT PRIMARY KEY, route TEXT, active INTEGER)")
+    conn.execute(
+        f"""
+        INSERT INTO temp._ic_route(chunk_id, route, active)
+        SELECT id, {ROUTE_CASE_SQL},
+               CASE WHEN {ACTIVE_CHUNK_SQL.strip()} THEN 1 ELSE 0 END
+        FROM chunks
+        """
+    )
+    staged: list[str] = []
+    for table in ROUTED_TABLES:
+        if table not in present:
+            continue
+        conn.execute(f"CREATE TEMP TABLE _ic_own_{table} (row_id INTEGER PRIMARY KEY, chunk_id TEXT)")
+        conn.execute(
+            f"INSERT INTO temp._ic_own_{table}(row_id, chunk_id) "
+            f"SELECT id, c6 FROM {table}_content WHERE c6 IS NOT NULL"
+        )
+        conn.execute(f"CREATE INDEX _ic_own_{table}_chunk ON _ic_own_{table}(chunk_id)")
+        staged.append(table)
+    return staged
+
+
+def _drop_scratch(conn: sqlite3.Connection, staged: list[str]) -> None:
+    """Remove this census's TEMP staging tables. Touches temp only, never the DB."""
+    for table in staged:
+        conn.execute(f"DROP TABLE IF EXISTS temp._ic_own_{table}")
+    conn.execute("DROP TABLE IF EXISTS temp._ic_route")
+
+
+def _ids(conn: sqlite3.Connection, sql: str, params: Sequence[Any] = (), *, collect: bool) -> list[str]:
+    """Ids for a defect, or a count-shaped stand-in when ids are not wanted.
+
+    Doctor only needs to know a set is non-empty and how big it is; the
+    migration needs the ids themselves. Collecting 16k ids is cheap, but
+    collecting them on every doctor run over a growing corpus is not.
+    """
+    if collect:
+        return [str(row[0]) for row in conn.execute(sql, params)]
+    count = conn.execute(f"SELECT COUNT(*) FROM ({sql})", params).fetchone()[0]
+    return [""] * int(count)
+
+
+def census(
+    conn: sqlite3.Connection,
+    *,
+    verify_vector_payload: bool = False,
+    collect_ids: bool = True,
+) -> CompletenessCensus:
+    """Measure completeness in both directions. Reads only the main database."""
+    present = _table_names(conn)
+    result = CompletenessCensus()
+    staged = _build_scratch(conn, present)
+    try:
+        # ── chunk -> aux ──────────────────────────────────────────────────
+        for table in staged:
+            wanted_route = ROUTED_TABLES[table]
+            missing = _ids(
+                conn,
+                f"""
+                SELECT r.chunk_id FROM temp._ic_route r
+                WHERE r.active = 1 AND r.route = '{wanted_route}'
+                  AND NOT EXISTS (SELECT 1 FROM temp._ic_own_{table} o WHERE o.chunk_id = r.chunk_id)
+                ORDER BY r.chunk_id
+                """,
+                collect=collect_ids,
+            )
+            duplicate = _ids(
+                conn,
+                f"""
+                SELECT chunk_id FROM temp._ic_own_{table}
+                GROUP BY chunk_id HAVING COUNT(*) > 1 ORDER BY chunk_id
+                """,
+                collect=collect_ids,
+            )
+            misrouted = _ids(
+                conn,
+                f"""
+                SELECT DISTINCT o.chunk_id FROM temp._ic_own_{table} o
+                JOIN temp._ic_route r ON r.chunk_id = o.chunk_id
+                WHERE r.active = 1 AND r.route <> '{wanted_route}'
+                ORDER BY o.chunk_id
+                """,
+                collect=collect_ids,
+            )
+            if missing:
+                result.missing_index_rows[table] = missing
+            if duplicate:
+                result.duplicate_index_rows[table] = duplicate
+            if misrouted:
+                result.misrouted_index_rows[table] = misrouted
+
+        # ── aux -> chunk: index rows whose chunk is gone ──────────────────
+        for table in staged:
+            orphans = [
+                int(row[0])
+                for row in conn.execute(
+                    f"""
+                    SELECT o.row_id FROM temp._ic_own_{table} o
+                    WHERE NOT EXISTS (SELECT 1 FROM temp._ic_route r WHERE r.chunk_id = o.chunk_id)
+                    ORDER BY o.row_id
+                    """
+                )
+            ]
+            if orphans:
+                result.orphan_index_rows[table] = orphans
+
+        # ── vectors: pointer presence ─────────────────────────────────────
+        if "chunk_vectors_rowids" in present:
+            result.missing_vector_rowid = _ids(
+                conn,
+                """
+                SELECT r.chunk_id FROM temp._ic_route r
+                WHERE r.active = 1
+                  AND NOT EXISTS (SELECT 1 FROM chunk_vectors_rowids v WHERE v.id = r.chunk_id)
+                ORDER BY r.chunk_id
+                """,
+                collect=collect_ids,
+            )
+            result.orphan_vector_rowids = _ids(
+                conn,
+                """
+                SELECT v.id FROM chunk_vectors_rowids v
+                WHERE NOT EXISTS (SELECT 1 FROM temp._ic_route r WHERE r.chunk_id = v.id)
+                ORDER BY v.id
+                """,
+                collect=collect_ids,
+            )
+        if "chunk_vectors_binary_rowids" in present:
+            result.missing_binary_vector = _ids(
+                conn,
+                """
+                SELECT r.chunk_id FROM temp._ic_route r
+                WHERE r.active = 1
+                  AND NOT EXISTS (SELECT 1 FROM chunk_vectors_binary_rowids v WHERE v.id = r.chunk_id)
+                ORDER BY r.chunk_id
+                """,
+                collect=collect_ids,
+            )
+
+        # ── pointers: orphan, dangling, and aimed at someone else's row ───
+        if "chunk_fts_rowids" in present and staged:
+            result.orphan_pointer_rows = _ids(
+                conn,
+                """
+                SELECT p.chunk_id FROM chunk_fts_rowids p
+                WHERE NOT EXISTS (SELECT 1 FROM temp._ic_route r WHERE r.chunk_id = p.chunk_id)
+                ORDER BY p.chunk_id
+                """,
+                collect=collect_ids,
+            )
+            for table in staged:
+                column = POINTER_COLUMN[table]
+                dangling = _ids(
+                    conn,
+                    f"""
+                    SELECT p.chunk_id FROM chunk_fts_rowids p
+                    WHERE p.{column} IS NOT NULL
+                      AND NOT EXISTS (SELECT 1 FROM temp._ic_own_{table} o WHERE o.row_id = p.{column})
+                    ORDER BY p.chunk_id
+                    """,
+                    collect=collect_ids,
+                )
+                mismatched = _ids(
+                    conn,
+                    f"""
+                    SELECT p.chunk_id FROM chunk_fts_rowids p
+                    JOIN temp._ic_own_{table} o ON o.row_id = p.{column}
+                    WHERE p.{column} IS NOT NULL AND o.chunk_id <> p.chunk_id
+                    ORDER BY p.chunk_id
+                    """,
+                    collect=collect_ids,
+                )
+                if dangling:
+                    result.dangling_pointers[table] = dangling
+                if mismatched:
+                    result.mismatched_pointers[table] = mismatched
+
+        # ── vector payload: a pointer is not a vector ─────────────────────
+        if verify_vector_payload and "chunk_vectors_chunks" in present and "chunk_vectors_rowids" in present:
+            result.phantom_vectors, result.vector_payload_checked = _verify_vector_payload(conn)
+    finally:
+        _drop_scratch(conn, staged)
+    return result
+
+
+def _verify_vector_payload(conn: sqlite3.Connection) -> tuple[list[str], int]:
+    """Decode the vec0 validity bitmap and float blob for every active vector.
+
+    A `chunk_vectors_rowids` row proves a pointer, not a vector. Doctor's
+    `vector_parity_gap` counts pointers, so a row whose validity bit is clear,
+    whose blob is missing, or whose 1024 floats are all zero reads as embedded
+    while semantic search can never return it.
+    """
+    validity = {
+        int(vec_chunk): bytes(bitmap)
+        for vec_chunk, bitmap in conn.execute("SELECT chunk_id, validity FROM chunk_vectors_chunks")
+    }
+    phantom: list[str] = []
+    checked = 0
+    blob_cache: dict[int, bytes | None] = {}
+    # Walk vec0 storage order, not chunk-id order: each vector blob holds 1024
+    # vectors and is ~4MB, so visiting ids at random re-reads the same blob
+    # thousands of times.
+    rows = conn.execute(
+        """
+        SELECT v.chunk_id, v.chunk_offset, v.id
+        FROM chunk_vectors_rowids v
+        JOIN temp._ic_route r ON r.chunk_id = v.id
+        WHERE r.active = 1
+        ORDER BY v.chunk_id, v.chunk_offset
+        """
+    )
+    for vec_chunk, offset, chunk_id in rows:
+        checked += 1
+        bitmap = validity.get(int(vec_chunk))
+        if bitmap is None or not _bit_set(bitmap, int(offset)):
+            phantom.append(str(chunk_id))
+            continue
+        if vec_chunk not in blob_cache:
+            blob_cache.clear()
+            found = conn.execute(
+                "SELECT vectors FROM chunk_vectors_vector_chunks00 WHERE rowid = ?", (vec_chunk,)
+            ).fetchone()
+            blob_cache[vec_chunk] = bytes(found[0]) if found else None
+        blob = blob_cache[vec_chunk]
+        start = int(offset) * VECTOR_BYTES
+        if blob is None or start + VECTOR_BYTES > len(blob):
+            phantom.append(str(chunk_id))
+            continue
+        if blob[start : start + VECTOR_BYTES] == b"\x00" * VECTOR_BYTES:
+            phantom.append(str(chunk_id))
+    return phantom, checked
+
+
+# ── repair ───────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RepairResult:
+    apply: bool
+    census_before: dict[str, Any]
+    census_after: dict[str, Any] | None
+    inserted_rows: int = 0
+    deleted_rows: int = 0
+    pointers_rewritten: int = 0
+    orphans_deleted: int = 0
+    chunks_touched: int = 0
+    vector_debt: dict[str, Any] = field(default_factory=dict)
+    spot_checks: list[dict[str, Any]] = field(default_factory=list)
+    batches: int = 0
+
+
+def _ensure_preimage(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {PREIMAGE_TABLE} (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            chunk_id TEXT NOT NULL,
+            table_name TEXT NOT NULL,
+            action TEXT NOT NULL,
+            rowid_value INTEGER,
+            payload TEXT,
+            recorded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+        )
+        """
+    )
+    conn.execute(f"CREATE INDEX IF NOT EXISTS idx_{PREIMAGE_TABLE}_chunk ON {PREIMAGE_TABLE}(chunk_id)")
+
+
+def _chunk_payload(conn: sqlite3.Connection, chunk_id: str) -> tuple[Any, ...] | None:
+    row = conn.execute(
+        """
+        SELECT content, summary, tags, resolved_query, key_facts, resolved_queries, id
+        FROM chunks WHERE id = ?
+        """,
+        (chunk_id,),
+    ).fetchone()
+    return tuple(row) if row else None
+
+
+def _delete_index_row(conn: sqlite3.Connection, table: str, rowid: int, chunk_id: str, action: str) -> bool:
+    """Delete one aux index row after re-verifying it belongs to chunk_id.
+
+    The verification is the whole point: a rowid recorded during the census is
+    not trusted at write time. If the row now carries a different chunk_id the
+    delete is skipped, because deleting it would silently unindex someone else
+    -- exactly the failure the mismatched pointers would have caused.
+    """
+    row = conn.execute(f"SELECT c0, c1, c2, c3, c4, c5, c6 FROM {table}_content WHERE id = ?", (rowid,)).fetchone()
+    if row is None or str(row[6]) != chunk_id:
+        return False
+    conn.execute(
+        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?)",
+        (chunk_id, table, action, rowid, json.dumps(list(row), default=str)),
+    )
+    conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+    return True
+
+
+def _next_rowid(conn: sqlite3.Connection, table: str) -> int:
+    row = conn.execute(f"SELECT COALESCE(MAX(id), 0) + 1 FROM {table}_content").fetchone()
+    return int(row[0])
+
+
+def _existing_index_rows(
+    conn: sqlite3.Connection, chunk_ids: Sequence[str]
+) -> tuple[dict[str, dict[str, list[int]]], dict[str, int]]:
+    """Every existing FTS rowid for the chunks about to be repaired, in one scan each.
+
+    Also returns the first free rowid per index. New rows are appended above
+    the current maximum and rowids freed by a delete are never reused, so a
+    pointer written in this run can never collide with a row this run removed.
+    """
+    present = _table_names(conn)
+    conn.execute("PRAGMA temp_store = FILE")
+    conn.execute("CREATE TEMP TABLE IF NOT EXISTS _ic_touched (chunk_id TEXT PRIMARY KEY)")
+    conn.execute("DELETE FROM temp._ic_touched")
+    conn.executemany("INSERT OR IGNORE INTO temp._ic_touched(chunk_id) VALUES (?)", [(cid,) for cid in chunk_ids])
+    rows: dict[str, dict[str, list[int]]] = {}
+    next_rowid: dict[str, int] = {}
+    for table in ROUTED_TABLES:
+        if table not in present:
+            continue
+        found: dict[str, list[int]] = {}
+        for rowid, chunk_id in conn.execute(
+            f"""
+            SELECT c.id, c.c6 FROM {table}_content c
+            JOIN temp._ic_touched t ON t.chunk_id = c.c6
+            """
+        ):
+            found.setdefault(str(chunk_id), []).append(int(rowid))
+        rows[table] = found
+        next_rowid[table] = _next_rowid(conn, table)
+    return rows, next_rowid
+
+
+def _insert_index_row(conn: sqlite3.Connection, table: str, payload: Sequence[Any], chunk_id: str, rowid: int) -> int:
+    """Insert one FTS row at an explicitly chosen rowid.
+
+    The rowid is assigned by the caller rather than read back afterwards. Two
+    reasons. Recovering it with `SELECT ... WHERE c6 = ?` is a full scan of the
+    FTS content table -- `c6` carries no index -- which measured at ~2s per
+    chunk on the canonical corpus, i.e. hours for the real repair. And
+    `last_insert_rowid()` after an FTS5 insert can report a shadow-table rowid
+    rather than the row's own, which is one candidate mechanism for the 2,661
+    mismatched pointers this migration exists to fix. Choosing the value
+    removes both problems: the pointer written afterwards cannot be a guess.
+    """
+    columns = ", ".join(("rowid", *FTS_INSERT_COLUMNS))
+    placeholders = ", ".join("?" for _ in range(len(FTS_INSERT_COLUMNS) + 1))
+    conn.execute(f"INSERT INTO {table}({columns}) VALUES ({placeholders})", [rowid, *payload])
+    conn.execute(
+        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?)",
+        (chunk_id, table, "insert", rowid, None),
+    )
+    return rowid
+
+
+def _rewrite_pointer(conn: sqlite3.Connection, chunk_id: str, updates: dict[str, int | None]) -> bool:
+    if not updates:
+        return False
+    before = conn.execute(
+        "SELECT fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids WHERE chunk_id = ?",
+        (chunk_id,),
+    ).fetchone()
+    desired = {
+        "fts_rowid": before[0] if before else None,
+        "trigram_rowid": before[1] if before else None,
+        "operational_rowid": before[2] if before else None,
+    }
+    desired.update(updates)
+    if before is not None and tuple(desired.values()) == tuple(before):
+        return False
+    conn.execute(
+        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) VALUES (?,?,?,?,?)",
+        (
+            chunk_id,
+            "chunk_fts_rowids",
+            "pointer",
+            None,
+            json.dumps({"before": list(before) if before else None}),
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid, operational_rowid)
+        VALUES (?,?,?,?)
+        ON CONFLICT(chunk_id) DO UPDATE SET
+            fts_rowid = excluded.fts_rowid,
+            trigram_rowid = excluded.trigram_rowid,
+            operational_rowid = excluded.operational_rowid
+        """,
+        (chunk_id, desired["fts_rowid"], desired["trigram_rowid"], desired["operational_rowid"]),
+    )
+    return True
+
+
+def _checkpoint(conn: sqlite3.Connection) -> None:
+    try:
+        conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+    except sqlite3.Error:
+        pass
+
+
+def _detect_git_sha() -> str | None:
+    try:
+        sha = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True).stdout.strip()
+    except Exception:
+        return None
+    return sha if len(sha) == 40 else None
+
+
+def _record_migration(conn: sqlite3.Connection, *, git_sha: str, actor: str, payload: dict[str, Any]) -> None:
+    if "schema_migrations" not in _table_names(conn):
+        return
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(schema_migrations)")}
+    if not {"name"} <= columns:
+        return
+    values: dict[str, Any] = {"name": MIGRATION_NAME}
+    if "applied_at" in columns:
+        values["applied_at"] = conn.execute("SELECT strftime('%Y-%m-%dT%H:%M:%fZ','now')").fetchone()[0]
+    if "git_sha" in columns:
+        values["git_sha"] = git_sha
+    if "actor" in columns:
+        values["actor"] = actor
+    if "details" in columns:
+        # The canonical table is (name PK, applied_at, details) with no git_sha
+        # or actor column, so the receipt has to carry them itself -- dropping
+        # them would leave a migration record that cannot be traced to a commit.
+        details = dict(payload)
+        details.setdefault("git_sha", git_sha)
+        details.setdefault("actor", actor)
+        values["details"] = json.dumps(details, sort_keys=True)
+    names = ", ".join(values)
+    marks = ", ".join("?" for _ in values)
+    # OR REPLACE: `name` is the primary key, so a re-run must update its receipt
+    # rather than abort the whole migration on the very last statement.
+    conn.execute(f"INSERT OR REPLACE INTO schema_migrations({names}) VALUES ({marks})", list(values.values()))
+
+
+def _spot_check(conn: sqlite3.Connection, chunk_ids: Iterable[str]) -> list[dict[str, Any]]:
+    """Re-read repaired chunks and verify VALUES, not counts.
+
+    For each sampled chunk: exactly one row in every index its class routes to,
+    the indexed text byte-equal to `chunks.content`, no row in any index it
+    does not route to, and a pointer that resolves back to this same chunk.
+    """
+    checks: list[dict[str, Any]] = []
+    for chunk_id in chunk_ids:
+        row = conn.execute("SELECT content, content_class FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+        if row is None:
+            checks.append({"chunk_id": chunk_id, "ok": False, "why": ["chunk_missing"]})
+            continue
+        content, content_class = row
+        route = route_of(content_class)
+        why: list[str] = []
+        pointers = conn.execute(
+            "SELECT fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids WHERE chunk_id = ?",
+            (chunk_id,),
+        ).fetchone()
+        pointer_by_table = dict(
+            zip(("chunks_fts", "chunks_fts_trigram", "chunks_fts_operational"), pointers or (None, None, None))
+        )
+        for table, wanted_route in ROUTED_TABLES.items():
+            rows = conn.execute(f"SELECT id, c0 FROM {table}_content WHERE c6 = ?", (chunk_id,)).fetchall()
+            if wanted_route == route:
+                if len(rows) != 1:
+                    why.append(f"{table}:expected_1_row_got_{len(rows)}")
+                    continue
+                rowid, indexed = rows[0]
+                if indexed != content:
+                    why.append(f"{table}:indexed_text_differs_from_chunk_content")
+                if pointer_by_table.get(table) != rowid:
+                    why.append(f"{table}:pointer_does_not_resolve_to_this_row")
+            elif rows:
+                why.append(f"{table}:present_but_class_routes_to_{route}")
+        checks.append({"chunk_id": chunk_id, "route": route, "ok": not why, "why": why})
+    return checks
+
+
+def repair_index_completeness(
+    db_path: Path,
+    *,
+    git_sha: str,
+    apply: bool = False,
+    allow_live: bool = False,
+    batch_size: int = 500,
+    checkpoint_every: int = 3,
+    spot_check: int = 0,
+    delete_orphans: bool = True,
+    actor: str = "repair-f",
+) -> RepairResult:
+    """Rebuild missing/duplicated/misrouted FTS rows and realign pointers.
+
+    Never embeds, never writes `chunks`, never writes a vec0 table.
+    """
+    resolved = assert_not_live_db(Path(db_path), allow_live=allow_live)
+    conn = sqlite3.connect(resolved, timeout=60)
+    # Autocommit: this migration opens every write transaction by hand
+    # (BEGIN IMMEDIATE / COMMIT per batch), and the driver's implicit
+    # transaction would otherwise still be open from the census's TEMP writes.
+    conn.isolation_level = None
+    conn.execute("PRAGMA foreign_keys = OFF")
+    try:
+        before = census(conn, verify_vector_payload=True)
+        result = RepairResult(apply=apply, census_before=before.summary(), census_after=None)
+        result.vector_debt = {
+            "missing_vector_rowid": len(before.missing_vector_rowid),
+            "missing_binary_vector": len(before.missing_binary_vector),
+            "phantom_vectors": len(before.phantom_vectors),
+            "owner": "brainlayer reembed-backfill",
+            "note": (
+                "this migration never embeds; a missing vector is work for the embed "
+                "pipeline, which finds these rows by the same LEFT JOIN"
+            ),
+            "sample": before.missing_vector_rowid[:10],
+            "phantom_sample": before.phantom_vectors[:10],
+        }
+
+        # Chunks needing lexical work, and what to do with each.
+        work: dict[str, dict[str, list[int] | None]] = {}
+        for table, ids in before.missing_index_rows.items():
+            for chunk_id in ids:
+                work.setdefault(chunk_id, {}).setdefault(table, None)
+        for table, ids in before.duplicate_index_rows.items():
+            for chunk_id in ids:
+                work.setdefault(chunk_id, {}).setdefault(table, None)
+        for table, ids in before.misrouted_index_rows.items():
+            for chunk_id in ids:
+                work.setdefault(chunk_id, {}).setdefault(table, None)
+        for table, ids in before.dangling_pointers.items():
+            for chunk_id in ids:
+                work.setdefault(chunk_id, {}).setdefault(table, None)
+        for table, ids in before.mismatched_pointers.items():
+            for chunk_id in ids:
+                work.setdefault(chunk_id, {}).setdefault(table, None)
+
+        result.chunks_touched = len(work)
+        if not apply:
+            result.census_after = before.summary()
+            return result
+
+        _ensure_preimage(conn)
+        touched: list[str] = sorted(work)
+        # One scan per FTS table to find the touched chunks' existing rows.
+        # `c6` (chunk_id) carries no index, so asking per chunk would be one
+        # full scan of a multi-GB content table per chunk.
+        existing_rows, next_rowid = _existing_index_rows(conn, touched)
+        for index, start in enumerate(range(0, len(touched), batch_size), start=1):
+            batch = touched[start : start + batch_size]
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                for chunk_id in batch:
+                    row = conn.execute("SELECT content_class FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+                    if row is None:
+                        continue
+                    route = route_of(row[0])
+                    payload = _chunk_payload(conn, chunk_id)
+                    pointer_updates: dict[str, int | None] = {}
+                    for table, wanted_route in ROUTED_TABLES.items():
+                        if table not in next_rowid:
+                            continue
+                        existing = sorted(existing_rows.get(table, {}).get(chunk_id, ()))
+                        if wanted_route == route and payload is not None and payload[0]:
+                            # Rebuild to exactly one row carrying current content.
+                            for rowid in existing:
+                                if _delete_index_row(conn, table, rowid, chunk_id, "rebuild"):
+                                    result.deleted_rows += 1
+                            new_rowid = next_rowid[table]
+                            next_rowid[table] += 1
+                            _insert_index_row(conn, table, payload, chunk_id, new_rowid)
+                            result.inserted_rows += 1
+                            pointer_updates[POINTER_COLUMN[table]] = new_rowid
+                        else:
+                            # Wrong index for this class: drop the leaked rows.
+                            for rowid in existing:
+                                if _delete_index_row(conn, table, rowid, chunk_id, "misroute"):
+                                    result.deleted_rows += 1
+                            pointer_updates[POINTER_COLUMN[table]] = None
+                    if _rewrite_pointer(conn, chunk_id, pointer_updates):
+                        result.pointers_rewritten += 1
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+            result.batches = index
+            if checkpoint_every and index % checkpoint_every == 0:
+                _checkpoint(conn)
+
+        # Orphan aux rows: index rows and pointers whose chunk is gone. These
+        # are index entries, never chunk data, and the absence is re-verified
+        # inside the transaction before anything is removed.
+        if delete_orphans:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                for table, rowids in before.orphan_index_rows.items():
+                    for rowid in rowids:
+                        found = conn.execute(f"SELECT c6 FROM {table}_content WHERE id = ?", (rowid,)).fetchone()
+                        if found is None:
+                            continue
+                        chunk_id = str(found[0])
+                        still_gone = conn.execute("SELECT 1 FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+                        if still_gone is not None:
+                            continue
+                        if _delete_index_row(conn, table, rowid, chunk_id, "orphan"):
+                            result.orphans_deleted += 1
+                for chunk_id in before.orphan_pointer_rows:
+                    if conn.execute("SELECT 1 FROM chunks WHERE id = ?", (chunk_id,)).fetchone() is not None:
+                        continue
+                    row = conn.execute(
+                        "SELECT fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids WHERE chunk_id = ?",
+                        (chunk_id,),
+                    ).fetchone()
+                    conn.execute(
+                        f"INSERT INTO {PREIMAGE_TABLE}(chunk_id, table_name, action, rowid_value, payload) "
+                        "VALUES (?,?,?,?,?)",
+                        (chunk_id, "chunk_fts_rowids", "orphan_pointer", None, json.dumps(list(row) if row else None)),
+                    )
+                    conn.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = ?", (chunk_id,))
+                    result.orphans_deleted += 1
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+
+        _record_migration(
+            conn,
+            git_sha=git_sha,
+            actor=actor,
+            payload={
+                "inserted_rows": result.inserted_rows,
+                "deleted_rows": result.deleted_rows,
+                "pointers_rewritten": result.pointers_rewritten,
+                "orphans_deleted": result.orphans_deleted,
+            },
+        )
+        conn.commit()
+        _checkpoint(conn)
+
+        after = census(conn, verify_vector_payload=True)
+        result.census_after = after.summary()
+        if spot_check and touched:
+            step = max(1, len(touched) // spot_check)
+            sample = touched[::step][:spot_check]
+            result.spot_checks = _spot_check(conn, sample)
+        return result
+    finally:
+        conn.close()
+
+
+def rollback_repair(db_path: Path, *, allow_live: bool = False) -> dict[str, Any]:
+    """Undo the lexical repair from its preimages, newest write first.
+
+    Inserted rows are deleted; deleted rows are re-inserted with their recorded
+    text; pointer rows are restored to their recorded triple. The preimage table
+    is retained afterwards as the audit trail (repair-b/d/e precedent).
+    """
+    resolved = assert_not_live_db(Path(db_path), allow_live=allow_live)
+    conn = sqlite3.connect(resolved, timeout=60)
+    stats = {"restored_rows": 0, "removed_rows": 0, "restored_pointers": 0, "preimage_tables": "retained"}
+    try:
+        if PREIMAGE_TABLE not in _table_names(conn):
+            return {**stats, "preimage": "absent"}
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            rows = conn.execute(
+                f"SELECT seq, chunk_id, table_name, action, rowid_value, payload FROM {PREIMAGE_TABLE} ORDER BY seq DESC"
+            ).fetchall()
+            for _seq, chunk_id, table, action, rowid_value, payload in rows:
+                if action == "insert":
+                    found = conn.execute(f"SELECT c6 FROM {table}_content WHERE id = ?", (rowid_value,)).fetchone()
+                    if found is not None and str(found[0]) == chunk_id:
+                        conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid_value,))
+                        stats["removed_rows"] += 1
+                elif action in {"rebuild", "misroute", "orphan"}:
+                    # Restore at the ORIGINAL rowid, not wherever FTS5 would put
+                    # a fresh row. The pointer preimages restore the old rowid
+                    # numbers, so a row that comes back at a different rowid
+                    # leaves every restored pointer dangling -- a rollback that
+                    # reports success while breaking what it claimed to fix.
+                    values = json.loads(payload)
+                    columns = ", ".join(("rowid", *FTS_INSERT_COLUMNS))
+                    marks = ", ".join("?" for _ in range(len(FTS_INSERT_COLUMNS) + 1))
+                    conn.execute(f"INSERT INTO {table}({columns}) VALUES ({marks})", [rowid_value, *values])
+                    stats["restored_rows"] += 1
+                elif action == "pointer":
+                    before = json.loads(payload).get("before")
+                    if before is None:
+                        conn.execute("DELETE FROM chunk_fts_rowids WHERE chunk_id = ?", (chunk_id,))
+                    else:
+                        conn.execute(
+                            """
+                            INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid, trigram_rowid, operational_rowid)
+                            VALUES (?,?,?,?)
+                            ON CONFLICT(chunk_id) DO UPDATE SET
+                                fts_rowid = excluded.fts_rowid,
+                                trigram_rowid = excluded.trigram_rowid,
+                                operational_rowid = excluded.operational_rowid
+                            """,
+                            (chunk_id, *before),
+                        )
+                    stats["restored_pointers"] += 1
+                elif action == "orphan_pointer":
+                    before = json.loads(payload)
+                    if before:
+                        conn.execute(
+                            "INSERT OR REPLACE INTO chunk_fts_rowids"
+                            "(chunk_id, fts_rowid, trigram_rowid, operational_rowid) VALUES (?,?,?,?)",
+                            (chunk_id, *before),
+                        )
+                        stats["restored_pointers"] += 1
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        return stats
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Repair (f) FTS/vector completeness. Default is dry-run. Requires --db; "
+            "refuses the live canonical DB unless --allow-live. Never embeds, never "
+            "writes the chunks table."
+        )
+    )
+    parser.add_argument("--db", type=Path, required=True, help="Rehearsal copy DB path (required)")
+    parser.add_argument("--apply", action="store_true", help="Write the lexical repairs")
+    parser.add_argument("--allow-live", action="store_true")
+    parser.add_argument("--git-sha", dest="git_sha")
+    parser.add_argument("--batch-size", type=int, default=500)
+    parser.add_argument("--checkpoint-every", type=int, default=3)
+    parser.add_argument("--spot-check", type=int, default=0)
+    parser.add_argument("--keep-orphans", action="store_true", help="Do not delete orphan aux index rows")
+    parser.add_argument("--actor", default="repair-f")
+    parser.add_argument("--rollback", action="store_true")
+    parser.add_argument("--census-only", action="store_true", help="Print the census and exit")
+    args = parser.parse_args(argv)
+
+    if args.rollback:
+        print(json.dumps(rollback_repair(args.db.expanduser(), allow_live=args.allow_live), sort_keys=True))
+        return 0
+
+    if args.census_only:
+        conn = sqlite3.connect(f"file:{args.db.expanduser()}?mode=ro", uri=True)
+        try:
+            print(json.dumps(census(conn, verify_vector_payload=True).summary(), indent=2, sort_keys=True))
+        finally:
+            conn.close()
+        return 0
+
+    git_sha = args.git_sha or _detect_git_sha()
+    if not git_sha:
+        parser.error("--git-sha is required (40-char hex) when HEAD is not a full SHA")
+    result = repair_index_completeness(
+        args.db.expanduser(),
+        git_sha=git_sha,
+        apply=args.apply,
+        allow_live=args.allow_live,
+        batch_size=args.batch_size,
+        checkpoint_every=args.checkpoint_every,
+        spot_check=args.spot_check,
+        delete_orphans=not args.keep_orphans,
+        actor=args.actor,
+    )
+    print(
+        json.dumps(
+            {
+                "apply": result.apply,
+                "chunks_touched": result.chunks_touched,
+                "inserted_rows": result.inserted_rows,
+                "deleted_rows": result.deleted_rows,
+                "pointers_rewritten": result.pointers_rewritten,
+                "orphans_deleted": result.orphans_deleted,
+                "batches": result.batches,
+                "vector_debt": result.vector_debt,
+                "census_before": result.census_before,
+                "census_after": result.census_after,
+                "spot_checks": result.spot_checks,
+            },
+            sort_keys=True,
+        )
+    )
+    if result.apply and result.spot_checks and not all(check["ok"] for check in result.spot_checks):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1794,9 +1794,7 @@ def _doctor_db_with_index_gap(path: Path, *, direction: str) -> None:
         _insert_vector(store, "completeness-2", 2.0)
         cursor = store.conn.cursor()
         if direction == "chunk_to_aux":
-            rowid = cursor.execute(
-                "SELECT id FROM chunks_fts_content WHERE c6 = 'completeness-1'"
-            ).fetchone()[0]
+            rowid = cursor.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'completeness-1'").fetchone()[0]
             cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (rowid,))
             # counterweight so COUNT(chunks) == COUNT(chunks_fts) still holds
             cursor.execute(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1868,3 +1868,39 @@ def test_doctor_index_completeness_is_quiet_on_a_healthy_db(tmp_path):
     assert result.index_completeness["total"] == 0
     codes = {issue.code for issue in result.issues}
     assert not {code for code in codes if code.startswith("index_completeness")}
+
+
+def test_doctor_index_completeness_does_not_fatal_on_ordinary_embed_lag(tmp_path):
+    """A chunk waiting on the embed queue must not make the completeness gate red.
+
+    Ordinary embed lag is never zero on a live DB, so folding it into this gate
+    would make "both completeness codes silent" an exit criterion no repair run
+    could satisfy. Missing vectors have their own check and their own owner.
+    """
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "completeness-embed-lag.db"
+    store = VectorStore(db_path)
+    try:
+        _insert_chunk(store, "lag-vectored", content="doctor completeness vectored content")
+        _insert_vector(store, "lag-vectored", 1.0)
+        # indexed lexically by the write path, but no vector yet
+        _insert_chunk(store, "lag-unvectored", content="doctor completeness unvectored content")
+        store.conn.cursor().execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        store.close()
+
+    result = run_doctor(
+        _doctor_config(tmp_path, db_path),
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.index_completeness["chunk_to_aux"]["missing_vector_rowid"] == 1
+    assert result.index_completeness["lexical_total"] == 0
+    codes = {issue.code for issue in result.issues}
+    assert "index_completeness_chunk_to_aux" not in codes
+    assert "index_completeness_aux_to_chunk" not in codes
+    # the pre-existing vector check still owns this signal
+    assert "vector_parity_gap" in codes

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1779,3 +1779,94 @@ def test_doctor_cli_json_uses_injected_runner_and_db_option(tmp_path, monkeypatc
     payload = json.loads(result.output)
     assert payload["ok"] is True
     assert payload["db_path"] == str(db_path)
+
+
+# ── repair (f): index completeness, both directions ──────────────────────────
+
+
+def _doctor_db_with_index_gap(path: Path, *, direction: str) -> None:
+    """Build a doctor fixture whose aux/chunk sets diverge without the counts diverging."""
+    store = VectorStore(path)
+    try:
+        _insert_chunk(store, "completeness-1", content="doctor completeness alpha content")
+        _insert_chunk(store, "completeness-2", content="doctor completeness beta content")
+        _insert_vector(store, "completeness-1", 1.0)
+        _insert_vector(store, "completeness-2", 2.0)
+        cursor = store.conn.cursor()
+        if direction == "chunk_to_aux":
+            rowid = cursor.execute(
+                "SELECT id FROM chunks_fts_content WHERE c6 = 'completeness-1'"
+            ).fetchone()[0]
+            cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (rowid,))
+            # counterweight so COUNT(chunks) == COUNT(chunks_fts) still holds
+            cursor.execute(
+                "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, "
+                "resolved_queries, chunk_id) VALUES ('doctor completeness beta content', NULL, "
+                "NULL, NULL, NULL, NULL, 'completeness-2')"
+            )
+        elif direction == "aux_to_chunk":
+            cursor.execute(
+                "INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid) VALUES ('completeness-gone', 8675309) "
+                "ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid"
+            )
+        cursor.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        store.close()
+
+
+def test_doctor_index_completeness_catches_a_gap_counts_cannot_see(tmp_path):
+    """3,536 chunks went unfindable while fts5_health called the index synced."""
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "completeness-chunk-to-aux.db"
+    _doctor_db_with_index_gap(db_path, direction="chunk_to_aux")
+
+    result = run_doctor(
+        _doctor_config(tmp_path, db_path),
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    codes = {issue.code for issue in result.issues if issue.severity == "fatal"}
+    assert "index_completeness_chunk_to_aux" in codes
+    assert result.index_completeness["chunk_to_aux"]["missing_index_rows"]["chunks_fts"] == 1
+    assert result.index_completeness["chunk_to_aux"]["duplicate_index_rows"]["chunks_fts"] == 1
+    assert result.exit_code != 0
+
+
+def test_doctor_index_completeness_catches_the_reverse_direction(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "completeness-aux-to-chunk.db"
+    _doctor_db_with_index_gap(db_path, direction="aux_to_chunk")
+
+    result = run_doctor(
+        _doctor_config(tmp_path, db_path),
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    codes = {issue.code for issue in result.issues if issue.severity == "fatal"}
+    assert "index_completeness_aux_to_chunk" in codes
+    assert result.index_completeness["aux_to_chunk"]["orphan_pointer_rows"] == 1
+    assert result.index_completeness["aux_to_chunk"]["dangling_pointers"]["chunks_fts"] == 1
+
+
+def test_doctor_index_completeness_is_quiet_on_a_healthy_db(tmp_path):
+    from brainlayer.doctor import run_doctor
+
+    db_path = tmp_path / "completeness-healthy.db"
+    _build_db(db_path)
+
+    result = run_doctor(
+        _doctor_config(tmp_path, db_path),
+        ps_output_fn=_hotlane_ps,
+        command_runner=_loaded_launchctl,
+        now_fn=lambda: NOW,
+    )
+
+    assert result.index_completeness["total"] == 0
+    codes = {issue.code for issue in result.issues}
+    assert not {code for code in codes if code.startswith("index_completeness")}

--- a/tests/test_index_completeness.py
+++ b/tests/test_index_completeness.py
@@ -46,6 +46,22 @@ def _sqlite(store: VectorStore) -> sqlite3.Connection:
     return sqlite3.connect(store.db_path)
 
 
+def _fts_snapshot(store: VectorStore) -> dict[str, list[tuple]]:
+    """Rowid-level state of every lexical index plus the pointer table."""
+    conn = _sqlite(store)
+    try:
+        snapshot = {
+            table: sorted(conn.execute(f"SELECT id, c6, c0 FROM {table}_content"))
+            for table in ("chunks_fts", "chunks_fts_trigram", "chunks_fts_operational")
+        }
+        snapshot["pointers"] = sorted(
+            conn.execute("SELECT chunk_id, fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids")
+        )
+        return snapshot
+    finally:
+        conn.close()
+
+
 # ── the write path must produce lexical rows synchronously ───────────────────
 
 
@@ -321,7 +337,10 @@ def test_repair_skips_a_row_that_changed_owner_under_it(store: VectorStore):
     try:
         rowid = conn.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'victim'").fetchone()[0]
         index_completeness._ensure_preimage(conn)
-        assert index_completeness._delete_index_row(conn, "chunks_fts", rowid, "someone-else", "rebuild") is False
+        assert (
+            index_completeness._delete_index_row(conn, "chunks_fts", rowid, "someone-else", "rebuild", "run-test")
+            is False
+        )
         assert conn.execute("SELECT COUNT(*) FROM chunks_fts_content WHERE c6 = 'victim'").fetchone()[0] == 1
     finally:
         conn.close()
@@ -360,6 +379,7 @@ def test_rollback_restores_rows_at_their_original_rowids(store: VectorStore):
     Restoring the text at a fresh rowid looks identical by content and by count,
     and leaves every restored pointer dangling.
     """
+
     def snapshot() -> tuple[dict[str, list[tuple]], int]:
         conn = _sqlite(store)
         try:
@@ -422,6 +442,75 @@ def test_repair_receipt_survives_a_rerun(store: VectorStore):
     repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
     again = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
     assert again.census_after["lexical_total"] == 0
+
+
+def test_repair_leaves_lifecycle_rows_the_census_did_not_report(store: VectorStore):
+    """A migration must not delete more than its census reported.
+
+    The misroute check is scoped to active chunks. An archived chunk whose class
+    routes elsewhere is therefore never reported -- and must not be silently
+    unindexed just because a pointer defect pulled it into the work set.
+    """
+    _add(store, "retired", content="retired but still indexed")
+    cursor = store.conn.cursor()
+    cursor.execute("UPDATE chunks SET content_class = 'cold' WHERE id = 'retired'")
+    cursor.execute("UPDATE chunks SET archived_at = '2026-01-01T00:00:00Z' WHERE id = 'retired'")
+    # put a row back in the knowledge index and aim a broken pointer at nothing
+    cursor.execute(
+        "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id) "
+        "VALUES ('retired but still indexed', NULL, NULL, NULL, NULL, NULL, 'retired')"
+    )
+    cursor.execute(
+        "INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid) VALUES ('retired', 987654) "
+        "ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid"
+    )
+
+    conn = _sqlite(store)
+    try:
+        reported = census(conn)
+    finally:
+        conn.close()
+    assert "retired" not in reported.misrouted_index_rows.get("chunks_fts", [])
+    assert "retired" in reported.dangling_pointers["chunks_fts"]
+
+    repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+
+    conn = _sqlite(store)
+    try:
+        rows = conn.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'retired'").fetchall()
+        pointer = conn.execute("SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = 'retired'").fetchone()[0]
+    finally:
+        conn.close()
+    assert len(rows) == 1, "the unreported row must survive"
+    assert pointer == rows[0][0], "and the pointer must resolve to it"
+
+
+def test_apply_rollback_apply_rollback_cycle(store: VectorStore):
+    """Preimages accumulate, so rollback must be scoped to ONE run.
+
+    Replaying the whole table on the second rollback tries to undo an apply that
+    was already undone and dies on a rowid collision -- which is how this was
+    found, on the canonical-size copy.
+    """
+    _damage(store)
+    snapshot = _fts_snapshot(store)
+
+    first = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    rollback_repair(store.db_path)
+    assert _fts_snapshot(store) == snapshot
+
+    second = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    assert second.run_id != first.run_id
+    stats = rollback_repair(store.db_path)
+    assert stats["run_id"] == second.run_id
+    assert _fts_snapshot(store) == snapshot, "the second rollback must land on the same state"
+
+    # Both runs are now reversed, so a further rollback is a no-op rather than a
+    # replay of an apply that was already undone.
+    third = rollback_repair(store.db_path)
+    assert third["run_id"] is None
+    assert third["restored_rows"] == 0 and third["removed_rows"] == 0
+    assert _fts_snapshot(store) == snapshot
 
 
 def test_repair_refuses_the_live_db(tmp_path: Path, monkeypatch):

--- a/tests/test_index_completeness.py
+++ b/tests/test_index_completeness.py
@@ -513,6 +513,36 @@ def test_apply_rollback_apply_rollback_cycle(store: VectorStore):
     assert _fts_snapshot(store) == snapshot
 
 
+def test_repair_converges_to_zero_on_a_lifecycle_duplicate(store: VectorStore):
+    """Everything the census reports must be repairable, or it never reaches zero.
+
+    An archived chunk whose class routes elsewhere keeps its row (the misroute
+    check does not cover it) -- but a *duplicate* is reported for every chunk,
+    so the surplus copy still has to go.
+    """
+    _add(store, "twin", content="twin content")
+    cursor = store.conn.cursor()
+    cursor.execute("UPDATE chunks SET content_class = 'cold' WHERE id = 'twin'")
+    cursor.execute("UPDATE chunks SET archived_at = '2026-01-01T00:00:00Z' WHERE id = 'twin'")
+    for _ in range(2):
+        cursor.execute(
+            "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id) "
+            "VALUES ('twin content', NULL, NULL, NULL, NULL, NULL, 'twin')"
+        )
+
+    result = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    assert result.census_after["lexical_total"] == 0, result.census_after
+
+    conn = _sqlite(store)
+    try:
+        rows = conn.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'twin'").fetchall()
+        pointer = conn.execute("SELECT fts_rowid FROM chunk_fts_rowids WHERE chunk_id = 'twin'").fetchone()[0]
+    finally:
+        conn.close()
+    assert len(rows) == 1, "the surplus copy goes, the chunk stays indexed"
+    assert pointer == rows[0][0]
+
+
 def test_repair_refuses_the_live_db(tmp_path: Path, monkeypatch):
     from brainlayer import chunk_origin_wipe
 

--- a/tests/test_index_completeness.py
+++ b/tests/test_index_completeness.py
@@ -1,0 +1,455 @@
+"""Repair (f): FTS/vector completeness census, repair, rollback, write-path guarantee."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from brainlayer.chunk_write import insert_canonical_chunk  # noqa: E402
+from brainlayer.index_completeness import (  # noqa: E402
+    PREIMAGE_TABLE,
+    census,
+    repair_index_completeness,
+    rollback_repair,
+    route_of,
+)
+from brainlayer.vector_store import VectorStore  # noqa: E402
+
+GIT_SHA = "0" * 40
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    instance = VectorStore(tmp_path / "completeness.db")
+    yield instance
+    instance.close()
+
+
+def _add(
+    store: VectorStore, chunk_id: str, *, content: str = "alpha beta gamma delta", content_class: str = "knowledge"
+) -> None:
+    cursor = store.conn.cursor()
+    insert_canonical_chunk(
+        cursor,
+        {"id": chunk_id, "content": content, "source": "test", "content_class": content_class},
+    )
+
+
+def _sqlite(store: VectorStore) -> sqlite3.Connection:
+    """A stdlib connection on the same file; the migration uses sqlite3, not apsw."""
+    return sqlite3.connect(store.db_path)
+
+
+# ── the write path must produce lexical rows synchronously ───────────────────
+
+
+@pytest.mark.parametrize(
+    "content_class,expected_tables",
+    [
+        ("knowledge", ("chunks_fts", "chunks_fts_trigram")),
+        ("decision", ("chunks_fts", "chunks_fts_trigram")),
+        (None, ("chunks_fts", "chunks_fts_trigram")),
+        ("operational", ("chunks_fts_operational",)),
+        ("test", ()),
+        ("cold", ()),
+        ("benchmark", ()),
+    ],
+)
+def test_canonical_insert_indexes_synchronously(store: VectorStore, content_class, expected_tables):
+    """A canonical insert leaves the routed FTS rows in place before it returns.
+
+    No queue, no catch-up job: if this ever regresses to asynchronous indexing,
+    a chunk is unfindable between the insert and whenever the catch-up runs.
+    """
+    chunk_id = f"c-{content_class or 'null'}"
+    _add(store, chunk_id, content="synchronous indexing guarantee", content_class=content_class)
+    cursor = store.conn.cursor()
+    for table in ("chunks_fts", "chunks_fts_trigram", "chunks_fts_operational"):
+        rows = cursor.execute(f"SELECT COUNT(*) FROM {table}_content WHERE c6 = ?", (chunk_id,)).fetchone()[0]
+        assert rows == (1 if table in expected_tables else 0), f"{table} rows for {content_class}"
+    pointer = cursor.execute(
+        "SELECT fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids WHERE chunk_id = ?",
+        (chunk_id,),
+    ).fetchone()
+    if expected_tables:
+        assert pointer is not None
+        for table, value in zip(("chunks_fts", "chunks_fts_trigram", "chunks_fts_operational"), pointer):
+            if table not in expected_tables:
+                continue
+            owner = cursor.execute(f"SELECT c6 FROM {table}_content WHERE id = ?", (value,)).fetchone()
+            assert owner is not None and owner[0] == chunk_id, f"{table} pointer must resolve to this chunk"
+
+
+def test_write_path_leaves_no_completeness_gap(store: VectorStore):
+    """Bulk inserts through the canonical writer produce a clean census.
+
+    This is the regression fence for the drift repair (f) cleans up: the census
+    that finds 3,536 missing rows on the historical DB must find zero on a DB
+    written only by today's write path.
+    """
+    for index in range(300):
+        _add(store, f"bulk-{index}", content=f"payload number {index} " + "lorem ipsum " * 20)
+    for index in range(20):
+        _add(store, f"ops-{index}", content=f"operational note {index}", content_class="operational")
+    store.conn.cursor().execute("UPDATE chunks SET content_class = 'operational' WHERE id = 'bulk-1'")
+    store.conn.cursor().execute("UPDATE chunks SET content = content || ' edited' WHERE id = 'bulk-2'")
+    store.conn.cursor().execute("UPDATE chunks SET summary = 'enriched' WHERE id = 'bulk-3'")
+
+    conn = _sqlite(store)
+    try:
+        result = census(conn)
+    finally:
+        conn.close()
+    assert result.missing_index_rows == {}
+    assert result.duplicate_index_rows == {}
+    assert result.misrouted_index_rows == {}
+    assert result.mismatched_pointers == {}
+    assert result.dangling_pointers == {}
+
+
+def test_vector_debt_lands_in_the_embed_queue(store: VectorStore):
+    """A chunk written without a vector is visible to the pipeline that owns embedding.
+
+    The migration never embeds, so the only thing that makes this safe is that
+    `reembed_backfill` finds the row by the same LEFT JOIN the census uses.
+    """
+    from brainlayer.reembed_backfill import count_unvectored_chunks, fetch_unvectored_batch
+
+    _add(store, "unvectored-1", content="needs an embedding")
+    conn = _sqlite(store)
+    try:
+        gap = census(conn)
+    finally:
+        conn.close()
+    assert "unvectored-1" in gap.missing_vector_rowid
+    assert count_unvectored_chunks(store) >= 1
+    assert any(pending.chunk_id == "unvectored-1" for pending in fetch_unvectored_batch(store, batch_size=50))
+
+
+def test_route_of_matches_the_trigger_predicates():
+    """The migration's routing law is the write path's routing law."""
+    from brainlayer import vector_store as vector_store_module
+
+    source = Path(vector_store_module.__file__).read_text()
+    assert "NOT IN ('operational', 'test', 'benchmark', 'cold')" in source
+    assert route_of("operational") == "operational"
+    for cls in ("test", "benchmark", "cold"):
+        assert route_of(cls) == "none"
+    for cls in (None, "knowledge", "decision", "anything-else"):
+        assert route_of(cls) == "knowledge"
+
+
+# ── census sees both directions ──────────────────────────────────────────────
+
+
+def test_census_finds_a_missing_row_that_counts_hide(store: VectorStore):
+    """A surplus row must not mask a missing one -- the #722 lesson, in a test."""
+    _add(store, "present", content="findable text")
+    _add(store, "vanished", content="unfindable text")
+    cursor = store.conn.cursor()
+    rowid = cursor.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'vanished'").fetchone()[0]
+    cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (rowid,))
+    # counterweight: a duplicate row for the other chunk, so COUNT(*) balances
+    cursor.execute(
+        "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id) "
+        "VALUES ('findable text', NULL, NULL, NULL, NULL, NULL, 'present')"
+    )
+    knowledge_chunks = cursor.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    fts_rows = cursor.execute("SELECT COUNT(*) FROM chunks_fts_content").fetchone()[0]
+    assert knowledge_chunks == fts_rows, "counts agree, which is exactly why counts are not enough"
+
+    conn = _sqlite(store)
+    try:
+        result = census(conn)
+    finally:
+        conn.close()
+    assert result.missing_index_rows["chunks_fts"] == ["vanished"]
+    assert result.duplicate_index_rows["chunks_fts"] == ["present"]
+
+
+def test_census_finds_orphans_and_bad_pointers(store: VectorStore):
+    _add(store, "alive", content="alive text")
+    _add(store, "doomed", content="doomed text")
+    cursor = store.conn.cursor()
+    doomed_rowid = cursor.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'doomed'").fetchone()[0]
+    # orphan the index row without firing the delete trigger
+    cursor.execute("DROP TRIGGER chunks_fts_delete")
+    cursor.execute("DROP TRIGGER chunks_fts_trigram_delete")
+    cursor.execute("DELETE FROM chunks WHERE id = 'doomed'")
+    # aim alive's pointer at the orphan row, and add a dangling pointer
+    cursor.execute("UPDATE chunk_fts_rowids SET fts_rowid = ? WHERE chunk_id = 'alive'", (doomed_rowid,))
+    cursor.execute(
+        "INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid) VALUES ('ghost', 999999) "
+        "ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid"
+    )
+
+    conn = _sqlite(store)
+    try:
+        result = census(conn)
+    finally:
+        conn.close()
+    assert result.orphan_index_rows["chunks_fts"] == [doomed_rowid]
+    assert result.mismatched_pointers["chunks_fts"] == ["alive"]
+    assert result.dangling_pointers["chunks_fts"] == ["ghost"]
+    assert result.orphan_pointer_rows == ["doomed", "ghost"]  # doomed's own pointer is orphaned too
+    assert result.aux_to_chunk_total >= 4
+
+
+def test_census_flags_a_misrouted_row(store: VectorStore):
+    _add(store, "leaky", content="operational content", content_class="knowledge")
+    store.conn.cursor().execute("UPDATE chunks SET content_class = 'test' WHERE id = 'leaky'")
+    store.conn.cursor().execute(
+        "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id) "
+        "VALUES ('operational content', NULL, NULL, NULL, NULL, NULL, 'leaky')"
+    )
+    conn = _sqlite(store)
+    try:
+        result = census(conn)
+    finally:
+        conn.close()
+    assert "leaky" in result.misrouted_index_rows["chunks_fts"]
+
+
+# ── repair ───────────────────────────────────────────────────────────────────
+
+
+def _damage(store: VectorStore) -> None:
+    cursor = store.conn.cursor()
+    _add(store, "gap", content="gap chunk content")
+    _add(store, "dupe", content="dupe chunk content")
+    _add(store, "leak", content="leak chunk content")
+    _add(store, "clean", content="clean chunk content")
+    rowid = cursor.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'gap'").fetchone()[0]
+    cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (rowid,))
+    cursor.execute(
+        "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id) "
+        "VALUES ('stale dupe text', NULL, NULL, NULL, NULL, NULL, 'dupe')"
+    )
+    cursor.execute("UPDATE chunks SET content_class = 'cold' WHERE id = 'leak'")
+
+
+def test_dry_run_writes_nothing(store: VectorStore, tmp_path: Path):
+    _damage(store)
+    conn = _sqlite(store)
+    try:
+        before = census(conn).summary()
+    finally:
+        conn.close()
+    result = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=False)
+    assert result.apply is False
+    assert result.inserted_rows == 0 and result.deleted_rows == 0
+    conn = _sqlite(store)
+    try:
+        assert census(conn).summary() == before
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert PREIMAGE_TABLE not in tables
+    finally:
+        conn.close()
+
+
+def test_repair_closes_every_gap_and_spot_checks_values(store: VectorStore):
+    _damage(store)
+    result = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True, spot_check=4)
+    assert result.census_after["lexical_total"] == 0, result.census_after
+    # the residue is vector debt, which a migration must never close by embedding
+    assert result.census_after["vector_total"] == result.census_before["vector_total"]
+    assert result.spot_checks and all(check["ok"] for check in result.spot_checks)
+
+    conn = _sqlite(store)
+    try:
+        # VALUE check, not a count: the repaired row carries the chunk's own text
+        indexed = conn.execute("SELECT c0 FROM chunks_fts_content WHERE c6 = 'gap'").fetchone()[0]
+        content = conn.execute("SELECT content FROM chunks WHERE id = 'gap'").fetchone()[0]
+        assert indexed == content
+        assert conn.execute("SELECT COUNT(*) FROM chunks_fts_content WHERE c6 = 'dupe'").fetchone()[0] == 1
+        stale = conn.execute(
+            "SELECT COUNT(*) FROM chunks_fts_content WHERE c6 = 'dupe' AND c0 = 'stale dupe text'"
+        ).fetchone()[0]
+        assert stale == 0, "the stale duplicate text must be gone, not merely deduplicated by count"
+        assert conn.execute("SELECT COUNT(*) FROM chunks_fts_content WHERE c6 = 'leak'").fetchone()[0] == 0
+        # the migration never touches chunk data
+        assert conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 4
+    finally:
+        conn.close()
+
+
+def test_repair_makes_the_chunk_findable_by_a_real_query(store: VectorStore):
+    """Serving proof: the repaired chunk comes back from an actual MATCH."""
+    _add(store, "hidden", content="quokka telemetry manifest")
+    cursor = store.conn.cursor()
+    rowid = cursor.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'hidden'").fetchone()[0]
+    cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (rowid,))
+    assert cursor.execute("SELECT COUNT(*) FROM chunks_fts WHERE chunks_fts MATCH 'quokka'").fetchone()[0] == 0
+
+    repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+
+    conn = _sqlite(store)
+    try:
+        hits = conn.execute("SELECT chunk_id FROM chunks_fts WHERE chunks_fts MATCH 'quokka'").fetchall()
+    finally:
+        conn.close()
+    assert [row[0] for row in hits] == ["hidden"]
+
+
+def test_repair_never_embeds_and_reports_vector_debt(store: VectorStore):
+    _add(store, "novec", content="no vector for this one")
+    result = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    assert result.vector_debt["missing_vector_rowid"] >= 1
+    assert result.vector_debt["owner"] == "brainlayer reembed-backfill"
+    conn = _sqlite(store)
+    try:
+        # the migration wrote no vector rows of its own
+        assert conn.execute("SELECT COUNT(*) FROM chunk_vectors_rowids").fetchone()[0] == 0
+        actions = {row[0] for row in conn.execute(f"SELECT DISTINCT table_name FROM {PREIMAGE_TABLE}")}
+    finally:
+        conn.close()
+    assert not any(name.startswith("chunk_vectors") for name in actions)
+
+
+def test_repair_skips_a_row_that_changed_owner_under_it(store: VectorStore):
+    """A rowid recorded by the census is re-verified before any delete."""
+    from brainlayer import index_completeness
+
+    _add(store, "victim", content="victim content")
+    conn = _sqlite(store)
+    try:
+        rowid = conn.execute("SELECT id FROM chunks_fts_content WHERE c6 = 'victim'").fetchone()[0]
+        index_completeness._ensure_preimage(conn)
+        assert index_completeness._delete_index_row(conn, "chunks_fts", rowid, "someone-else", "rebuild") is False
+        assert conn.execute("SELECT COUNT(*) FROM chunks_fts_content WHERE c6 = 'victim'").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_rollback_restores_the_previous_index_state(store: VectorStore):
+    _damage(store)
+    conn = _sqlite(store)
+    try:
+        before = sorted((str(row[0]), str(row[1])) for row in conn.execute("SELECT c6, c0 FROM chunks_fts_content"))
+        pointers_before = sorted(
+            conn.execute("SELECT chunk_id, fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids")
+        )
+    finally:
+        conn.close()
+
+    repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    stats = rollback_repair(store.db_path)
+    assert stats["restored_rows"] > 0 and stats["removed_rows"] > 0
+
+    conn = _sqlite(store)
+    try:
+        after = sorted((str(row[0]), str(row[1])) for row in conn.execute("SELECT c6, c0 FROM chunks_fts_content"))
+        pointers_after = sorted(
+            conn.execute("SELECT chunk_id, fts_rowid, trigram_rowid, operational_rowid FROM chunk_fts_rowids")
+        )
+    finally:
+        conn.close()
+    assert after == before, "rollback restores indexed VALUES, not just row counts"
+    assert pointers_after == pointers_before
+
+
+def test_rollback_restores_rows_at_their_original_rowids(store: VectorStore):
+    """A restored pointer must still resolve; that requires the original rowid back.
+
+    Restoring the text at a fresh rowid looks identical by content and by count,
+    and leaves every restored pointer dangling.
+    """
+    def snapshot() -> tuple[dict[str, list[tuple]], int]:
+        conn = _sqlite(store)
+        try:
+            rows = {
+                table: sorted(conn.execute(f"SELECT id, c6 FROM {table}_content"))
+                for table in ("chunks_fts", "chunks_fts_trigram", "chunks_fts_operational")
+            }
+            dangling = conn.execute(
+                """
+                SELECT COUNT(*) FROM chunk_fts_rowids p
+                WHERE p.fts_rowid IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM chunks_fts_content c WHERE c.id = p.fts_rowid)
+                """
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        return rows, dangling
+
+    _damage(store)
+    before_rows, before_dangling = snapshot()
+
+    repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    _, repaired_dangling = snapshot()
+    assert repaired_dangling == 0, "the repair itself must leave no dangling pointer"
+
+    rollback_repair(store.db_path)
+    after_rows, after_dangling = snapshot()
+
+    assert after_rows == before_rows, "every row must come back at the rowid it had"
+    # The pre-state's own dangling pointer is part of the damage and must come
+    # back too: a rollback restores the previous state, not a better one.
+    assert after_dangling == before_dangling
+
+
+def test_migration_receipt_carries_the_commit(store: VectorStore):
+    """The canonical schema_migrations has no git_sha column, so details must carry it."""
+    from brainlayer.index_completeness import MIGRATION_NAME
+
+    _damage(store)
+    sha = "a" * 40
+    repair_index_completeness(store.db_path, git_sha=sha, apply=True, actor="repair-f-test")
+
+    conn = _sqlite(store)
+    try:
+        row = conn.execute(
+            "SELECT applied_at, details FROM schema_migrations WHERE name = ?", (MIGRATION_NAME,)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, "an applied migration must leave a receipt"
+    details = json.loads(row[1])
+    assert details["git_sha"] == sha
+    assert details["actor"] == "repair-f-test"
+    assert details["inserted_rows"] > 0
+
+
+def test_repair_receipt_survives_a_rerun(store: VectorStore):
+    """`name` is the primary key; a second run updates the receipt, never aborts."""
+    _damage(store)
+    repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    again = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    assert again.census_after["lexical_total"] == 0
+
+
+def test_repair_refuses_the_live_db(tmp_path: Path, monkeypatch):
+    from brainlayer import chunk_origin_wipe
+
+    live = tmp_path / "brainlayer.db"
+    sqlite3.connect(live).close()
+    monkeypatch.setattr(chunk_origin_wipe, "_live_db_candidates", lambda: (live,))
+    with pytest.raises(RuntimeError, match="refusing to write the live"):
+        repair_index_completeness(live, git_sha=GIT_SHA, apply=True)
+
+
+def test_orphan_deletes_only_index_rows(store: VectorStore):
+    _add(store, "ghosted", content="ghosted content")
+    cursor = store.conn.cursor()
+    cursor.execute("DROP TRIGGER chunks_fts_delete")
+    cursor.execute("DROP TRIGGER chunks_fts_trigram_delete")
+    cursor.execute("DELETE FROM chunks WHERE id = 'ghosted'")
+    _add(store, "kept", content="kept content")
+
+    result = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    assert result.orphans_deleted >= 1
+
+    conn = _sqlite(store)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM chunks_fts_content WHERE c6 = 'ghosted'").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM chunks WHERE id = 'kept'").fetchone()[0] == 1
+        payloads = conn.execute(f"SELECT payload FROM {PREIMAGE_TABLE} WHERE action = 'orphan'").fetchall()
+    finally:
+        conn.close()
+    assert payloads and json.loads(payloads[0][0])[6] == "ghosted", "orphan deletes are preimaged"

--- a/tests/test_index_completeness.py
+++ b/tests/test_index_completeness.py
@@ -513,6 +513,61 @@ def test_apply_rollback_apply_rollback_cycle(store: VectorStore):
     assert _fts_snapshot(store) == snapshot
 
 
+def test_spot_check_passes_a_lifecycle_row_the_repair_keeps_on_purpose(store: VectorStore):
+    """The success gate must not fail the migration's own correct behaviour.
+
+    A lifecycle-managed chunk in an index its class does not route to is KEPT by
+    design (the census never reported it). If `--spot-check` calls that a
+    failure, `main()` exits non-zero and a live operator reads a good run as a
+    bad one and reaches for `--rollback`. On the canonical copy exactly 1 chunk
+    of the 10,478-chunk work set is in that state, so the 50-sample stride hits
+    it about half a percent of the time -- invisible in rehearsal, live only.
+    """
+    _add(store, "kept", content="kept lifecycle content")
+    cursor = store.conn.cursor()
+    cursor.execute("UPDATE chunks SET content_class = 'test' WHERE id = 'kept'")
+    cursor.execute("UPDATE chunks SET archived_at = '2026-01-01T00:00:00Z' WHERE id = 'kept'")
+    cursor.execute(
+        "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id) "
+        "VALUES ('kept lifecycle content', NULL, NULL, NULL, NULL, NULL, 'kept')"
+    )
+    # a broken pointer is what pulls this chunk into the work set at all
+    cursor.execute(
+        "INSERT INTO chunk_fts_rowids(chunk_id, fts_rowid) VALUES ('kept', 4242) "
+        "ON CONFLICT(chunk_id) DO UPDATE SET fts_rowid = excluded.fts_rowid"
+    )
+
+    # spot-check every touched chunk, so the sample cannot miss it
+    result = repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True, spot_check=100)
+
+    assert result.census_after["lexical_total"] == 0
+    sampled = {check["chunk_id"] for check in result.spot_checks}
+    assert "kept" in sampled, "the fixture must actually be sampled"
+    failures = [check for check in result.spot_checks if not check["ok"]]
+    assert failures == [], failures
+
+
+def test_spot_check_still_fails_an_active_chunk_left_in_the_wrong_index(store: VectorStore):
+    """Relaxing the gate for lifecycle rows must not relax it for active ones."""
+    from brainlayer import index_completeness
+
+    _add(store, "leaky", content="leaky active content")
+    cursor = store.conn.cursor()
+    cursor.execute("UPDATE chunks SET content_class = 'operational' WHERE id = 'leaky'")
+    cursor.execute(
+        "INSERT INTO chunks_fts(content, summary, tags, resolved_query, key_facts, resolved_queries, chunk_id) "
+        "VALUES ('leaky active content', NULL, NULL, NULL, NULL, NULL, 'leaky')"
+    )
+
+    conn = _sqlite(store)
+    try:
+        checks = index_completeness._spot_check(conn, ["leaky"])
+    finally:
+        conn.close()
+    assert checks[0]["ok"] is False
+    assert any("present_but_class_routes_to" in reason for reason in checks[0]["why"])
+
+
 def test_repair_converges_to_zero_on_a_lifecycle_duplicate(store: VectorStore):
     """Everything the census reports must be repairable, or it never reaches zero.
 
@@ -541,6 +596,127 @@ def test_repair_converges_to_zero_on_a_lifecycle_duplicate(store: VectorStore):
         conn.close()
     assert len(rows) == 1, "the surplus copy goes, the chunk stays indexed"
     assert pointer == rows[0][0]
+
+
+def test_rollback_all_unwinds_an_interrupted_then_resumed_apply(store: VectorStore, monkeypatch):
+    """One `--rollback` is not an exit path after an interrupted window.
+
+    Batches commit individually, so a killed run leaves run A partly applied and
+    the re-run becomes run B. Undoing only B lands on an intermediate state --
+    which, on a personal-memory DB, is not an exit path at all.
+    """
+    from brainlayer import index_completeness
+
+    for index in range(12):
+        _add(store, f"gap-{index}", content=f"gap content number {index}")
+    cursor = store.conn.cursor()
+    for index in range(12):
+        rowid = cursor.execute("SELECT id FROM chunks_fts_content WHERE c6 = ?", (f"gap-{index}",)).fetchone()[0]
+        cursor.execute("DELETE FROM chunks_fts WHERE rowid = ?", (rowid,))
+    before = _fts_snapshot(store)
+
+    # interrupt after the first batch commits, exactly as a killed window would
+    real_delete = index_completeness._delete_index_row
+    state = {"batches": 0}
+
+    def exploding_checkpoint(conn):
+        state["batches"] += 1
+        if state["batches"] >= 1:
+            raise KeyboardInterrupt("window killed mid-apply")
+
+    monkeypatch.setattr(index_completeness, "_checkpoint", exploding_checkpoint)
+    with pytest.raises(KeyboardInterrupt):
+        repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True, batch_size=4, checkpoint_every=1)
+    monkeypatch.undo()
+    assert index_completeness._delete_index_row is real_delete
+
+    interrupted = _fts_snapshot(store)
+    assert interrupted != before, "the interrupted run must have committed something"
+
+    # resume: a second, complete apply, recorded as its own run
+    repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True, batch_size=4)
+
+    # the runbook's old exit path — one rollback — does NOT get back to pre-apply
+    single = rollback_repair(store.db_path)
+    assert single["run_id"] is not None
+    assert _fts_snapshot(store) != before, "one rollback lands on an intermediate state"
+
+    # --rollback-all does
+    every = rollback_repair(store.db_path, all_runs=True)
+    assert len(every["runs"]) >= 1
+    assert _fts_snapshot(store) == before, "rollback-all must reach the pre-apply state"
+    assert rollback_repair(store.db_path, all_runs=True)["run_id"] is None
+
+
+@pytest.mark.parametrize(
+    "sabotage",
+    [
+        pytest.param("pointer_swap", id="pointer aimed at another chunk's row"),
+        pytest.param("text_edit", id="indexed text altered in place"),
+        pytest.param("chunk_id_swap", id="two rows' chunk_ids swapped"),
+    ],
+)
+def test_fingerprint_has_teeth_at_identical_row_counts(store: VectorStore, sabotage):
+    """The fingerprint must move where counts cannot.
+
+    Every sabotage here leaves row counts untouched. If the digest does not
+    change, "rollback is exact" and "apply is deterministic" are claims resting
+    on nothing.
+    """
+    from brainlayer.index_completeness import fingerprint
+
+    _add(store, "one", content="first content")
+    _add(store, "two", content="second content")
+
+    conn = _sqlite(store)
+    try:
+        before = fingerprint(conn)
+        counts_before = {k: v["rows"] for k, v in before.items()}
+        rows = dict(conn.execute("SELECT c6, id FROM chunks_fts_content"))
+        if sabotage == "pointer_swap":
+            conn.execute("UPDATE chunk_fts_rowids SET fts_rowid = ? WHERE chunk_id = 'one'", (rows["two"],))
+        elif sabotage == "text_edit":
+            conn.execute("UPDATE chunks_fts_content SET c0 = 'tampered' WHERE id = ?", (rows["one"],))
+        else:
+            conn.execute("UPDATE chunks_fts_content SET c6 = 'two' WHERE id = ?", (rows["one"],))
+            conn.execute("UPDATE chunks_fts_content SET c6 = 'one' WHERE id = ?", (rows["two"],))
+        conn.commit()
+        after = fingerprint(conn)
+        counts_after = {k: v["rows"] for k, v in after.items()}
+    finally:
+        conn.close()
+
+    assert counts_after == counts_before, "the sabotage must be invisible to counts"
+    assert after != before, "but visible to the fingerprint"
+
+
+def test_fingerprint_survives_apply_and_rollback(store: VectorStore):
+    """The shipped fingerprint is what the live window uses to prove reversibility."""
+    from brainlayer.index_completeness import fingerprint
+
+    _damage(store)
+    conn = _sqlite(store)
+    try:
+        before = fingerprint(conn)
+    finally:
+        conn.close()
+
+    repair_index_completeness(store.db_path, git_sha=GIT_SHA, apply=True)
+    conn = _sqlite(store)
+    try:
+        applied = fingerprint(conn)
+    finally:
+        conn.close()
+    assert applied != before
+    assert applied["chunks"] == before["chunks"], "chunk data must never move"
+
+    rollback_repair(store.db_path, all_runs=True)
+    conn = _sqlite(store)
+    try:
+        restored = fingerprint(conn)
+    finally:
+        conn.close()
+    assert restored == before
 
 
 def test_repair_refuses_the_live_db(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
# fix: rebuild the lexical index rows history lost, and make the gap detectable (repair f)

Repair (f), the last of the repair queue. **No live-DB writes** were made in producing this PR.
The census ran on one online-backup copy (inode `262769218`) and the rehearsal on a fresh one
(inode `262854860`); live is inode `807397`, and both copies passed `PRAGMA quick_check`. The two
copies were taken ~40 minutes apart, so their absolute row counts differ by the handful of chunks
the watcher wrote in between — every defect count below is identical on both.

## The finding

3,536 active knowledge chunks have **no `chunks_fts` row**. For 200 of them the census ran the
real MATCH query built from each chunk's own distinctive terms: **200/200 returned zero hits**
from `chunks_fts`, and **200/200 came back from `chunks_fts_trigram`**. These memories are
unfindable through the BM25 path and survive only because the trigram index still holds them.

Nothing detected it, because the existing check counts. `check_fts5_health` compares
`COUNT(knowledge-class chunks)` against `COUNT(chunks_fts)`:

| Measure | Rows |
| --- | ---: |
| `chunks_fts` rows | 756,620 |
| FTS-eligible active chunks | 748,012 |

4,551 chunks carry **duplicate** rows and 2,509 rows **leak in** from classes that route
elsewhere. The surplus numerically cancels the 3,536-row deficit, so the counts agree and the
index reports itself in sync. This is #722's *counts are blind* at corpus scale.

Two more defects, both invisible to any count:

- **2,661 `chunk_fts_rowids.fts_rowid` pointers aim at another chunk's row** (2,630 distinct
  victims), plus 944 pointing at a rowid that no longer exists. `chunks_fts_delete` and
  `chunks_fts_update` delete *by that pointer*, so the next edit or delete of chunk A silently
  removes chunk B's FTS row. None of the victims is missing yet — this is an armed landmine, and
  a plausible mechanism for how the 3,536 became missing.
- **Sampled duplicates disagree with each other.** Of 200 duplicated chunks, 105 have two copies
  with *different text*; in every sampled case one copy is stale. Search can rank and snippet on
  text the chunk no longer contains.

**The vector side is healthy** and this PR does not touch it: 7 active chunks lack a vector rowid
(all created 2026-08 — ordinary embed lag), and decoding the vec0 validity bitmap and float
payload for all 755,152 active vectors found **0 phantoms**.

## One correction to the brief

"Every active chunk must be findable both ways" is not the shipped contract. The FTS triggers
route by `content_class`: `knowledge`/`decision`/NULL → `chunks_fts` + `chunks_fts_trigram`,
`operational` → `chunks_fts_operational`, and `test`/`benchmark`/`cold` → **no lexical row at
all, by design**. Completeness is per-route; a `cold` chunk with no `chunks_fts` row is correct,
and one *with* a row is the leak counted above. The census and the invariant both measure the
routed contract.

## What the migration does — and refuses to do

`src/brainlayer/index_completeness.py` (+ `scripts/repair_index_completeness.py`), on the
repair-b/c/d/e fenced pattern: dry-run default, `--db` required, refuses the live canonical DB
without `--allow-live`, batched with WAL checkpoints, full preimage, `--rollback`.

- **Missing / duplicated / misrouted FTS rows rebuild in place.** An FTS row is a pure function of
  `chunks.content` (+ summary/tags/resolved_query/key_facts/resolved_queries), so for each affected
  chunk the migration removes whatever rows exist in each routed index and inserts exactly one
  built from current content, then rewrites `chunk_fts_rowids` to the rowids it just created.
- **Vectors go to the pipeline that owns embedding — never to a migration.** A vector is not
  derivable from stored data; producing one means running bge-large. The migration reports vector
  debt, names `brainlayer reembed-backfill` as its owner, and stops. That handoff is safe only
  because `reembed_backfill` finds exactly these rows by the same `LEFT JOIN chunk_vectors_rowids`
  the census uses — asserted by `test_vector_debt_lands_in_the_embed_queue`. Phantom vectors (0
  today) are reported, never patched: `chunk_vectors` and its shadow tables belong to sqlite-vec.
- **What may be deleted, precisely.** Only **aux index rows** — entries in `chunks_fts`,
  `chunks_fts_trigram`, `chunks_fts_operational`, and pointer rows in `chunk_fts_rowids`. These
  are *index* rows, not chunk data: each is reproducible byte-for-byte from `chunks`, which is why
  removing one is not a memory loss. **No row in `chunks` is written, archived, or deleted**, and
  no vec0 table is written at all. An orphan aux row is deleted only after its chunk's absence is
  re-verified **inside the write transaction** (population today: 0 — the guard is for the future).
- **Every delete re-verifies ownership.** A rowid from the census is never trusted at write time:
  `_delete_index_row` re-reads the row and skips it unless it still carries the expected
  `chunk_id`. Deleting on a stale rowid is exactly the bug the mismatched pointers cause, and the
  repair must not commit it while fixing it.
- **New rows take explicitly chosen rowids** above the current maximum, never recycled. Reading
  the rowid back after the insert would mean either a full scan of the FTS content table (`c6`
  carries no index — measured at ~2s per chunk, hours for the real repair) or trusting
  `last_insert_rowid()`, which after an FTS5 insert can report a shadow-table rowid. Choosing the
  value removes both problems: the pointer written afterwards cannot be a guess.

## The search consequence — corrected, and much smaller than I first claimed

**An earlier version of this PR body said "2,509 chunks stop appearing in default lexical search"
and asked the lead to rule on it. That was wrong**, and PR724's review caught it. Default search
does not filter by index membership at all — it filters by `content_class` in the SQL WHERE clause
(`search_repo.py:403`, `COALESCE(content_class,'knowledge') NOT IN ('operational','test',
'benchmark','cold')`). I re-derived this on live, read-only, replaying that clause shape against a
real misrouted operational chunk:

| mode | via `chunks_fts` | via `chunks_fts_operational` |
| --- | ---: | ---: |
| default (class filter on) | **0** | 0 |
| `include_operational=True` | 1 | **1** |

So the misrouted row is already unreachable in default search today, and under
`include_operational=True` the chunk is served from `chunks_fts_operational` before and after the
repair (verified: 0 operational chunks lack an operational-index row, on live and post-apply).
**The 2,277 operational chunks lose nothing an operator can observe.**

The genuine residue is the **232** `test`/`benchmark` chunks, which route to no index at all: after
the repair they are unreachable even under an explicit `content_class_filter` search. That is the
trigger law working as written. It is worth Etan knowing, but it is not the blocking policy
question I originally framed, and `--keep-misrouted` is not needed unless those 232 matter.

Verified alongside it, because repair-e's live window is still pending: the lexical path filters
lifecycle rows in SQL (`lifecycle_active_clauses`), not by index absence, so repair-f rebuilding
rows for archived chunks cannot resurrect archived history into search. The two lanes do not
collide.

## The invariant

`doctor` gains `index_completeness`, fataling separately per direction:

- `index_completeness_chunk_to_aux` — active chunks missing the rows their class routes to,
  duplicated rows, misrouted rows, missing vector rowids.
- `index_completeness_aux_to_chunk` — orphan index rows, orphan/dangling/mismatched pointers,
  orphan vector rowids, phantom vectors.

It is set-difference on chunk ids, never a count comparison, so a surplus can no longer hide a
deficit — `test_doctor_index_completeness_catches_a_gap_counts_cannot_see` builds exactly that
cancelling pair and requires doctor to fail on it.

The check stages its working set in TEMP tables rather than Python dicts: the first implementation
peaked at **1.1GB RSS** on the canonical corpus, which is not a price doctor can pay on every run.
It now measures **58MB / ~15s**. Vector payload decoding stays off by default in doctor (validity
bitmaps only); the full ~3GB blob sweep belongs to the census script.

**Cost worth a decision:** ~15s is real, and it is added to every `brainlayer doctor` run. It buys
a true set-difference — the only kind of check that would have caught this — so I did not trade it
for a cheaper approximation, since the cheap approximation is precisely the count comparison that
missed 3,536 chunks. `DoctorConfig.index_completeness_enabled=False` turns it off if the lead wants
it on a slower cadence instead.

## The write-path guarantee

`test_canonical_insert_indexes_synchronously` requires a canonical insert to leave its routed FTS
rows in place *before it returns*, for all seven class cases, with a pointer that resolves back to
the row it just wrote.

**Today's write path is not the culprit here, and that was tested rather than assumed.** A fresh
DB driven through `insert_canonical_chunk` — 20,000 inserts plus `content_class` flips, content
edits and summary updates — produced 0 missing rows, 0 duplicates, 0 mismatched pointers
(`test_write_path_leaves_no_completeness_gap`). The drift is historical: 3,393 of the 3,536 missing
rows were created in **2026-06**, overwhelmingly from `realtime_watcher`. So this PR repairs
history and installs the detector; it changes no trigger.

## Rehearsal — fresh online-backup copy, gated on the shipped `--fingerprint`

Numbers from the final code, on a fresh copy, using the fingerprint the PR now ships (so a reviewer
or the live operator can reproduce them):

| Step | Wall clock | Result |
| --- | ---: | --- |
| `--fingerprint` (pre) | 40s | recorded, as the runbook now requires |
| Dry-run | 12s | 16,757 lexical defects, 10,478 chunks to touch, fingerprint proves it wrote nothing |
| `--apply --spot-check 20000` — **every touched chunk** | **38s** | 21 batches, 18,157 rows inserted, 24,220 index rows deleted, 10,478 pointers rewritten, **0 rows deleted from `chunks`** |
| Post-apply census | — | **lexical 16,757 → 0** |
| Spot-checks | — | **10,478 / 10,478 pass, 0 failures** |
| `--rollback-all` | 8.3s | 18,157 removed, 24,220 restored, 10,478 pointers restored |
| `--fingerprint` (post-rollback) | — | **identical to pre** on all four structures |

The spot-checks are VALUE checks: each re-reads the stored row and requires the indexed text to
equal `chunks.content` byte-for-byte, the pointer to resolve back to that row, exactly one row in
every index the chunk routes to, and — for an active chunk — none in any index it does not.

**Rollback is exact**, verified with the shipped fingerprint rather than by counting: the digest
over every `(rowid, chunk_id, indexed text)` triple plus the pointer triples is identical before the
apply and after `--rollback-all`, rowid identity included. `chunks` carries digest
`c0583903afd5d21b7cfc4b7ce477e597` at every step — pre, post-apply, post-rollback.

Row counts across the cycle: `chunks_fts` 756,681 → 753,174 → 756,681; `chunks_fts_trigram`
755,730 → 753,174 → 755,730. After the repair the two knowledge indexes agree exactly, where
before they did not.

### What the rehearsal caught that the tests did not

Rehearsing the cycle at corpus scale surfaced defects the unit tests did not:

1. **A second `--rollback` crashed** with `constraint failed`. Preimages accumulate — they are the
   retained audit trail — so replaying the whole table tries to undo applies already undone and
   collides on a rowid. Every preimage row now carries a `run_id`; rollback is scoped to one run
   and writes a `rolled_back:<run>` marker. Fenced by
   `test_apply_rollback_apply_rollback_cycle`, which fails against the pre-fix code.
2. **The repair deleted rows the census never reported**: an archived chunk whose class routes
   elsewhere is deliberately outside the misroute check, but a pointer defect could still pull it
   into the work set and into the delete branch. A migration must not delete more than it reported.
   Fenced by `test_repair_leaves_lifecycle_rows_the_census_did_not_report`, which fails against the
   pre-fix code.
3. **That same guard then broke convergence**, because it also skipped a duplicate the census *does*
   report for every chunk regardless of lifecycle. Fenced by
   `test_repair_converges_to_zero_on_a_lifecycle_duplicate`, which fails against the pre-fix code.
4. A timing trap rather than a correctness bug: recovering an inserted row's rowid with
   `SELECT ... WHERE c6 = ?` is a full scan of the FTS content table, ~2s per chunk — about six
   hours for the real repair. Explicit rowids brought the apply to 53s.

**Correction (PR724 review, F4).** An earlier version of this list, and commit 2's message, claimed
the restore-at-original-rowid fix was a fourth rehearsal finding whose test "fails against the old
code". That provenance is wrong and I could not reproduce it either: both the fix and
`test_rollback_restores_rows_at_their_original_rowids` were already in **commit 1** (`5b90fb8e`) —
I found it during self-review before the first commit and then mis-narrated it in commit 2. The fix
is real and the test does have teeth (a mutation that restores at an auto-assigned rowid kills it),
but the *history* claim was not reproducible, and in this lane a receipt nobody else can reproduce
is the thing we are trying to stamp out (#722, PR723). The commits are left as pushed so the
reviewer's cited SHAs still resolve; this is the correction of record.

### Live-window plan (lead-gated, not run)

1. **Stop watcher, drain, and enrichment first.** The migration snapshots each touched chunk's
   existing rowids once up front; a concurrent writer moving those rows would make the snapshot
   stale. The delete guard then refuses to act — safe, but it can leave a duplicate for a later pass.
2. `PRAGMA wal_checkpoint(FULL)`, take the pre-window backup.
3. Confirm no `index_completeness_preimage` table exists on live (clean-start requirement, the same
   precondition PR723's reviewer set for repair-e).
4. **Record the pre-window fingerprint**: `scripts/repair_index_completeness.py --db <live>
   --fingerprint > pre.json`. This is what makes step 5's success or step 6's reversal checkable by
   the operator rather than only by the author.
5. `scripts/repair_index_completeness.py --db <live> --allow-live --apply --spot-check 50 --git-sha <sha>`
   — ~53s plus census; budget a 5-minute window. Non-zero exit on any failed spot-check.
6. **Exit path: `--rollback-all`, not `--rollback`.** Batches commit individually, so an interrupted
   window leaves run A partly applied and the re-run becomes run B; undoing only the newest run
   lands on an intermediate state, not the pre-apply one. `--rollback-all` keeps going until it
   reports nothing left to roll back (~11s). Then re-run `--fingerprint` and require it to equal
   `pre.json` — reversal is a claim to verify, not to assume.
7. `brainlayer doctor` after: **`index_completeness_chunk_to_aux` and `index_completeness_aux_to_chunk`
   silent, and `index_completeness_phantom_vectors` silent.** Ordinary embed lag is *not* part of
   that gate and never was passable as such — `vector_parity_gap` owns missing vectors and hands
   them to `brainlayer reembed-backfill`. An `index_completeness_orphan_vector_rowids` **warning**
   is possible and is not a blocker: nothing in the repo deletes a vec0 rowid row, so it is
   reported with that stated rather than fataled with no owner.

## Tests

`tests/test_index_completeness.py` 34 and `tests/test_doctor.py` 66 — 100 pass locally, plus a full
unit suite run of **4,211 passed / 0 failed** at the pre-review head. `ruff check src/ tests/` and
`ruff format --check` clean. **CI on this exact head is the gate**, per the review — a local run is
not a substitute.

## Review round 1 (PR724, head `afcd7545`) — all findings addressed

ACCEPT after F1 + F2; both fixed, plus F5–F7 which were raised as recommended/minor.

- **F1 (blocker)** — `--spot-check` failed any chunk holding a row in an index its class does not
  route to, which is exactly what the migration deliberately *keeps* for lifecycle-managed chunks.
  The success gate called its own correct behaviour a failure, and `main()` exits non-zero on that,
  so a live operator would have read a converged run as a failed one. The gate now asserts what the
  migration promises, per lifecycle. **The population is 35 chunks, not the 1 the review
  estimated** — with a 50-sample stride that is roughly a 1-in-6 chance of failing a good live run.
  Fixing it surfaced a second bug: the gate cost one full scan of a multi-GB content table *per
  chunk* (`c6` is unindexed), so spot-checking everything would never have finished. It now
  prefetches in one scan per index, and the apply got *faster* (53s → 38s) while checking 200× more.
- **F2 (blocker)** — shipped `--rollback-all`. Batches commit individually, so an interrupted window
  leaves run A partly applied and the re-run is run B; undoing one run lands on an intermediate
  state. Fenced by a test that interrupts mid-apply, resumes, and requires `--rollback-all` to reach
  the pre-apply snapshot where a single `--rollback` does not.
- **F3** — the search-consequence warning was wrong; corrected above, re-derived on live read-only.
- **F4** — the defect-(2) provenance claim was wrong; withdrawn above.
- **F5** — the fingerprint now ships as `--fingerprint`, sabotage-fenced in CI at identical row
  counts against the review's three cases (pointer swap, in-place text edit, chunk_id swap).
- **F6** — doctor's fatal gates are lexical only, so the runbook's exit criterion is now passable;
  phantom vectors get their own fatal, orphan vec0 rowids a warning with no owner claimed. The two
  reported asymmetries (binary debt uncounted, no orphan-binary check) are closed.
- **F7** — no more all-NULL pointer rows.

## Not in this PR

- No live-DB write. The live window stays lead-gated.
- No embedding, no vec0 write, no trigger change.
- The 7 vector-debt rows are left for `brainlayer reembed-backfill`.

---

**DO NOT MERGE** — reviewer confirms the fixes, then the lead merges. The live window stays
Etan-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— brainlayerClaude (worker) · claude-code/opus-5
<!-- golem-id v1 {"seat":"brainlayerClaude","role":"worker","harness":"claude-code","model":"claude-opus-5","model_source":"session-jsonl","session":"d9cac551","ts":"2026-08-18T22:41:32Z"} -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lexical index completeness census and reversible repair to detect and fix FTS gaps
> - Adds [index_completeness.py](https://github.com/EtanHey/brainlayer/pull/724/files#diff-446e48d71f3a1ecc4426c95aace4c55a13580eaafb5276d7e610645e5a29ea40) with a `census` function that detects missing, duplicate, misrouted, and orphaned FTS rows in both directions (chunk→aux and aux→chunk), plus phantom vector detection via payload verification.
> - Adds `repair_index_completeness` which rebuilds correct FTS rows and pointers in batches using `BEGIN IMMEDIATE` transactions, writes an audit preimage log, and supports full rollback via `rollback_repair`.
> - Integrates the census into `run_doctor` in [doctor.py](https://github.com/EtanHey/brainlayer/pull/724/files#diff-41071e7067b327f299dfaa0e5ce4c4455911658ff543b818c684f321f91b29ff): lexical gaps in either direction are fatal issues; orphan vector rowids are warnings; phantom vectors are fatal.
> - Exposes a CLI via [scripts/repair_index_completeness.py](https://github.com/EtanHey/brainlayer/pull/724/files#diff-2ee299b499e05aee4e5613aeb1c546518c5bbc9adfe3df767cb1e6b93f2f588c) supporting census-only, apply, rollback, rollback-all, and fingerprint modes with JSON output.
> - Risk: repair writes FTS rows at controlled rowids using `BEGIN IMMEDIATE`; it never touches chunk or vector tables, but concurrent writers during apply could cause lock contention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42d57ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->