### PR TITLE
fix: a tool description is the last thing dropped, not the first (#726)

### DIFF
--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -765,14 +765,31 @@ final class BrainBarServer: @unchecked Sendable {
 
     private static let claudeExtensionRawChunkLimit = 8192
 
-    private static func encodeRawJSONResponse(_ response: [String: Any]) -> Data? {
+    /// Floor for a truncated tool description. A description is the tool's
+    /// contract with the agent ("The rules for agents USING it live in the tool
+    /// descriptions" — AGENTS.md), so it is the LAST thing the raw-line encoder
+    /// gives up: annotations and inputSchema prose go first, and a description is
+    /// truncated-with-notice rather than removed. Issue #726.
+    private static let minimumRawToolDescriptionLength = 48
+
+    /// Marker appended to a description the raw-line encoder had to shorten, so a
+    /// truncated contract never reads as a complete one.
+    private static let rawToolDescriptionTruncationMarker = "…[truncated]"
+
+    /// Internal (not private) so the compaction ladder can be exercised directly on
+    /// payloads larger than the real palette — the wire tests cover the shipped
+    /// palettes, this covers the rung a future tool addition would hit.
+    static func encodeRawJSONResponse(_ response: [String: Any]) -> Data? {
         guard let jsonData = try? MCPFraming.encodeJSONResponse(response) else { return nil }
         guard jsonData.count >= claudeExtensionRawChunkLimit else { return jsonData }
         guard let compacted = compactRawJSONResponseIfNeeded(response),
               let compactData = try? MCPFraming.encodeJSONResponse(compacted) else {
             return jsonData
         }
-        return compactData
+        guard compactData.count >= claudeExtensionRawChunkLimit else { return compactData }
+        // Rung 2: still over budget with annotations and schema prose gone. Shorten
+        // the descriptions — never delete them — and say so in the response.
+        return truncatedRawJSONResponse(compacted) ?? compactData
     }
 
     private static func compactRawJSONResponseIfNeeded(_ response: [String: Any]) -> [String: Any]? {
@@ -782,18 +799,18 @@ final class BrainBarServer: @unchecked Sendable {
         }
 
         // Claude Desktop's MCPB utility process currently parses raw extension
-        // stdout in 8192-byte chunks. Raw newline transport omits optional tool
-        // annotations and the verbose human-readable description prose (both the
-        // top-level tool descriptions and the per-property inputSchema
-        // descriptions). The Content-Length transport keeps the canonical, fully
-        // described tools/list; the raw line keeps only the machine-required
-        // shape (name + inputSchema structure) so the response stays under the
-        // 8192-byte MCPB chunk limit without dropping any tool.
+        // stdout in 8192-byte chunks. Rung 1 of the compaction ladder drops only
+        // what an agent needs neither to PICK a tool nor to CALL it: optional
+        // annotations and the per-property inputSchema prose. The top-level tool
+        // `description` — the contract that tells the agent what the tool is for —
+        // survives this rung unconditionally (issue #726: it used to be dropped
+        // here, which silently downgraded every expanded palette to 0/17
+        // descriptions). The Content-Length transport keeps the canonical,
+        // fully described tools/list.
         var compactResult = result
         compactResult["tools"] = tools.map { tool in
             var compact = tool
             compact.removeValue(forKey: "annotations")
-            compact.removeValue(forKey: "description")
             if let schema = compact["inputSchema"] as? [String: Any] {
                 compact["inputSchema"] = stripSchemaDescriptions(schema)
             }
@@ -803,6 +820,99 @@ final class BrainBarServer: @unchecked Sendable {
         var compactResponse = response
         compactResponse["result"] = compactResult
         return compactResponse
+    }
+
+    /// Rung 2: binary-search the largest per-tool description budget whose encoded
+    /// response still fits the chunk limit, and attach an explicit `_meta` notice
+    /// naming every tool that was shortened. If even the floor budget does not fit,
+    /// the floor payload is returned anyway — an over-limit response that still
+    /// carries its contract beats an under-limit one that silently lost it.
+    private static func truncatedRawJSONResponse(_ response: [String: Any]) -> Data? {
+        guard let result = response["result"] as? [String: Any],
+              let tools = result["tools"] as? [[String: Any]] else {
+            return nil
+        }
+        let longest = tools.compactMap { ($0["description"] as? String)?.count }.max() ?? 0
+        guard longest > minimumRawToolDescriptionLength else { return nil }
+
+        var low = minimumRawToolDescriptionLength
+        var high = longest
+        var best: Data?
+        while low <= high {
+            let budget = (low + high) / 2
+            guard let candidate = try? MCPFraming.encodeJSONResponse(
+                responseTruncatingDescriptions(response, result: result, tools: tools, budget: budget)
+            ) else {
+                break
+            }
+            if candidate.count < claudeExtensionRawChunkLimit {
+                best = candidate
+                low = budget + 1
+            } else {
+                high = budget - 1
+            }
+        }
+
+        if best == nil {
+            NSLog(
+                "[BrainBar] ⚠️ raw tools/list exceeds %d bytes even at a %d-char description budget; sending it over-limit rather than dropping the tool contract (issue #726)",
+                claudeExtensionRawChunkLimit,
+                minimumRawToolDescriptionLength
+            )
+            best = try? MCPFraming.encodeJSONResponse(
+                responseTruncatingDescriptions(
+                    response,
+                    result: result,
+                    tools: tools,
+                    budget: minimumRawToolDescriptionLength
+                )
+            )
+        }
+        return best
+    }
+
+    private static func responseTruncatingDescriptions(
+        _ response: [String: Any],
+        result: [String: Any],
+        tools: [[String: Any]],
+        budget: Int
+    ) -> [String: Any] {
+        var truncatedNames: [String] = []
+        let truncatedTools = tools.map { tool -> [String: Any] in
+            guard let description = tool["description"] as? String,
+                  description.count > budget else {
+                return tool
+            }
+            var shortened = tool
+            shortened["description"] = truncate(description, to: budget)
+            truncatedNames.append((tool["name"] as? String) ?? "unknown")
+            return shortened
+        }
+
+        var truncatedResult = result
+        truncatedResult["tools"] = truncatedTools
+        if !truncatedNames.isEmpty {
+            var meta = (result["_meta"] as? [String: Any]) ?? [:]
+            meta["brainlayer/descriptionsTruncated"] = [
+                "reason": "raw newline tools/list must fit the client's \(claudeExtensionRawChunkLimit)-byte chunk limit",
+                "limitBytes": claudeExtensionRawChunkLimit,
+                "budgetChars": budget,
+                "tools": truncatedNames,
+                "fullDescriptionsAvailableOver": "Content-Length framing",
+            ] as [String: Any]
+            truncatedResult["_meta"] = meta
+        }
+
+        var truncatedResponse = response
+        truncatedResponse["result"] = truncatedResult
+        return truncatedResponse
+    }
+
+    private static func truncate(_ description: String, to budget: Int) -> String {
+        let keep = max(1, budget - rawToolDescriptionTruncationMarker.count)
+        let head = String(description.prefix(keep))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return head + rawToolDescriptionTruncationMarker
     }
 
     /// Recursively removes human-readable `description` keys from a JSON schema

--- a/brain-bar/Sources/BrainBar/BrainBarServer.swift
+++ b/brain-bar/Sources/BrainBar/BrainBarServer.swift
@@ -789,7 +789,15 @@ final class BrainBarServer: @unchecked Sendable {
         guard compactData.count >= claudeExtensionRawChunkLimit else { return compactData }
         // Rung 2: still over budget with annotations and schema prose gone. Shorten
         // the descriptions — never delete them — and say so in the response.
-        return truncatedRawJSONResponse(compacted) ?? compactData
+        let finalData = truncatedRawJSONResponse(compacted) ?? compactData
+        if finalData.count >= claudeExtensionRawChunkLimit {
+            NSLog(
+                "[BrainBar] ⚠️ raw tools/list exceeds %d bytes even at a %d-char description budget; sending it over-limit rather than dropping the tool contract (issue #726)",
+                claudeExtensionRawChunkLimit,
+                minimumRawToolDescriptionLength
+            )
+        }
+        return finalData
     }
 
     private static func compactRawJSONResponseIfNeeded(_ response: [String: Any]) -> [String: Any]? {
@@ -833,7 +841,6 @@ final class BrainBarServer: @unchecked Sendable {
             return nil
         }
         let longest = tools.compactMap { ($0["description"] as? String)?.count }.max() ?? 0
-        guard longest > minimumRawToolDescriptionLength else { return nil }
 
         var low = minimumRawToolDescriptionLength
         var high = longest
@@ -854,17 +861,13 @@ final class BrainBarServer: @unchecked Sendable {
         }
 
         if best == nil {
-            NSLog(
-                "[BrainBar] ⚠️ raw tools/list exceeds %d bytes even at a %d-char description budget; sending it over-limit rather than dropping the tool contract (issue #726)",
-                claudeExtensionRawChunkLimit,
-                minimumRawToolDescriptionLength
-            )
             best = try? MCPFraming.encodeJSONResponse(
                 responseTruncatingDescriptions(
                     response,
                     result: result,
                     tools: tools,
-                    budget: minimumRawToolDescriptionLength
+                    budget: minimumRawToolDescriptionLength,
+                    forceNotice: true
                 )
             )
         }
@@ -875,7 +878,8 @@ final class BrainBarServer: @unchecked Sendable {
         _ response: [String: Any],
         result: [String: Any],
         tools: [[String: Any]],
-        budget: Int
+        budget: Int,
+        forceNotice: Bool = false
     ) -> [String: Any] {
         var truncatedNames: [String] = []
         let truncatedTools = tools.map { tool -> [String: Any] in
@@ -891,10 +895,12 @@ final class BrainBarServer: @unchecked Sendable {
 
         var truncatedResult = result
         truncatedResult["tools"] = truncatedTools
-        if !truncatedNames.isEmpty {
+        if !truncatedNames.isEmpty || forceNotice {
             var meta = (result["_meta"] as? [String: Any]) ?? [:]
             meta["brainlayer/descriptionsTruncated"] = [
-                "reason": "raw newline tools/list must fit the client's \(claudeExtensionRawChunkLimit)-byte chunk limit",
+                "reason": forceNotice && truncatedNames.isEmpty
+                    ? "raw newline tools/list exceeds the client's \(claudeExtensionRawChunkLimit)-byte chunk limit even though every description is already at or below the \(minimumRawToolDescriptionLength)-char floor"
+                    : "raw newline tools/list must fit the client's \(claudeExtensionRawChunkLimit)-byte chunk limit",
                 "limitBytes": claudeExtensionRawChunkLimit,
                 "budgetChars": budget,
                 "tools": truncatedNames,

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -1686,7 +1686,7 @@ final class MCPRouter: @unchecked Sendable {
     nonisolated(unsafe) static let toolDefinitions: [[String: Any]] = [
         [
             "name": "brain_search",
-            "description": "Search BrainLayer's memory (past decisions, learnings, notes, project history) with hybrid semantic + keyword ranking. Pass a natural-language query; narrow with project, tag, source, or importance_min. Returns ranked snippets (title, source, date, preview).",
+            "description": "Search memory for past decisions, bugs, notes, and project history by topic. Use when asked \"have we done this\", \"what did we decide\", \"how did I implement X\". For session context, not topics, use brain_recall.",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1706,7 +1706,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_store",
-            "description": "Save a decision, learning, mistake, idea, or todo to durable memory so future sessions can retrieve it with brain_search. Add tags, importance (1-10), and project to improve later retrieval. Every call returns exactly one of six outcomes, named in the response text; the four SUCCESS outcomes also carry a structured `status` field: STORED (a new chunk was written); DUPLICATE (an identical memory already existed and was refreshed, not re-inserted); MERGED (a near-identical memory existed and your content was folded into it); STORED (deferred), status DEFERRED (accepted and durably queued while the DB is busy \u{2014} it WILL be stored automatically under the same chunk_id). The other two come back as errors with no `status`: REJECTED (a content gate refused it \u{2014} nothing stored, nothing queued); ERROR (the write failed \u{2014} nothing stored, nothing queued). STORED, DUPLICATE, MERGED, and DEFERRED all resolve to a canonical chunk_id and are all SUCCESS: do NOT re-store, do NOT retry, and never save a fallback copy. Only REJECTED and ERROR store nothing, and they return no chunk_id. For digesting long raw text use brain_digest instead.",
+            "description": "Store a decision, correction, bug cause, or learning so future sessions find it. status STORED|DUPLICATE|MERGED|DEFERRED all = success, do NOT re-store (DEFERRED is queued and will be stored); REJECTED|ERROR store nothing and return no `status` or chunk_id. For long raw text use brain_digest.",
             "annotations": MCPRouter.writeAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1721,7 +1721,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_recall",
-            "description": "Get session-level context, not topical search. Modes: context = what you're working on now; sessions = recent session history; operations/summary = details for one session_id; plan = plan linkage; stats = knowledge-base health stats. For looking up facts or past decisions by topic, use brain_search.",
+            "description": "Get session-level context: what you are working on now, recent sessions, one session's detail, or knowledge-base stats. For topic lookup use brain_search.",
             "annotations": MCPRouter.recallAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1733,7 +1733,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_entity",
-            "description": "Look up a named entity (person, project, company, tool) in the knowledge graph and return its profile and graph relations. Returns 'No entity found' if the name isn't in the graph yet — for fuzzy topical recall across memories use brain_search instead.",
+            "description": "Look up a named person, project, company, or tool in the knowledge graph and return its relations. For fuzzy topical recall use brain_search.",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1745,7 +1745,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_get_person",
-            "description": "Get a person's profile, relations, and linked memories in one call.",
+            "description": "Get one person's profile, relations, and linked memories in a single call.",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1759,7 +1759,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_digest",
-            "description": "Digest a large block of raw text (transcript, doc, article) into one durable, enriched memory chunk that brain_search can find. Pass `project` to scope the chunk so brain_search(project=...) finds it, and an optional `title` to label the digest. Extracted entities are written to the knowledge graph and become resolvable via brain_entity. For a short scoped note use brain_store with a project instead.",
+            "description": "Digest a large block of raw text (transcript, doc, article) into one searchable memory chunk: it enriches the text and connects the entities it extracts into the knowledge graph. For a short note use brain_store.",
             "annotations": MCPRouter.writeAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1773,7 +1773,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_update",
-            "description": "Update the importance and/or tags of an existing memory chunk in place. Provide chunk_id plus at least one of importance or tags (tags replace the chunk's existing tag list). This does NOT edit content — to replace content store a new memory with brain_store, to hide a chunk use brain_archive, to mark a replacement use brain_supersede.",
+            "description": "Change an existing chunk's importance or tags. Does not edit content: store new content with brain_store, hide a chunk with brain_archive.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1787,7 +1787,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_expand",
-            "description": "Drill into a specific search result. Returns full content + surrounding chunks.",
+            "description": "Open one search result in full, with the chunks around it.",
             "annotations": MCPRouter.expandAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1801,7 +1801,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_tags",
-            "description": "List tags used across the knowledge base, each with its usage count. Pass an optional query to filter to tags containing that substring.",
+            "description": "List the tags in use with their counts; filter by substring.",
             "annotations": MCPRouter.readOnlyAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1812,7 +1812,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_supersede",
-            "description": "Mark an old chunk as replaced by a newer one and hide it from default search.",
+            "description": "Mark an old chunk as replaced by a newer one and hide it from search. To hide with no replacement use brain_archive.",
             "annotations": MCPRouter.toolAnnotations(readOnly: false, destructive: true, idempotent: false),
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1827,7 +1827,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_archive",
-            "description": "Archive a chunk so it stops appearing in default search but remains recoverable.",
+            "description": "Hide a chunk from default search, recoverably. To point at a replacement instead use brain_supersede.",
             "annotations": MCPRouter.toolAnnotations(readOnly: false, destructive: true, idempotent: false),
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1856,7 +1856,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_subscribe",
-            "description": "Subscribe an agent to push notifications for matching tags.",
+            "description": "Subscribe an agent to live notifications for the given tags.",
             "annotations": MCPRouter.writeAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1869,7 +1869,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_unsubscribe",
-            "description": "Remove some or all tag subscriptions for an agent.",
+            "description": "Remove some or all of an agent's tag subscriptions.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1882,7 +1882,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_ack",
-            "description": "Acknowledge that an agent processed messages through the given chunk rowid.",
+            "description": "Acknowledge that an agent processed messages up to a chunk rowid.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",
@@ -1895,7 +1895,7 @@ final class MCPRouter: @unchecked Sendable {
         ],
         [
             "name": "brain_backup_vacuum_into",
-            "description": "Create a SQLite backup snapshot using VACUUM INTO on BrainBar's single-writer connection.",
+            "description": "Write a SQLite backup snapshot (VACUUM INTO) to a target path.",
             "annotations": MCPRouter.writeIdempotentAnnotations,
             "inputSchema": MCPRouter.limitedInputSchema([
                 "type": "object",

--- a/brain-bar/Sources/BrainBar/MCPRouter.swift
+++ b/brain-bar/Sources/BrainBar/MCPRouter.swift
@@ -258,11 +258,18 @@ final class MCPRouter: @unchecked Sendable {
         exposedToolDefinitions(for: session).contains { ($0["name"] as? String) == name }
     }
 
-    private static func compactCoreToolDefinition(_ definition: [String: Any]) -> [String: Any] {
+    static func compactCoreToolDefinition(_ definition: [String: Any]) -> [String: Any] {
         guard let name = definition["name"] as? String else { return definition }
+        guard let description = coreToolDescriptions[name]
+            ?? (definition["description"] as? String),
+              !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            preconditionFailure("Core tool '\(name)' has no usable description")
+        }
 
-        var compact: [String: Any] = ["name": name]
-        compact["description"] = coreToolDescriptions[name]
+        var compact: [String: Any] = [
+            "name": name,
+            "description": description,
+        ]
         if let inputSchema = definition["inputSchema"] as? [String: Any] {
             compact["inputSchema"] = removingDescriptions(from: inputSchema)
         }

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -242,6 +242,21 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertLessThanOrEqual(data.count, 1_600)
     }
 
+    func testCoreCompactionFallsBackToTheCanonicalDescription() throws {
+        let brainTags = try XCTUnwrap(
+            MCPRouter.toolDefinitions.first { ($0["name"] as? String) == "brain_tags" }
+        )
+
+        let compacted = MCPRouter.compactCoreToolDefinition(brainTags)
+
+        XCTAssertEqual(compacted["name"] as? String, "brain_tags")
+        XCTAssertEqual(
+            compacted["description"] as? String,
+            brainTags["description"] as? String,
+            "a core tool without a terse override must retain its canonical description"
+        )
+    }
+
     func testCorePaletteExpandsOnceAndDispatchesDeferredTools() throws {
         let router = MCPRouter(profile: "core")
 

--- a/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
+++ b/brain-bar/Tests/BrainBarTests/MCPRouterTests.swift
@@ -3359,3 +3359,85 @@ private func openSQLiteConnection(path: String) throws -> OpaquePointer {
     }
     return db
 }
+
+// MARK: - Issue #726 Part B — tool-description house style
+//
+// skillCreator's measured norm across 86 golems skills (check-skill-library.mjs):
+// median 125 chars, p90 263, max 475. Etan, 2026-08-19: "the tool descriptions
+// should be extremely short. Just tell them what to do with it." The shape is
+// (a) what it does as a verb phrase, (b) the words a user actually says, and
+// (c) a one-clause not-for ONLY where a sibling tool is genuinely confusable.
+final class ToolDescriptionHouseStyleTests: XCTestCase {
+    /// Tools with a near-neighbour an agent can plausibly pick instead. Only these
+    /// owe a not-for clause; a tool with no near-neighbour does not.
+    private static let confusableSiblings: [String: [String]] = [
+        "brain_search": ["brain_recall"],
+        "brain_recall": ["brain_search"],
+        "brain_entity": ["brain_search"],
+        "brain_store": ["brain_digest"],
+        "brain_digest": ["brain_store"],
+        "brain_update": ["brain_store", "brain_archive"],
+        "brain_archive": ["brain_supersede"],
+        "brain_supersede": ["brain_archive"],
+    ]
+
+    private func descriptions() -> [String: String] {
+        var result: [String: String] = [:]
+        for definition in MCPRouter.toolDefinitions {
+            guard let name = definition["name"] as? String,
+                  let description = definition["description"] as? String else { continue }
+            result[name] = description
+        }
+        return result
+    }
+
+    func testEveryToolHasANonEmptyDescription() {
+        for definition in MCPRouter.toolDefinitions {
+            let name = (definition["name"] as? String) ?? "unknown"
+            let description = (definition["description"] as? String) ?? ""
+            XCTAssertFalse(description.isEmpty, "\(name) has no description")
+        }
+    }
+
+    func testDescriptionsStayWithinTheHouseStyleBudget() {
+        let lengths = descriptions().values.map(\.count).sorted()
+        XCTAssertFalse(lengths.isEmpty)
+
+        for (name, description) in descriptions() {
+            // Hard cap, parity with tests/test_tool_description_quality.py.
+            XCTAssertLessThan(description.count, 1024, "\(name) is \(description.count) chars")
+            // Doctrine max is 475; BrainBar's palette is small enough to sit well under it.
+            XCTAssertLessThanOrEqual(
+                description.count,
+                320,
+                "\(name) is \(description.count) chars — over the per-tool ceiling"
+            )
+        }
+
+        let median = lengths[lengths.count / 2]
+        XCTAssertLessThanOrEqual(median, 175, "median description length is \(median) chars")
+    }
+
+    func testConfusableToolsNameTheSiblingToUseInstead() {
+        let all = descriptions()
+        for (name, siblings) in Self.confusableSiblings {
+            let description = try? XCTUnwrap(all[name])
+            let text = description ?? ""
+            XCTAssertTrue(
+                siblings.contains { text.contains($0) },
+                "\(name) is confusable with \(siblings.joined(separator: "/")) and must name the alternative"
+            )
+        }
+    }
+
+    /// PR #725's outcome contract must survive the shortening — compressed, not cut.
+    /// Its ENFORCEMENT is the write-time dedupe, not this sentence; the sentence only
+    /// stops an agent re-storing on an ambiguous response.
+    func testBrainStoreKeepsItsOutcomeContract() throws {
+        let description = try XCTUnwrap(descriptions()["brain_store"])
+        for outcome in ["STORED", "DUPLICATE", "MERGED", "DEFERRED", "REJECTED", "ERROR"] {
+            XCTAssertTrue(description.contains(outcome), "brain_store lost the \(outcome) outcome")
+        }
+        XCTAssertTrue(description.contains("do NOT re-store"))
+    }
+}

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -1647,4 +1647,227 @@ final class SocketIntegrationTests: XCTestCase {
         }
         throw NSError(domain: "test", code: 5, userInfo: [NSLocalizedDescriptionKey: "Timeout reading line JSON"])
     }
+
+    // MARK: - Issue #726 — tool descriptions must survive every profile x framing
+
+    /// Fetches tools/list over a REAL socket in the given framing, returning the
+    /// tools plus the exact byte count that went over the wire. Unit tests at
+    /// `router.handle()` sit one layer above the raw-line compaction and stayed
+    /// green while the wire was wrong twice — these assertions run on the wire.
+    private func wireToolsList(
+        palette: WirePalette,
+        framing: WireFraming
+    ) throws -> (tools: [[String: Any]], byteCount: Int) {
+        restartServer(profile: palette.serverProfile)
+        let fd = try connectClient()
+        defer { close(fd) }
+
+        var nextID = 1
+        func exchange(_ request: [String: Any]) throws -> (json: [String: Any], byteCount: Int) {
+            var payload = request
+            payload["id"] = nextID
+            nextID += 1
+            switch framing {
+            case .contentLength:
+                try sendMCPRequest(on: fd, request: payload)
+                let json = try readMCPMessage(fd: fd)
+                let encoded = try MCPFraming.encodeJSONResponse(json)
+                return (json, encoded.count)
+            case .newline:
+                try sendRawLineJSON(on: fd, object: payload)
+                let line = try readRawLineJSONData(fd: fd)
+                let json = try JSONSerialization.jsonObject(with: line) as? [String: Any] ?? [:]
+                // +1 for the delimiter newline the server appends.
+                return (json, line.count + 1)
+            }
+        }
+
+        _ = try exchange([
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": [
+                "protocolVersion": "2024-11-05",
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": "wire-\(palette.rawValue)-\(framing.rawValue)", "version": "1.0"],
+            ],
+        ])
+
+        if palette.requiresExpansion {
+            let expansion = try exchange([
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": ["name": "expand_palette", "arguments": [:] as [String: Any]],
+            ])
+            XCTAssertNil(expansion.json["error"], "expand_palette should succeed on the core profile")
+        }
+
+        let listed = try exchange(["jsonrpc": "2.0", "method": "tools/list"])
+        let tools = (listed.json["result"] as? [String: Any])?["tools"] as? [[String: Any]] ?? []
+        return (tools, listed.byteCount)
+    }
+
+    func testEveryToolCarriesADescriptionOnEveryProfileAndFraming() throws {
+        for framing in WireFraming.allCases {
+            for palette in WirePalette.allCases {
+                let label = "palette=\(palette.rawValue) framing=\(framing.rawValue)"
+                let listed = try wireToolsList(palette: palette, framing: framing)
+
+                print("[#726] \(label) tools=\(listed.tools.count) bytes=\(listed.byteCount)")
+
+                XCTAssertFalse(listed.tools.isEmpty, "\(label): tools/list returned no tools")
+                let expectedCount = palette == .core ? 5 : 17
+                XCTAssertEqual(listed.tools.count, expectedCount, "\(label): unexpected tool count")
+
+                for tool in listed.tools {
+                    let name = tool["name"] as? String ?? "unknown"
+                    let description = tool["description"] as? String
+                    XCTAssertNotNil(
+                        description,
+                        "\(label): \(name) reached the agent with NO description — descriptions are the contract (#726)"
+                    )
+                    XCTAssertFalse(
+                        (description ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                        "\(label): \(name) reached the agent with an EMPTY description (#726)"
+                    )
+                }
+            }
+        }
+    }
+
+    func testRawLineToolsListStaysUnderTheChunkLimitOnEveryProfile() throws {
+        for palette in WirePalette.allCases {
+            let listed = try wireToolsList(palette: palette, framing: .newline)
+            XCTAssertLessThan(
+                listed.byteCount,
+                8192,
+                "palette=\(palette.rawValue): raw newline tools/list must fit Claude Desktop's 8192-byte MCPB chunk"
+            )
+        }
+    }
+
+    /// Etan, 2026-08-19: brain_store must be a default (core) tool whose description
+    /// is on the wire at boot with no expand_palette call, in BOTH framings.
+    func testBrainStoreIsInTheDefaultPaletteWithItsDescriptionOnBoot() throws {
+        for framing in WireFraming.allCases {
+            let listed = try wireToolsList(palette: .core, framing: framing)
+            let store = listed.tools.first { ($0["name"] as? String) == "brain_store" }
+            XCTAssertNotNil(store, "framing=\(framing.rawValue): brain_store must be in the boot palette")
+            let description = (store?["description"] as? String) ?? ""
+            XCTAssertFalse(
+                description.isEmpty,
+                "framing=\(framing.rawValue): brain_store's description must be present on boot"
+            )
+            XCTAssertTrue(
+                description.contains("STORED"),
+                "framing=\(framing.rawValue): brain_store must carry its outcome contract on boot"
+            )
+        }
+    }
+
+    /// Rung 2 of the ladder: a payload too big even without annotations/schema prose
+    /// must SHORTEN descriptions with an explicit notice, never silently drop them.
+    func testOversizedRawToolsListTruncatesDescriptionsWithAnExplicitNotice() throws {
+        let longDescription = String(repeating: "contract sentence. ", count: 40)
+        let tools: [[String: Any]] = (0..<40).map { index in
+            [
+                "name": "tool_\(index)",
+                "description": longDescription,
+                "annotations": ["readOnlyHint": true] as [String: Any],
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "query": ["type": "string", "description": longDescription] as [String: Any],
+                    ] as [String: Any],
+                ] as [String: Any],
+            ]
+        }
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": ["tools": tools] as [String: Any],
+        ]
+
+        let encoded = try XCTUnwrap(BrainBarServer.encodeRawJSONResponse(response))
+        XCTAssertLessThan(encoded.count, 8192, "the ladder should land under the chunk limit")
+
+        let decoded = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        let result = try XCTUnwrap(decoded["result"] as? [String: Any])
+        let decodedTools = try XCTUnwrap(result["tools"] as? [[String: Any]])
+        XCTAssertEqual(decodedTools.count, 40, "no tool may be dropped to fit")
+
+        for tool in decodedTools {
+            let description = (tool["description"] as? String) ?? ""
+            XCTAssertFalse(
+                description.isEmpty,
+                "\(tool["name"] ?? "unknown") lost its description instead of being truncated (#726)"
+            )
+            XCTAssertTrue(
+                description.hasSuffix("…[truncated]"),
+                "a shortened description must say so"
+            )
+            XCTAssertNil(tool["annotations"], "annotations drop before descriptions")
+        }
+
+        let meta = try XCTUnwrap(result["_meta"] as? [String: Any])
+        let notice = try XCTUnwrap(meta["brainlayer/descriptionsTruncated"] as? [String: Any])
+        XCTAssertEqual((notice["tools"] as? [String])?.count, 40, "the notice must name what was shortened")
+        XCTAssertEqual(notice["limitBytes"] as? Int, 8192)
+        XCTAssertNotNil(notice["reason"] as? String)
+    }
+
+    /// The shipped palette must fit rung 1 — full descriptions, no truncation at all.
+    /// If a new tool pushes the raw line over, this fails LOUDLY here instead of
+    /// quietly shipping shortened contracts to every agent.
+    func testShippedPalettesFitWithoutAnyDescriptionTruncation() throws {
+        for palette in WirePalette.allCases {
+            _ = try wireToolsList(palette: palette, framing: .newline)
+        }
+
+        // Re-fetch full with the raw notice visible.
+        restartServer(profile: "full")
+        let fd = try connectClient()
+        defer { close(fd) }
+        try sendRawLineJSON(on: fd, object: [
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": [
+                "protocolVersion": "2024-11-05",
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": "headroom", "version": "1.0"],
+            ],
+        ])
+        _ = try readRawLineJSONData(fd: fd)
+        try sendRawLineJSON(on: fd, object: ["jsonrpc": "2.0", "id": 2, "method": "tools/list"])
+        let line = try readRawLineJSONData(fd: fd)
+        let response = try XCTUnwrap(try JSONSerialization.jsonObject(with: line) as? [String: Any])
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+
+        XCTAssertNil(
+            (result["_meta"] as? [String: Any])?["brainlayer/descriptionsTruncated"],
+            "the shipped palette must fit with FULL descriptions; shorten descriptions rather than "
+                + "letting the ladder truncate them (#726)"
+        )
+        for tool in (result["tools"] as? [[String: Any]]) ?? [] {
+            XCTAssertFalse(
+                ((tool["description"] as? String) ?? "").hasSuffix("…[truncated]"),
+                "\(tool["name"] ?? "unknown") shipped a truncated description"
+            )
+        }
+        print("[#726] shipped full raw-line bytes=\(line.count + 1)")
+    }
+}
+
+private enum WireFraming: String, CaseIterable {
+    case contentLength
+    case newline
+}
+
+private enum WirePalette: String, CaseIterable {
+    case core
+    case expanded
+    case full
+
+    var serverProfile: String { self == .full ? "full" : "core" }
+    var requiresExpansion: Bool { self == .expanded }
 }

--- a/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
+++ b/brain-bar/Tests/BrainBarTests/SocketIntegrationTests.swift
@@ -1817,6 +1817,39 @@ final class SocketIntegrationTests: XCTestCase {
         XCTAssertNotNil(notice["reason"] as? String)
     }
 
+    func testOverLimitRawToolsListAlreadyAtDescriptionFloorEmitsNotice() throws {
+        let shortDescription = "Short tool contract."
+        let tools: [[String: Any]] = (0..<617).map { index in
+            [
+                "name": "floor_tool_\(index)",
+                "description": shortDescription,
+                "inputSchema": ["type": "object"] as [String: Any],
+            ]
+        }
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": ["tools": tools] as [String: Any],
+        ]
+
+        let encoded = try XCTUnwrap(BrainBarServer.encodeRawJSONResponse(response))
+        XCTAssertGreaterThanOrEqual(encoded.count, 8192, "the floor case must remain over the limit")
+
+        let decoded = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        let result = try XCTUnwrap(decoded["result"] as? [String: Any])
+        let decodedTools = try XCTUnwrap(result["tools"] as? [[String: Any]])
+        XCTAssertEqual(decodedTools.count, tools.count, "the floor path must preserve every tool")
+        XCTAssertTrue(decodedTools.allSatisfy { ($0["description"] as? String) == shortDescription })
+
+        let meta = try XCTUnwrap(result["_meta"] as? [String: Any])
+        let notice = try XCTUnwrap(meta["brainlayer/descriptionsTruncated"] as? [String: Any])
+        XCTAssertEqual(notice["budgetChars"] as? Int, 48)
+        XCTAssertEqual(notice["tools"] as? [String], [])
+        XCTAssertNotNil(notice["reason"] as? String)
+    }
+
     /// The shipped palette must fit rung 1 — full descriptions, no truncation at all.
     /// If a new tool pushes the raw line over, this fails LOUDLY here instead of
     /// quietly shipping shortened contracts to every agent.

--- a/src/brainlayer/mcp/__init__.py
+++ b/src/brainlayer/mcp/__init__.py
@@ -461,7 +461,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_search",
             title="Search Knowledge Base",
-            description="""Search BrainLayer's persistent memory for past decisions, project history, debugging notes, preferences, and other stored knowledge. Use when: the user asks what was decided before, how something was implemented, what happened to a file, or what you are working on. Don't use when: you need current session context or stats (use brain_recall), a named entity graph lookup (use brain_entity), or to save new information (use brain_store). query should be a natural-language lookup phrase; file_path switches to file-history routing, chunk_id expands a known result, and project narrows scope. num_results defaults to 5 and detail defaults to 'compact'; add date, tag, intent, or source filters only when they materially narrow the search. Returns ranked matches with scores, metadata, and compact snippets or full content; after finding a promising chunk, call brain_search with chunk_id or use brain_recall for session-level context.""",
+            description="""Search memory for past decisions, bugs, notes, and project history by topic. Use when asked "have we done this", "what did we decide", "how did I implement X". For session context, not topics, use brain_recall.""",
             annotations=_READ_ONLY,
             meta=_MAX_RESULT_META,
             input_schema=_bounded_input_schema(
@@ -644,7 +644,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_resume",
             title="Resume From PreCompact Checkpoint",
-            description="""Return recent PreCompact checkpoint chunks for session recovery. Use when: an agent asks what it was working on after compaction or needs explicit session-restore state. Don't use for normal topical search; brain_search excludes checkpoints by default to avoid checkpoint pollution. session_id narrows to one session when known, and lookback_days defaults to 7.""",
+            description="""Return the recent PreCompact checkpoints so an agent can pick up what it was doing after a compaction. For topic lookup use brain_search.""",
             annotations=_READ_ONLY,
             meta=_MAX_RESULT_META,
             input_schema=_bounded_input_schema(
@@ -670,7 +670,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_store",
             title="Store Memory",
-            description="""Save decisions, learnings, corrections, and issues so future sessions can retrieve the reasoning with brain_search. Use when: you decided something, learned something important, hit a bug worth tracking, or were corrected. Don't use when: retrieving knowledge (brain_search), indexing large text (brain_digest), or archiving/superseding (brain_archive, brain_supersede). content explains what happened and why; type auto-detects, and project, tags, importance improve retrieval. Decision fields, issue fields, and supersedes are described in the schema. Every call returns ONE outcome, in the text and in structured `status`: STORED (new chunk); DUPLICATE (identical memory already stored); MERGED (near-identical, folded in); DEFERRED (queued while the DB is busy — it WILL be stored under the same chunk_id). All four resolve to a canonical chunk_id and are SUCCESS: do NOT re-store, do NOT retry, never save a fallback copy. REJECTED (gate refused) and ERROR (write failed) store nothing and return no chunk_id.""",
+            description="""Store a decision, correction, bug cause, or learning so future sessions find it. status STORED|DUPLICATE|MERGED|DEFERRED all = success, do NOT re-store (DEFERRED is queued and will be stored); REJECTED|ERROR store nothing and return no `status` or chunk_id. For long raw text use brain_digest.""",
             annotations=_WRITE,
             input_schema=_bounded_input_schema(
                 {
@@ -774,7 +774,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_get_person",
             title="Get Person Context",
-            description="""Get a person's profile, graph relations, and linked memories in one call. Use when: preparing for a meeting, recalling someone's preferences or constraints, or gathering person-specific context before taking action. Don't use when: you need fuzzy topic search across all memories (use brain_search), generic entity lookup without scoped memories (use brain_entity), or you are storing new information about the person (use brain_store). name should be the best-known person name; context reranks memories for the current task, and num_memories defaults to 10. Returns profile fields, related entities, and relevant memory chunks; after identifying the right person, use brain_search for broader topic recall if needed.""",
+            description="""Get one person's profile, relations, and linked memories in a single call.""",
             annotations=_READ_ONLY,
             meta=_MAX_RESULT_META,
             input_schema=_bounded_input_schema(
@@ -804,7 +804,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_recall",
             title="Recall / Search / Entity Lookup",
-            description="""Get working context, recent sessions, plan/session links, per-session operations, summaries, stats, or routed search from one entry point. Use when: you need 'what am I working on', recent session history, plan linkage, operation groups for a session, or knowledge-base health stats. Don't use when: you already know you want topical memory search (use brain_search), a direct entity graph lookup (use brain_entity), or to store or digest new content (use brain_store or brain_digest). mode can be explicit or auto-detected from query; session_id is required for operations and summary, plan_name targets plan mode, and hours, days, and limit control context windows. In search mode, file_path, chunk_id, content filters, num_results, and detail='compact'|'full' behave like brain_search. Returns structured context, search results, or stats depending on mode; use brain_search after broad routing when you need tighter topical retrieval.""",
+            description="""Get session-level context: what you are working on now, recent sessions, one session's detail, or knowledge-base stats. For topic lookup use brain_search.""",
             annotations=_RECALL_READ_ONLY,
             meta=_MAX_RESULT_META,
             input_schema=_bounded_input_schema(
@@ -988,7 +988,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_digest",
             title="Digest Content",
-            description="""Digest large text content into searchable memory plus extracted entities and relations in the knowledge graph. Use when: processing research notes, audits, transcripts, or other large text that should be deeply indexed instead of stored as a quick note. Don't use when: a short decision or learning can be saved directly with brain_store, you only need to retrieve knowledge with brain_search, or you want a specific entity lookup with brain_entity. mode='digest' writes a new enriched chunk, mode='connect' compares content to existing knowledge and returns a proposed connection or supersede plan without storing, and mode='enrich' backfills existing chunks using limit. content should be the raw text; title, project, and participants improve extraction quality. Returns extracted entity and relation counts or a proposal, and you can inspect the indexed result later with brain_search or brain_entity.""",
+            description="""Digest a large block of raw text (transcript, doc, article) into one searchable memory chunk: it enriches the text and connects the entities it extracts into the knowledge graph. For a short note use brain_store.""",
             annotations=_WRITE,
             input_schema=_bounded_input_schema(
                 {
@@ -1031,7 +1031,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_entity",
             title="Entity Lookup",
-            description="""Look up a known entity and traverse its relationships in the knowledge graph. Use when: the user names a specific person, project, company, library, tool, or technology and you need structured connections rather than fuzzy search. Don't use when: you need broad topical recall across memories (use brain_search), person-specific profile plus memories in one call (use brain_get_person), or to save new facts (use brain_store or brain_digest). query should be the likely entity name; action defaults to 'lookup', while action='list' browses an entity_type with limit and offset pagination. Returns entity records plus connected relations, and after finding the right entity you can use brain_search to pull narrative memory around it.""",
+            description="""Look up a named person, project, company, or tool in the knowledge graph and return its relations. For fuzzy topical recall use brain_search.""",
             annotations=_READ_ONLY,
             meta=_MAX_RESULT_META,
             input_schema=_bounded_input_schema(
@@ -1210,7 +1210,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_supersede",
             title="Supersede Memory",
-            description="""Mark an old chunk as replaced by a newer one and remove the old chunk from default search while keeping history. Use when: a technical fact, decision, or learning has been updated and search should prefer the replacement. Don't use when: you are writing the new memory itself (use brain_store with supersedes if you are creating it now) or you only need to hide a stale chunk without a replacement (use brain_archive). old_chunk_id and new_chunk_id are required; safety_check defaults to 'auto' for technical content, while personal data requires safety_check='confirm' and confirm=True. Returns the action taken, and you can verify the surviving record with brain_search.""",
+            description="""Mark an old chunk as replaced by a newer one and hide it from search. To hide with no replacement use brain_archive.""",
             annotations=_DESTRUCTIVE,
             input_schema=_bounded_input_schema(
                 {
@@ -1243,7 +1243,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_archive",
             title="Archive Memory",
-            description="""Archive a chunk with a soft-delete timestamp so it disappears from default search but remains recoverable. Use when: a memory is stale, irrelevant, or duplicative and should stop surfacing without being permanently deleted. Don't use when: a newer chunk should explicitly replace it (use brain_supersede) or you are writing fresh information (use brain_store). chunk_id is required and reason is optional audit metadata. Returns the archived chunk_id, and you can use brain_search or direct chunk lookup later if you need the history.""",
+            description="""Hide a chunk from default search, recoverably. To point at a replacement instead use brain_supersede.""",
             annotations=_DESTRUCTIVE,
             input_schema=_bounded_input_schema(
                 {
@@ -1265,7 +1265,7 @@ def _full_tool_definitions() -> list[Tool]:
         Tool(
             name="brain_enrich",
             title="Enrich Chunks",
-            description="""Run enrichment on existing chunks to backfill entities, summaries, and related metadata without rewriting the original memory text. Use when: you want realtime enrichment for recent writes, cheaper batch processing for backlog, local offline enrichment, or progress stats for the enrichment system. Don't use when: you are ingesting brand-new long-form content (use brain_digest), saving a quick note (use brain_store), or retrieving knowledge (use brain_search). mode defaults to 'realtime'; batch uses phase='submit'|'poll'|'import'|'run', stats=True returns progress only, and limit, since_hours, or chunk_ids narrow scope. Returns enrichment progress or per-run results, and you can inspect enriched chunks afterward with brain_search or brain_entity.""",
+            description="""Backfill summaries and enrichment metadata on existing chunks.""",
             annotations=_WRITE,
             input_schema=_bounded_input_schema(
                 {

--- a/tests/test_tool_description_quality.py
+++ b/tests/test_tool_description_quality.py
@@ -1,13 +1,37 @@
+"""Tool-description house style.
+
+Ratified doctrine: ~/Gits/skill-creator/docs.local/doctrine/tool-description-house-style.md
+(measured over 86 golems skills: median 125 chars, p90 263, max 475). Etan, 2026-08-19:
+"the tool descriptions should be extremely short. Just tell them what to do with it."
+
+The original R79 gate (PRs #212/#223) required EVERY active tool to carry a literal
+"Use when:" and "Don't use when:" clause. That gate forced prose onto tools with no
+confusable neighbour and pushed the palette 8x over the measured norm, which is what
+made the 8192-byte wire strip in issue #726 bite. Per the lead ruling of 2026-08-19 it
+is replaced by: a hard cap, a budget in the median/p90 spirit, and a not-for clause
+required ONLY for tools in the explicitly-named confusable set below.
+"""
+
+import statistics
+
 from brainlayer.mcp import _full_tool_definitions
 
-ACTIVE_TOOL_NAMES = {
-    "brain_search",
-    "brain_store",
-    "brain_recall",
-    "brain_entity",
-    "brain_digest",
-    "brain_get_person",
+# Tools with a near-neighbour an agent can plausibly pick instead. Only these owe a
+# not-for clause naming the sibling; a tool with no near-neighbour does not.
+CONFUSABLE_SIBLINGS = {
+    "brain_search": ("brain_recall",),
+    "brain_recall": ("brain_search",),
+    "brain_entity": ("brain_search",),
+    "brain_resume": ("brain_search",),
+    "brain_store": ("brain_digest",),
+    "brain_digest": ("brain_store",),
+    "brain_supersede": ("brain_archive",),
+    "brain_archive": ("brain_supersede",),
 }
+
+# Doctrine max is 475; BrainLayer's palette is small enough to sit under it.
+PER_TOOL_CEILING = 320
+MEDIAN_CEILING = 175
 
 
 def _tool_descriptions() -> dict[str, str]:
@@ -22,18 +46,42 @@ def test_all_descriptions_under_1024_chars():
         assert len(description) < 1024, f"{name} description is {len(description)} chars"
 
 
-def test_active_tools_have_use_when():
+def test_every_tool_has_a_non_empty_description():
+    for name, description in _tool_descriptions().items():
+        assert description.strip(), f"{name} has no description"
+
+
+def test_descriptions_stay_within_the_house_style_budget():
     descriptions = _tool_descriptions()
 
-    for name in sorted(ACTIVE_TOOL_NAMES):
-        assert name in descriptions, f"{name} not found in available tools"
-        assert "Use when:" in descriptions[name], f"{name} is missing 'Use when:'"
+    for name, description in descriptions.items():
+        assert len(description) <= PER_TOOL_CEILING, (
+            f"{name} is {len(description)} chars, over the {PER_TOOL_CEILING}-char ceiling"
+        )
+
+    median = statistics.median(len(d) for d in descriptions.values())
+    assert median <= MEDIAN_CEILING, f"median description length is {median} chars"
 
 
-def test_active_tools_have_dont_use():
+def test_confusable_tools_name_the_sibling_to_use_instead():
     descriptions = _tool_descriptions()
 
-    for name in sorted(ACTIVE_TOOL_NAMES):
+    for name, siblings in CONFUSABLE_SIBLINGS.items():
         assert name in descriptions, f"{name} not found in available tools"
         description = descriptions[name]
-        assert "Don't use when:" in description or "Does NOT" in description, f"{name} is missing don't-use guidance"
+        assert any(sibling in description for sibling in siblings), (
+            f"{name} is confusable with {'/'.join(siblings)} and must name the alternative"
+        )
+
+
+def test_brain_store_keeps_its_outcome_contract():
+    """PR #725's contract survives the shortening, compressed rather than cut.
+
+    Its ENFORCEMENT is the write-time dedupe, not this sentence; the sentence only
+    stops an agent re-storing on an ambiguous response.
+    """
+    description = _tool_descriptions()["brain_store"]
+
+    for outcome in ("STORED", "DUPLICATE", "MERGED", "DEFERRED", "REJECTED", "ERROR"):
+        assert outcome in description, f"brain_store lost the {outcome} outcome"
+    assert "do NOT re-store" in description


### PR DESCRIPTION
Fixes #726.

## The defect (Part A)

`BrainBarServer.encodeRawJSONResponse` stripped **every** tool `description` as soon as a raw
newline-framed `tools/list` crossed 8192 bytes (Claude Desktop's MCPB chunk limit). Core fit, so
core kept its descriptions — but calling `expand_palette` pushed the response over the limit and
came back with **0/17 descriptions**. Expanding the palette *downgraded* the contract, silently.

AGENTS.md: *"The rules for agents USING it live in the tool descriptions — keep those true."* A
description is the last thing to drop, not the first.

### The compaction ladder

`encodeRawJSONResponse` is now a ladder, and `description` survives every rung it can:

| Rung | Drops | Why |
|---|---|---|
| 0 | nothing | payload already fits |
| 1 | `annotations` + `inputSchema` property prose | an agent needs neither to pick nor to call a tool |
| 2 | shortens descriptions, **never removes them** | binary-searches the largest per-tool budget that fits |

Rung 2 marks each shortened description `…[truncated]` and attaches an explicit
`result._meta["brainlayer/descriptionsTruncated"]` notice naming every affected tool, the byte
limit, the char budget, and where the full text is available. If even the 48-char floor does not
fit, the response goes out **over the limit with its contract intact** and logs why — a silent
contract-free response is the worse failure.

Fixing this by shortening alone (Part B) was explicitly rejected: a future tool addition must not
silently re-break it.

### Tests run on the wire, not at `router.handle()`

Unit tests one layer above the stripping stayed green while the wire was wrong twice in this lane.
The new tests drive a **real Unix socket**, across the full matrix (`SocketIntegrationTests`):

- `testEveryToolCarriesADescriptionOnEveryProfileAndFraming` — core / expanded / full × newline /
  Content-Length; every tool must carry a non-empty description.
- `testRawLineToolsListStaysUnderTheChunkLimitOnEveryProfile`
- `testBrainStoreIsInTheDefaultPaletteWithItsDescriptionOnBoot` — Etan's expectation, verified on
  the wire in both framings: `brain_store` is in the boot palette and its outcome contract is
  present with no `expand_palette` call.
- `testShippedPalettesFitWithoutAnyDescriptionTruncation` — the shipped palette must fit rung 1.
  A new tool that pushes it into rung 2 fails **loudly here** instead of quietly shipping
  shortened contracts.
- `testOversizedRawToolsListTruncatesDescriptionsWithAnExplicitNotice` — exercises rung 2 on a
  40-tool payload.

## The rewrite (Part B)

Per skillCreator's doctrine — `~/Gits/skill-creator/docs.local/doctrine/tool-description-house-style.md`,
measured across 86 golems skills: median 125 chars, p90 263, max 475 — and Etan, 2026-08-19:
*"the tool descriptions should be extremely short. Just tell them what to do with it."*

Shape, in priority order: (a) what it does as a verb phrase, (b) the words a user actually says,
(c) a one-clause not-for **only** where a sibling is genuinely confusable. Cut: parameter prose,
rationale, history, examples, reassurance.

PR #725's outcome contract is kept, compressed:

> `status STORED|DUPLICATE|MERGED|DEFERRED = success, do NOT re-store; REJECTED|ERROR = nothing
> stored, no chunk_id.`

Its **enforcement** is the write-time dedupe, not the sentence. Descriptions state; they do not
enforce (measured: `send_to`'s length warning was correct, prominent, and ignored by two leads
hours apart — the fix there was a PreToolUse gate).

## Numbers — response bytes on the wire

| profile × framing | before | after Part A | after Part B |
|---|---|---|---|
| core × Content-Length | 1641 | 1641 | 1641 |
| core × newline | 1642 | 1642 | 1642 |
| expanded × Content-Length | 12385 | 12385 | **10775** |
| full × Content-Length | 12385 | 12385 | **10775** |
| expanded × newline | 4083 (**0/17 descriptions**) | 7939 (17/17) | **6329 (17/17)** |
| full × newline | 4083 (**0/17 descriptions**) | 7939 (17/17) | **6329 (17/17)** |

Part A alone restored 17/17 descriptions with only 253 bytes of headroom under the 8192 limit.
Part B widened that to 1863 bytes (~23%). Shortening buys headroom; the ladder removes the cliff.

### Description lengths vs the measured norm

skillCreator measured the golems skill library (86 skills, `check-skill-library.mjs`):
**median 125 · p90 263 · max 475**. BrainBar's palette before this PR:

| | before | after | norm |
|---|---|---|---|
| median | 89 | 94 | 125 |
| p90 | 337 | 212 | 263 |
| max | 1158 (`brain_store`) | 293 | 475 |
| total (17 tools) | 3576 | 1957 | — |

The median barely moves — most tools were already terse. What was broken was the tail:
`brain_store` alone was an 8x outlier, and the p90 sat above the library max. Python surface
(10 rewritten tools): 7563 -> 1500 chars.

(`brain_expand` / `brain_tags` are deprecated on the Python path and left alone.)

## Test gate change (lead ruling, 2026-08-19)

`tests/test_tool_description_quality.py`'s blanket requirement that all 6 active tools contain
`"Use when:"` **and** `"Don't use when:"` (origin R79, PRs #212/#223) is replaced. That gate forced
prose onto tools with no confusable neighbour and pushed the palette 8× over the measured norm —
which is what made the 8192-byte strip bite. Now:

- `<1024` hard cap kept;
- budget assertions in the median/p90 spirit (per-tool ≤320, median ≤175);
- a not-for clause required **only** for tools in an explicitly-named confusable set.

Mirrored in Swift as `ToolDescriptionHouseStyleTests`.

## Not claimed

cmux #121's controlled tool-routing eval found **no** wording effect (100% accuracy across
control / verbatim / rewrite). This PR does not claim better tool selection. It restores a contract
that was missing entirely, and cuts the boot payload.

## Verification

- `swift test` — **888 tests, 0 failures**, 0 compile errors (BrainBar, final wording)
- `pytest` — **4264 passed, 3 failed**; all three are pre-existing or environmental, none from
  this PR:
  - `test_think_recall_integration.py::TestSessionsReal::test_sessions_returns_data`
  - `test_think_recall_integration.py::TestSessionsReal::test_sessions_golems_project`
    — both fail **identically on unmodified `origin/main`**, verified by running them in a clean
    throwaway worktree checked out at `c9a4d28d`. They are real-DB tests.
  - `test_mcp_lazy_startup.py::test_handshake_fast_under_db_write_lock` — a latency assertion under
    a DB write lock; timing-sensitive under full-suite load, **passes in isolation on this branch**
    (`3 passed`).
  - `test_eval_baselines.py` + `test_search_validation.py` (31 errors) are real-DB suites that
    error the same way on `origin/main`; excluded from the final run for that reason.
- `ruff check src/ tests/` — clean

Two truths my first compression pass dropped were caught by the existing suites and restored
inline, because each is something an agent acts on rather than prose: DEFERRED is queued and
**will be stored** (which is exactly why re-storing it is wrong), and `brain_digest` enriches and
connects extracted entities into the knowledge graph. A third — REJECTED/ERROR carry no `status`
(PR #725 review, MUST-FIX 2) — was caught by `StoreResponseClarityTests`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP wire behavior for Claude Desktop raw newline clients and agent-facing tool contracts; logic is well-tested on real sockets but mis-tuned truncation or budgets could still confuse agents or break chunk parsing at the limit.
> 
> **Overview**
> Fixes **#726**: expanded palettes on raw newline MCP no longer ship **0/17** tool descriptions when `tools/list` exceeds Claude Desktop’s **8192-byte** chunk limit.
> 
> **Raw-line compaction (`BrainBarServer`)** — Rung 1 still drops `annotations` and `inputSchema` prose but **keeps** top-level tool `description` (previously removed here). If still over budget, rung 2 **binary-searches** a per-tool char budget, shortens descriptions with `…[truncated]`, and sets `result._meta["brainlayer/descriptionsTruncated"]` (affected tools, limits, pointer to Content-Length for full text). Payloads that cannot fit even at the **48-char** floor go out **over-limit** with contracts intact rather than silent stripping.
> 
> **Tool copy** — Swift `MCPRouter` and Python `_full_tool_definitions()` descriptions are rewritten to short “house style”; `compactCoreToolDefinition` now **requires** a non-empty description (canonical or core override). Quality gates drop blanket `"Use when:"` / `"Don't use when:"` in favor of length budgets and **not-for** clauses only for named confusable siblings; **`brain_store`** must still list all six outcomes and “do NOT re-store”.
> 
> **Tests** — New socket integration coverage across core/expanded/full × newline/Content-Length (descriptions present, raw line under 8192, shipped palette avoids rung 2, ladder behavior on synthetic oversized payloads), plus `ToolDescriptionHouseStyleTests` / updated `test_tool_description_quality.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ef4f509075aef7fe335a38a9bf472065c816fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep top-level tool descriptions in raw-line `tools/list` by truncating instead of dropping them
> - Fixes the compaction order in `BrainBarServer.encodeRawJSONResponse`: when a raw-line payload exceeds the 8192-byte chunk limit, annotations and schema prose are dropped first, then descriptions are shortened (never removed), and a `result._meta.brainlayer/descriptionsTruncated` notice is appended naming the affected tools.
> - Adds a binary-search helper (`truncatedRawJSONResponse`) that finds the largest per-tool description budget that fits, falling back to a 48-character floor; if even that exceeds the limit, the payload is returned as-is with a notice listing zero truncated tools.
> - `compactRawJSONResponseIfNeeded` no longer strips the top-level `description` field, and `MCPRouter.compactCoreToolDefinition` now guarantees a non-empty description, trapping via `preconditionFailure` in debug when none exists.
> - Rewords tool descriptions to a concise house style across Swift ([MCPRouter.toolDefinitions](https://github.com/EtanHey/brainlayer/pull/727/files#diff-be4605f84784ab2d58f05978b5940dbdcb8713c959b79ec6ffefd94fae58b23f)) and Python ([mcp._full_tool_definitions](https://github.com/EtanHey/brainlayer/pull/727/files#diff-b707fe059f28de703d53819bf809ca800bef866d46fac9f5867e52568026f686)).
> - Behavioral Change: `compactCoreToolDefinition` will `preconditionFailure` in debug builds if a core tool definition has no usable description; raw-line responses now carry truncated descriptions with an explicit `_meta` notice instead of silently removing the field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49ef4f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->