### PR TITLE
fix: make BrainBar updates drift-proof from any starting state

### DIFF
--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -147,25 +147,31 @@ app_dir_targets_protected_resident() {
 }
 
 brew_bin() {
-    # An explicit setting is authoritative: a non-executable value means "no brew here".
+    # An explicit setting is authoritative, but an unusable value is uncertainty,
+    # not evidence that the protected resident app is unmanaged.
     if [ -n "$BRAINBAR_BREW_BIN" ]; then
         if [ -x "$BRAINBAR_BREW_BIN" ]; then
             printf '%s\n' "$BRAINBAR_BREW_BIN"
+            return 0
         fi
-        return 0
+        return 2
     fi
     if [ -x /opt/homebrew/bin/brew ]; then
         printf '%s\n' /opt/homebrew/bin/brew
         return 0
     fi
-    command -v brew 2>/dev/null || true
+    command -v brew 2>/dev/null || return 2
 }
 
 brew_manages_cask() {
-    local brew
-    brew="$(brew_bin)"
-    [ -n "$brew" ] || return 1
-    "$brew" list --cask "$BRAINBAR_CASK_NAME" >/dev/null 2>&1
+    local brew casks cask
+    brew="$(brew_bin)" || return 2
+    [ -n "$brew" ] || return 2
+    casks="$("$brew" list --cask 2>/dev/null)" || return 2
+    while IFS= read -r cask; do
+        [ "$cask" = "$BRAINBAR_CASK_NAME" ] && return 0
+    done <<< "$casks"
+    return 1
 }
 
 # Contract rule 7 -- stop the drift at its source.
@@ -179,8 +185,22 @@ brew_manages_cask() {
 # So: refuse to write over a brew-managed BrainBar.app. Never re-register silently --
 # a build script that mutates Homebrew's ledger is a second source of truth.
 refuse_brew_managed_app_dir() {
+    local brew_status
     app_dir_targets_protected_resident || return 0
-    brew_manages_cask || return 0
+    if brew_manages_cask; then
+        brew_status=0
+    else
+        brew_status=$?
+    fi
+    if [ "$brew_status" -eq 1 ]; then
+        return 0
+    fi
+    if [ "$brew_status" -ne 0 ]; then
+        echo "[build-app] ERROR: could not determine whether Homebrew manages $BRAINBAR_CASK_NAME" >&2
+        echo "[build-app] using ${BRAINBAR_BREW_BIN:-brew discovery}; refusing to overwrite $APP_DIR." >&2
+        echo "[build-app] Build elsewhere with BRAINBAR_APP_DIR=\"\$HOME/Applications/BrainBar.app\"." >&2
+        exit 1
+    fi
 
     echo "[build-app] ERROR: refusing to build over the Homebrew-managed app at $APP_DIR" >&2
     echo "[build-app] Homebrew has $BRAINBAR_CASK_NAME registered; writing here in place creates" >&2

--- a/brain-bar/build-app.sh
+++ b/brain-bar/build-app.sh
@@ -59,6 +59,11 @@ BRAINBAR_NOTARY_KEY="${BRAINBAR_NOTARY_KEY:-}"
 BRAINBAR_NOTARY_KEY_ID="${BRAINBAR_NOTARY_KEY_ID:-}"
 BRAINBAR_NOTARY_ISSUER="${BRAINBAR_NOTARY_ISSUER:-}"
 BRAINBAR_PROTECTED_APPLICATIONS_DIR="${BRAINBAR_PROTECTED_APPLICATIONS_DIR:-/Applications}"
+# Rule 5 of the drift-proof contract: bare `brew` is not on a non-interactive ssh PATH.
+# Set BRAINBAR_BREW_BIN explicitly to pin (or, with a bogus path, to disable) the lookup.
+BRAINBAR_BREW_BIN="${BRAINBAR_BREW_BIN-}"
+BRAINBAR_CASK_NAME="${BRAINBAR_CASK_NAME:-brainbar}"
+
 UI_PLIST_LABEL="com.brainlayer.brainbar"
 DAEMON_PLIST_LABEL="com.brainlayer.brainbar-daemon"
 UI_PLIST_FILENAME="$UI_PLIST_LABEL.plist"
@@ -141,6 +146,51 @@ app_dir_targets_protected_resident() {
     [ "$(canonical_compare_path "$APP_DIR")" = "$(canonical_compare_path "$(protected_resident_app_path)")" ]
 }
 
+brew_bin() {
+    # An explicit setting is authoritative: a non-executable value means "no brew here".
+    if [ -n "$BRAINBAR_BREW_BIN" ]; then
+        if [ -x "$BRAINBAR_BREW_BIN" ]; then
+            printf '%s\n' "$BRAINBAR_BREW_BIN"
+        fi
+        return 0
+    fi
+    if [ -x /opt/homebrew/bin/brew ]; then
+        printf '%s\n' /opt/homebrew/bin/brew
+        return 0
+    fi
+    command -v brew 2>/dev/null || true
+}
+
+brew_manages_cask() {
+    local brew
+    brew="$(brew_bin)"
+    [ -n "$brew" ] || return 1
+    "$brew" list --cask "$BRAINBAR_CASK_NAME" >/dev/null 2>&1
+}
+
+# Contract rule 7 -- stop the drift at its source.
+#
+# VoiceBar lost eight weeks to exactly this: build-app.sh wrote a fresh bundle into
+# /Applications in place, brew was never told, and its ledger kept claiming the old
+# version. The next `brew upgrade --cask` then ran the OLD version's uninstall recipe
+# (`delete:` -> `sudo rm`), which has no TTY over ssh, aborted, and destroyed the
+# LaunchAgents without ever reinstalling.
+#
+# So: refuse to write over a brew-managed BrainBar.app. Never re-register silently --
+# a build script that mutates Homebrew's ledger is a second source of truth.
+refuse_brew_managed_app_dir() {
+    app_dir_targets_protected_resident || return 0
+    brew_manages_cask || return 0
+
+    echo "[build-app] ERROR: refusing to build over the Homebrew-managed app at $APP_DIR" >&2
+    echo "[build-app] Homebrew has $BRAINBAR_CASK_NAME registered; writing here in place creates" >&2
+    echo "[build-app] silent drift, and the next 'brew upgrade --cask' destroys the install." >&2
+    echo "[build-app] Do one of these instead:" >&2
+    echo "[build-app]   * update from the cask:  bash scripts/brainlayer-update-brainbar.sh" >&2
+    echo "[build-app]   * build somewhere else:  BRAINBAR_APP_DIR=\"\$HOME/Applications/BrainBar.app\" bash brain-bar/build-app.sh" >&2
+    exit 1
+}
+
 notary_credentials_available() {
     if [ -n "$BRAINBAR_NOTARY_PROFILE" ]; then
         return 0
@@ -173,7 +223,10 @@ protect_notarized_resident_before_rebuild() {
     fi
 
     echo "[build-app] ERROR: Refusing to replace notarized $(protected_resident_app_path) with an unnotarized local rebuild." >&2
-    echo "[build-app] Set BRAINBAR_NOTARY_PROFILE=notary-layers or use Homebrew: brew reinstall --cask etanhey/layers/brainbar" >&2
+    echo "[build-app] Set BRAINBAR_NOTARY_PROFILE=notary-layers or install from the cask:" >&2
+    echo "[build-app]   bash scripts/brainlayer-update-brainbar.sh" >&2
+    echo "[build-app] (Do not run 'brew reinstall'/'brew upgrade' by hand: both execute the OLD" >&2
+    echo "[build-app]  installed version's uninstall recipe, which can shell to sudo and abort.)" >&2
     return 1
 }
 
@@ -402,6 +455,7 @@ else
     APP_DIR="${BRAINBAR_APP_DIR:-$HOME/Applications/BrainBar.app}"
 fi
 normalize_app_dir_path
+refuse_brew_managed_app_dir
 
 DIRTY_STATUS="$(git -C "$CURRENT_REPO_ROOT" status --porcelain --untracked-files=all)"
 if [ -n "$DIRTY_STATUS" ] && [ "$FORCE_DIRTY" -ne 1 ]; then

--- a/scripts/brainlayer-update-brainbar.sh
+++ b/scripts/brainlayer-update-brainbar.sh
@@ -53,8 +53,9 @@ What it does:
      newly tapped one. A pre-fix 'delete:' stanza there shells to 'sudo rm', which
      has no TTY over ssh, aborts, and destroys the LaunchAgents without reinstalling.
   4. Refuse BEFORE touching anything if any path we would remove is root-owned.
-  5. Verify at the end: app version, cask version, formula, process, launchd
-     services, socket. Exit non-zero and say why if any of it is red.
+  5. Verify at the end: app version, cask version, formula, canonical CLI,
+     PATH resolution, process, launchd services, socket. Exit non-zero and say
+     why if any of it is red.
 
 recovery-no-sudo:
   If brew ever fails mid-uninstall on root-owned leftovers, do not rebuild locally.
@@ -143,7 +144,8 @@ update_tap() {
     fi
     # The tap has no upstream tracking branch, so a bare `git pull` fails. Be explicit.
     if ! run_cmd "$GIT_BIN" -C "$TAP_DIR" pull --ff-only origin "$TAP_BRANCH"; then
-        warn "Could not fast-forward $TAP_DIR from origin/$TAP_BRANCH; continuing with the tap as-is."
+        err "Could not fast-forward $TAP_DIR from origin/$TAP_BRANCH; aborting before using stale metadata."
+        return 1
     fi
 }
 
@@ -223,15 +225,28 @@ OFFERED_VERSION=""
 DRIFT_KIND=""   # none | unmanaged | stale-ledger | missing | outdated
 
 detect_state() {
+    local registered_app_version offered_app_version
     APP_VERSION="$(app_version || true)"
     REGISTERED_VERSION="$(registered_version || true)"
     OFFERED_VERSION="$(offered_version || true)"
+
+    if [[ -d "$APP_PATH" && -z "$APP_VERSION" ]]; then
+        if [[ "$VERIFY_ONLY" -eq 0 && "$DRY_RUN" -eq 0 && ! -O "$APP_PATH" ]]; then
+            assert_no_root_owned_paths
+        fi
+        err "Could not read CFBundleShortVersionString from $APP_PATH/Contents/Info.plist."
+        err "Refusing to classify or replace a present app whose version is unknown."
+        exit 4
+    fi
 
     if [[ -z "$OFFERED_VERSION" ]]; then
         err "Could not read the offered version for $CASK_TOKEN from the tap."
         err "Is the tap present? Try: $BREW_BIN tap $TAP_NAME"
         exit 4
     fi
+
+    registered_app_version="${REGISTERED_VERSION%%,*}"
+    offered_app_version="${OFFERED_VERSION%%,*}"
 
     if [[ -z "$APP_VERSION" && -z "$REGISTERED_VERSION" ]]; then
         DRIFT_KIND="missing"
@@ -240,9 +255,9 @@ detect_state() {
         DRIFT_KIND="unmanaged"
     elif [[ -z "$APP_VERSION" && -n "$REGISTERED_VERSION" ]]; then
         DRIFT_KIND="stale-ledger"
-    elif [[ "$APP_VERSION" != "$REGISTERED_VERSION" ]]; then
+    elif [[ "$APP_VERSION" != "$registered_app_version" ]]; then
         DRIFT_KIND="stale-ledger"
-    elif [[ "$APP_VERSION" != "$OFFERED_VERSION" ]]; then
+    elif [[ "$REGISTERED_VERSION" != "$OFFERED_VERSION" || "$APP_VERSION" != "$offered_app_version" ]]; then
         DRIFT_KIND="outdated"
     else
         DRIFT_KIND="none"
@@ -266,22 +281,16 @@ quarantine_stale_registration() {
     caskroom="$(caskroom_dir)"
     [[ -e "$caskroom" ]] || return 0
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-    dest="$QUARANTINE_ROOT/$stamp"
     log "Clearing the stale Caskroom registration (user-owned mv, fully reversible)."
-    run_cmd mkdir -p "$dest"
+    run_cmd mkdir -p "$QUARANTINE_ROOT"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        dest="$QUARANTINE_ROOT/$stamp.XXXXXX"
+    else
+        log "+ mktemp -d $QUARANTINE_ROOT/$stamp.XXXXXX"
+        dest="$(mktemp -d "$QUARANTINE_ROOT/$stamp.XXXXXX")"
+    fi
     run_cmd mv "$caskroom" "$dest/"
     log "  quarantined -> $dest/$CASK_NAME"
-}
-
-bootout_services() {
-    local domain label
-    domain="gui/$(id -u)"
-    for label in "$UI_LABEL" "$DAEMON_LABEL"; do
-        log "+ $LAUNCHCTL_BIN bootout $domain/$label (best effort)"
-        if [[ "$DRY_RUN" -eq 0 ]]; then
-            "$LAUNCHCTL_BIN" bootout "$domain/$label" >/dev/null 2>&1 || true
-        fi
-    done
 }
 
 adopt_install() {
@@ -302,7 +311,8 @@ apply_update() {
         unmanaged|stale-ledger|outdated)
             log "Drift detected ($DRIFT_KIND). Adopting $OFFERED_VERSION without running any uninstall recipe."
             quarantine_stale_registration
-            bootout_services
+            # Keep the current services alive until installation succeeds. The cask's
+            # postflight bootouts, bootstraps, and kickstarts both services atomically.
             adopt_install
             ;;
         *)
@@ -325,20 +335,36 @@ check() {
 }
 
 verify() {
-    local v ok
+    local v ok formula_version canonical_cli canonical_version path_cli expected_app_version
     log "Verification:"
 
+    expected_app_version="${OFFERED_VERSION%%,*}"
     v="$(app_version || true)"
-    [[ "$v" = "$OFFERED_VERSION" ]] && ok=1 || ok=0
-    check "app version" "$ok" "${v:-<absent>} (expected $OFFERED_VERSION)"
+    [[ "$v" = "$expected_app_version" ]] && ok=1 || ok=0
+    check "app version" "$ok" "${v:-<absent>} (expected $expected_app_version)"
 
     v="$(registered_version || true)"
     [[ "$v" = "$OFFERED_VERSION" ]] && ok=1 || ok=0
     check "cask version" "$ok" "${v:-<not registered>} (expected $OFFERED_VERSION)"
 
-    v="$("$BREW_BIN" list --versions brainlayer 2>/dev/null | awk '{print $2}')"
-    [[ -n "$v" ]] && ok=1 || ok=0
-    check "brainlayer formula" "$ok" "${v:-<not installed>}"
+    formula_version="$("$BREW_BIN" list --versions brainlayer 2>/dev/null | awk '{print $2}' || true)"
+    [[ -n "$formula_version" ]] && ok=1 || ok=0
+    check "brainlayer formula" "$ok" "${formula_version:-<not installed>}"
+
+    canonical_cli="${BREW_BIN%/*}/brainlayer"
+    canonical_version="$("$canonical_cli" --version 2>/dev/null | awk 'NF {print $NF; exit}' || true)"
+    [[ -n "$formula_version" && "$canonical_version" = "$formula_version" ]] && ok=1 || ok=0
+    check "canonical brainlayer CLI" "$ok" \
+        "$canonical_cli ${canonical_version:-<missing>} (expected ${formula_version:-installed formula version})"
+
+    path_cli="$(command -v brainlayer 2>/dev/null || true)"
+    if [[ -z "$path_cli" ]]; then
+        check "brainlayer PATH" 0 "<not on PATH> (expected $canonical_cli)"
+    elif [[ "$path_cli" != "$canonical_cli" ]]; then
+        check "brainlayer PATH" 0 "$path_cli shadows $canonical_cli"
+    else
+        check "brainlayer PATH" 1 "$path_cli"
+    fi
 
     if pgrep -x BrainBar >/dev/null 2>&1; then ok=1; else ok=0; fi
     check "BrainBar process" "$ok" "$([[ "$ok" = 1 ]] && printf running || printf 'not running')"

--- a/scripts/brainlayer-update-brainbar.sh
+++ b/scripts/brainlayer-update-brainbar.sh
@@ -197,8 +197,12 @@ assert_no_root_owned_paths() {
     local path owner
     for path in "${candidates[@]}"; do
         [[ -e "$path" ]] || continue
-        owner="$(stat -f '%u' "$path" 2>/dev/null || printf '%s' "$me")"
-        if [[ "$owner" != "$me" ]]; then
+        # `-O` is "owned by the effective uid" and is built into the shell, so the
+        # decision needs no external tool. `stat` differs between BSD and GNU (`-f`
+        # means format on macOS and FILESYSTEM on Linux), and a safety guard must not
+        # hinge on which one it got. stat is used only to name the owner in the message.
+        if [[ ! -O "$path" ]]; then
+            owner="$(stat -f '%u' "$path" 2>/dev/null || stat -c '%u' "$path" 2>/dev/null || printf 'unknown')"
             offender="$offender  $path (uid $owner)\n"
         fi
     done

--- a/scripts/brainlayer-update-brainbar.sh
+++ b/scripts/brainlayer-update-brainbar.sh
@@ -1,27 +1,65 @@
 #!/usr/bin/env bash
-# Update BrainBar through the notarized Homebrew cask artifact.
+# Drift-proof BrainBar updater.
+#
+# One command, idempotent, correct from ANY starting state: unmanaged app present,
+# stale Homebrew registration, no registration, already current, app running.
+# Never requires sudo or a TTY, so it works unattended over ssh.
+#
+# See docs.local/ and collab 2026-08-19-drift-proof-mac-sync.md for the ratified contract.
 set -euo pipefail
 
-DRY_RUN=0
+# --- configuration (env overrides exist so tests can stub every external tool) -----------
 CASK_TOKEN="${BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN:-etanhey/layers/brainbar}"
-TEST_CASK_INSTALLED="${BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED:-}"
-DRY_RUN_COMMANDS="${BRAINLAYER_UPDATE_DRY_RUN_COMMANDS:-0}"
+CASK_NAME="${CASK_TOKEN##*/}"
+APP_PATH="${BRAINLAYER_UPDATE_BRAINBAR_APP:-/Applications/BrainBar.app}"
+# Rule 5: bare `brew` is not on the M1's non-interactive ssh PATH.
+BREW_BIN="${BRAINLAYER_UPDATE_BREW_BIN:-/opt/homebrew/bin/brew}"
+TAP_NAME="${BRAINLAYER_UPDATE_TAP_NAME:-etanhey/layers}"
+TAP_DIR="${BRAINLAYER_UPDATE_TAP_DIR:-}"
+TAP_BRANCH="${BRAINLAYER_UPDATE_TAP_BRANCH:-main}"
+QUARANTINE_ROOT="${BRAINLAYER_UPDATE_QUARANTINE_DIR:-$HOME/.brainlayer/brainbar-caskroom-quarantine}"
+SOCKET_PATH="${BRAINLAYER_UPDATE_SOCKET_PATH:-/tmp/brainbar.sock}"
+LAUNCHCTL_BIN="${BRAINLAYER_UPDATE_LAUNCHCTL_BIN:-/bin/launchctl}"
+DEFAULTS_BIN="${BRAINLAYER_UPDATE_DEFAULTS_BIN:-/usr/bin/defaults}"
+GIT_BIN="${BRAINLAYER_UPDATE_GIT_BIN:-git}"
+UI_LABEL="com.brainlayer.brainbar"
+DAEMON_LABEL="com.brainlayer.brainbar-daemon"
+
+DRY_RUN=0
+VERIFY_ONLY=0
+SKIP_TAP_UPDATE="${BRAINLAYER_UPDATE_SKIP_TAP_UPDATE:-0}"
+SKIP_VERIFY="${BRAINLAYER_UPDATE_SKIP_VERIFY:-0}"
 
 usage() {
     cat <<EOF
-Usage: brainlayer-update-brainbar.sh [--dry-run]
+Usage: brainlayer-update-brainbar.sh [--dry-run] [--verify-only] [--skip-tap-update]
 
-Routes BrainBar app updates through Homebrew:
-  installed:     brew reinstall --cask $CASK_TOKEN
-  not installed: brew install --cask $CASK_TOKEN
+Brings this Mac's BrainBar to the canonical tapped version from any starting state,
+without sudo and without a TTY. Running it twice is a no-op.
 
-Default reinstall command:
-  brew reinstall --cask etanhey/layers/brainbar
+  --dry-run          Print the resolved plan; change nothing.
+  --verify-only      Skip the update; just report drift and green/red status.
+  --skip-tap-update  Do not git-pull the tap (offline / already fresh).
+
+What it does:
+  1. Update the $TAP_NAME tap explicitly (bare 'brew update' does NOT refresh it,
+     and the tap has no upstream tracking branch, so a bare 'git pull' fails).
+  2. Detect drift: 'brew list --versions --cask $CASK_NAME' vs the real
+     CFBundleShortVersionString inside $APP_PATH.
+  3. On drift, quarantine the stale Caskroom registration (a user-owned mv) and
+     'brew install --cask --force' to ADOPT the app in place.
+     It never runs 'brew upgrade'/'brew reinstall': both execute the OLD installed
+     version's uninstall recipe, read from Caskroom/<cask>/.metadata/ — never the
+     newly tapped one. A pre-fix 'delete:' stanza there shells to 'sudo rm', which
+     has no TTY over ssh, aborts, and destroys the LaunchAgents without reinstalling.
+  4. Refuse BEFORE touching anything if any path we would remove is root-owned.
+  5. Verify at the end: app version, cask version, formula, process, launchd
+     services, socket. Exit non-zero and say why if any of it is red.
 
 recovery-no-sudo:
-  If brew fails mid-uninstall on root-owned leftovers, do not rebuild locally.
+  If brew ever fails mid-uninstall on root-owned leftovers, do not rebuild locally.
   The notarized .app and Homebrew receipt may still survive. Restore the user
-  LaunchAgents from the app bundle and then rerun the cask command:
+  LaunchAgents from the app bundle and then rerun this script:
 
     app="/Applications/BrainBar.app"
     agents="\$app/Contents/Resources/LaunchAgents"
@@ -37,13 +75,10 @@ EOF
 
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        --dry-run)
-            DRY_RUN=1
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
+        --dry-run) DRY_RUN=1 ;;
+        --verify-only) VERIFY_ONLY=1 ;;
+        --skip-tap-update) SKIP_TAP_UPDATE=1 ;;
+        -h|--help) usage; exit 0 ;;
         *)
             echo "[brainlayer-update-brainbar] ERROR: unknown argument: $1" >&2
             usage >&2
@@ -53,68 +88,303 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-log() {
-    printf '%s\n' "$*"
-}
-
-brainbar_cask_installed() {
-    local installed_token="${CASK_TOKEN##*/}"
-    case "$TEST_CASK_INSTALLED" in
-        1) return 0 ;;
-        0) return 1 ;;
-    esac
-    command -v brew >/dev/null 2>&1 && brew list --cask "$installed_token" >/dev/null 2>&1
-}
-
-brainbar_update_command() {
-    if brainbar_cask_installed; then
-        printf 'brew\0reinstall\0--cask\0%s\0' "$CASK_TOKEN"
-    else
-        printf 'brew\0install\0--cask\0%s\0' "$CASK_TOKEN"
-    fi
-}
-
-brainbar_update_label() {
-    local parts=()
-    while IFS= read -r -d '' part; do
-        parts+=("$part")
-    done < <(brainbar_update_command)
-    printf '%s' "${parts[*]}"
-}
+log() { printf '%s\n' "$*"; }
+err() { printf '[brainlayer-update-brainbar] ERROR: %s\n' "$*" >&2; }
+warn() { printf '[brainlayer-update-brainbar] WARN: %s\n' "$*" >&2; }
 
 run_cmd() {
     log "+ $*"
-    if [[ "$DRY_RUN" -eq 1 || "$DRY_RUN_COMMANDS" = "1" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
         return 0
     fi
     "$@"
 }
 
-print_plan() {
-    local app_update
-    app_update="$(brainbar_update_label)"
-    log "BrainLayer BrainBar update plan"
-    log "DRY RUN: $([[ "$DRY_RUN" -eq 1 ]] && printf yes || printf no)"
-    log "BRAINBAR APP UPDATE: $app_update"
-    log "Steps:"
-    log "  1. + $app_update"
-    log "  2. Homebrew installs the notarized BrainBar cask artifact"
-    log "Recovery:"
-    log "  recovery-no-sudo: restore LaunchAgents from /Applications/BrainBar.app/Contents/Resources/LaunchAgents if brew stops on root-owned leftovers."
+# --- rule 5: absolute brew ---------------------------------------------------------------
+resolve_brew() {
+    if [[ -x "$BREW_BIN" ]]; then
+        return 0
+    fi
+    local fallback
+    if fallback="$(command -v brew 2>/dev/null)" && [[ -n "$fallback" ]]; then
+        warn "$BREW_BIN is not executable; falling back to $fallback"
+        BREW_BIN="$fallback"
+        return 0
+    fi
+    err "Homebrew not found at $BREW_BIN and not on PATH."
+    err "Set BRAINLAYER_UPDATE_BREW_BIN to the absolute brew path."
+    exit 127
+}
+
+# --- rule 4: explicit tap refresh ---------------------------------------------------------
+resolve_tap_dir() {
+    if [[ -n "$TAP_DIR" ]]; then
+        return 0
+    fi
+    local repo user name
+    repo="$("$BREW_BIN" --repository 2>/dev/null || true)"
+    user="${TAP_NAME%%/*}"
+    name="${TAP_NAME##*/}"
+    if [[ -n "$repo" ]]; then
+        TAP_DIR="$repo/Library/Taps/$user/homebrew-$name"
+    fi
+}
+
+update_tap() {
+    if [[ "$SKIP_TAP_UPDATE" = "1" ]]; then
+        log "Tap update: skipped (--skip-tap-update)"
+        return 0
+    fi
+    resolve_tap_dir
+    if [[ -z "$TAP_DIR" || ! -d "$TAP_DIR/.git" ]]; then
+        log "Tap $TAP_NAME is not tapped yet; tapping it."
+        run_cmd "$BREW_BIN" tap "$TAP_NAME"
+        return 0
+    fi
+    # The tap has no upstream tracking branch, so a bare `git pull` fails. Be explicit.
+    if ! run_cmd "$GIT_BIN" -C "$TAP_DIR" pull --ff-only origin "$TAP_BRANCH"; then
+        warn "Could not fast-forward $TAP_DIR from origin/$TAP_BRANCH; continuing with the tap as-is."
+    fi
+}
+
+# --- state readers -------------------------------------------------------------------------
+app_version() {
+    [[ -d "$APP_PATH" ]] || return 1
+    "$DEFAULTS_BIN" read "$APP_PATH/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null
+}
+
+registered_version() {
+    local line
+    line="$("$BREW_BIN" list --versions --cask "$CASK_NAME" 2>/dev/null || true)"
+    [[ -n "$line" ]] || return 1
+    printf '%s\n' "$line" | awk '{print $2}'
+}
+
+offered_version() {
+    "$BREW_BIN" info --cask --json=v2 "$CASK_TOKEN" 2>/dev/null | python3 -c '
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(1)
+casks = payload.get("casks") or []
+if not casks:
+    raise SystemExit(1)
+version = casks[0].get("version") or ""
+if not version:
+    raise SystemExit(1)
+print(version)
+'
+}
+
+caskroom_dir() {
+    local prefix
+    prefix="$("$BREW_BIN" --prefix 2>/dev/null || printf '/opt/homebrew')"
+    printf '%s/Caskroom/%s\n' "$prefix" "$CASK_NAME"
+}
+
+# --- rule 3: never require sudo -------------------------------------------------------------
+# Stop BEFORE destroying anything if any path we would move or replace is root-owned.
+assert_no_root_owned_paths() {
+    local me offender=""
+    me="$(id -u)"
+    local candidates=(
+        "$APP_PATH"
+        "$(caskroom_dir)"
+        "$HOME/Library/LaunchAgents/$UI_LABEL.plist"
+        "$HOME/Library/LaunchAgents/$DAEMON_LABEL.plist"
+    )
+    local path owner
+    for path in "${candidates[@]}"; do
+        [[ -e "$path" ]] || continue
+        owner="$(stat -f '%u' "$path" 2>/dev/null || printf '%s' "$me")"
+        if [[ "$owner" != "$me" ]]; then
+            offender="$offender  $path (uid $owner)\n"
+        fi
+    done
+    if [[ -n "$offender" ]]; then
+        err "Refusing to continue: these paths are not owned by uid $me, so any"
+        err "removal would shell out to sudo and abort without a TTY:"
+        printf '%b' "$offender" >&2
+        err "Nothing has been changed. Reclaim ownership once, then rerun:"
+        err "  sudo chown -R \$(id -u):\$(id -g) <path>"
+        exit 3
+    fi
+}
+
+# --- drift detection (rule 1) ---------------------------------------------------------------
+APP_VERSION=""
+REGISTERED_VERSION=""
+OFFERED_VERSION=""
+DRIFT_KIND=""   # none | unmanaged | stale-ledger | missing | outdated
+
+detect_state() {
+    APP_VERSION="$(app_version || true)"
+    REGISTERED_VERSION="$(registered_version || true)"
+    OFFERED_VERSION="$(offered_version || true)"
+
+    if [[ -z "$OFFERED_VERSION" ]]; then
+        err "Could not read the offered version for $CASK_TOKEN from the tap."
+        err "Is the tap present? Try: $BREW_BIN tap $TAP_NAME"
+        exit 4
+    fi
+
+    if [[ -z "$APP_VERSION" && -z "$REGISTERED_VERSION" ]]; then
+        DRIFT_KIND="missing"
+    elif [[ -n "$APP_VERSION" && -z "$REGISTERED_VERSION" ]]; then
+        # An app brew does not know about — exactly today's VoiceBar disease.
+        DRIFT_KIND="unmanaged"
+    elif [[ -z "$APP_VERSION" && -n "$REGISTERED_VERSION" ]]; then
+        DRIFT_KIND="stale-ledger"
+    elif [[ "$APP_VERSION" != "$REGISTERED_VERSION" ]]; then
+        DRIFT_KIND="stale-ledger"
+    elif [[ "$APP_VERSION" != "$OFFERED_VERSION" ]]; then
+        DRIFT_KIND="outdated"
+    else
+        DRIFT_KIND="none"
+    fi
+}
+
+print_state() {
+    log "BrainBar drift-proof update"
+    log "  mode:        $([[ "$DRY_RUN" -eq 1 ]] && printf 'dry-run' || { [[ "$VERIFY_ONLY" -eq 1 ]] && printf 'verify-only' || printf 'apply'; })"
+    log "  brew:        $BREW_BIN"
+    log "  cask:        $CASK_TOKEN"
+    log "  app path:    $APP_PATH"
+    log "  app version: ${APP_VERSION:-<absent>}"
+    log "  registered:  ${REGISTERED_VERSION:-<not registered with brew>}"
+    log "  offered:     $OFFERED_VERSION"
+    log "  drift:       $DRIFT_KIND"
+}
+
+quarantine_stale_registration() {
+    local caskroom stamp dest
+    caskroom="$(caskroom_dir)"
+    [[ -e "$caskroom" ]] || return 0
+    stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    dest="$QUARANTINE_ROOT/$stamp"
+    log "Clearing the stale Caskroom registration (user-owned mv, fully reversible)."
+    run_cmd mkdir -p "$dest"
+    run_cmd mv "$caskroom" "$dest/"
+    log "  quarantined -> $dest/$CASK_NAME"
+}
+
+bootout_services() {
+    local domain label
+    domain="gui/$(id -u)"
+    for label in "$UI_LABEL" "$DAEMON_LABEL"; do
+        log "+ $LAUNCHCTL_BIN bootout $domain/$label (best effort)"
+        if [[ "$DRY_RUN" -eq 0 ]]; then
+            "$LAUNCHCTL_BIN" bootout "$domain/$label" >/dev/null 2>&1 || true
+        fi
+    done
+}
+
+adopt_install() {
+    # --force adopts an app already sitting at the target path. Without it brew says
+    # "It seems there is already an App at '<path>'" and does nothing.
+    run_cmd "$BREW_BIN" install --cask --force "$CASK_TOKEN"
+}
+
+apply_update() {
+    case "$DRIFT_KIND" in
+        none)
+            log "Already canonical at $OFFERED_VERSION — nothing to do."
+            ;;
+        missing)
+            log "BrainBar is not installed. Installing $OFFERED_VERSION."
+            adopt_install
+            ;;
+        unmanaged|stale-ledger|outdated)
+            log "Drift detected ($DRIFT_KIND). Adopting $OFFERED_VERSION without running any uninstall recipe."
+            quarantine_stale_registration
+            bootout_services
+            adopt_install
+            ;;
+        *)
+            err "Unhandled drift kind: $DRIFT_KIND"
+            exit 5
+            ;;
+    esac
+}
+
+# --- rule 6: verify at the end, fail loudly --------------------------------------------------
+VERIFY_FAILED=0
+check() {
+    local label="$1" ok="$2" detail="$3"
+    if [[ "$ok" = "1" ]]; then
+        log "  [ok]   $label: $detail"
+    else
+        log "  [FAIL] $label: $detail"
+        VERIFY_FAILED=1
+    fi
+}
+
+verify() {
+    local v ok
+    log "Verification:"
+
+    v="$(app_version || true)"
+    [[ "$v" = "$OFFERED_VERSION" ]] && ok=1 || ok=0
+    check "app version" "$ok" "${v:-<absent>} (expected $OFFERED_VERSION)"
+
+    v="$(registered_version || true)"
+    [[ "$v" = "$OFFERED_VERSION" ]] && ok=1 || ok=0
+    check "cask version" "$ok" "${v:-<not registered>} (expected $OFFERED_VERSION)"
+
+    v="$("$BREW_BIN" list --versions brainlayer 2>/dev/null | awk '{print $2}')"
+    [[ -n "$v" ]] && ok=1 || ok=0
+    check "brainlayer formula" "$ok" "${v:-<not installed>}"
+
+    if pgrep -x BrainBar >/dev/null 2>&1; then ok=1; else ok=0; fi
+    check "BrainBar process" "$ok" "$([[ "$ok" = 1 ]] && printf running || printf 'not running')"
+
+    local domain label
+    domain="gui/$(id -u)"
+    for label in "$DAEMON_LABEL" "$UI_LABEL"; do
+        if "$LAUNCHCTL_BIN" print "$domain/$label" >/dev/null 2>&1; then ok=1; else ok=0; fi
+        check "launchd $label" "$ok" "$([[ "$ok" = 1 ]] && printf loaded || printf 'not loaded')"
+    done
+
+    [[ -S "$SOCKET_PATH" ]] && ok=1 || ok=0
+    check "socket" "$ok" "$SOCKET_PATH $([[ "$ok" = 1 ]] && printf present || printf missing)"
+
+    if [[ "$VERIFY_FAILED" -eq 1 ]]; then
+        err "BrainBar is NOT green. See the [FAIL] lines above."
+        exit 1
+    fi
+    log "BrainBar is green at $OFFERED_VERSION."
 }
 
 main() {
-    print_plan
-    local command_parts=()
-    while IFS= read -r -d '' part; do
-        command_parts+=("$part")
-    done < <(brainbar_update_command)
-    if [[ "$DRY_RUN" -ne 1 && "$DRY_RUN_COMMANDS" != "1" ]] && ! command -v brew >/dev/null 2>&1; then
-        echo "[brainlayer-update-brainbar] ERROR: brew is required for BrainBar cask updates" >&2
-        exit 127
+    resolve_brew
+    if [[ "$VERIFY_ONLY" -eq 0 ]]; then
+        update_tap
     fi
-    run_cmd "${command_parts[@]}"
-    log "BrainBar update command complete."
+    detect_state
+    print_state
+
+    if [[ "$VERIFY_ONLY" -eq 1 ]]; then
+        verify
+        return 0
+    fi
+
+    if [[ "$DRIFT_KIND" != "none" && "$DRY_RUN" -eq 0 ]]; then
+        assert_no_root_owned_paths
+    fi
+
+    apply_update
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        log "Dry run complete. Nothing was changed."
+        return 0
+    fi
+
+    if [[ "$SKIP_VERIFY" = "1" ]]; then
+        log "Verification skipped (BRAINLAYER_UPDATE_SKIP_VERIFY=1)."
+        return 0
+    fi
+    verify
 }
 
 main

--- a/scripts/brainlayer-update-brainbar.sh
+++ b/scripts/brainlayer-update-brainbar.sh
@@ -359,7 +359,7 @@ verify() {
 
     path_cli="$(command -v brainlayer 2>/dev/null || true)"
     if [[ -z "$path_cli" ]]; then
-        check "brainlayer PATH" 0 "<not on PATH> (expected $canonical_cli)"
+        log "  [WARN] brainlayer PATH: <not on PATH>; add ${canonical_cli%/*} to PATH to invoke brainlayer by name"
     elif [[ "$path_cli" != "$canonical_cli" ]]; then
         check "brainlayer PATH" 0 "$path_cli shadows $canonical_cli"
     else

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -84,6 +84,9 @@ def _run_build_script(
     env.pop("BRAINBAR_APP_DIR", None)
     env["HOME"] = str(home)
     env["BRAINBAR_CANONICAL_REPO_ROOT"] = str(canonical_root)
+    # Default every test to "Homebrew does not manage BrainBar here" so the
+    # brew-managed refusal guard cannot depend on the developer's real machine.
+    env["BRAINBAR_BREW_BIN"] = str(repo / "no-such-brew")
     if extra_env:
         env.update(extra_env)
     cmd = ["bash", str(script)]
@@ -579,7 +582,7 @@ def test_build_app_refuses_to_clobber_notarized_resident_with_unnotarized_rebuil
     assert result.returncode == 1
     assert f"Refusing to replace notarized {resident_app} with an unnotarized local rebuild" in result.stderr
     assert "BRAINBAR_NOTARY_PROFILE=notary-layers" in result.stderr
-    assert "brew reinstall --cask etanhey/layers/brainbar" in result.stderr
+    assert "bash scripts/brainlayer-update-brainbar.sh" in result.stderr
     spctl_calls = spctl_log.read_text(encoding="utf-8")
     assert "--assess --type execute" in spctl_calls
     assert str(resident_app) in spctl_calls
@@ -1231,3 +1234,93 @@ def test_brainbar_package_declares_separate_ui_and_daemon_products() -> None:
     assert '.executable(name: "BrainBar", targets: ["BrainBar"])' in content
     assert '.executable(name: "BrainBarDaemon", targets: ["BrainBarDaemon"])' in content
     assert 'path: "Sources/BrainBarDaemon"' in content
+
+
+# --- drift-proof contract rule 7: stop the drift at its source ------------------------------
+
+
+def _brew_stub(tmp_path: Path, *, manages: bool, log: Path | None = None) -> Path:
+    stub = tmp_path / ("brew-manages" if manages else "brew-clean")
+    log_line = f"printf '%s\\n' \"$*\" >> {log}\n" if log else ""
+    stub.write_text(
+        "#!/usr/bin/env bash\n" + log_line + f"exit {0 if manages else 1}\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return stub
+
+
+def test_build_app_refuses_to_overwrite_a_brew_managed_resident_app(tmp_path: Path) -> None:
+    """VoiceBar's root cause: building in place over a brew-managed app creates silent drift."""
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    resident_app.mkdir(parents=True)
+    brew_log = tmp_path / "brew.log"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            "BRAINBAR_APP_DIR": str(resident_app),
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=True, log=brew_log)),
+        },
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert f"refusing to build over the Homebrew-managed app at {resident_app}" in result.stderr
+    assert "bash scripts/brainlayer-update-brainbar.sh" in result.stderr
+    assert "BRAINBAR_APP_DIR=" in result.stderr
+    assert "list --cask brainbar" in brew_log.read_text(encoding="utf-8")
+
+
+def test_build_app_allows_the_resident_path_when_brew_does_not_manage_it(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_apps.mkdir(parents=True)
+    resident_app = resident_apps / "BrainBar.app"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            "BRAINBAR_APP_DIR": str(resident_app),
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=False)),
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Dry run OK" in result.stdout
+    assert "refusing to build over the Homebrew-managed app" not in result.stderr
+
+
+def test_build_app_does_not_consult_brew_for_non_resident_paths(tmp_path: Path) -> None:
+    """A ~/Applications build is never brew-managed, so it must not be blocked."""
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_apps.mkdir(parents=True)
+    brew_log = tmp_path / "brew.log"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=True, log=brew_log)),
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert str(home / "Applications" / "BrainBar.app") in result.stdout
+    assert not brew_log.exists(), "consulted brew for a path Homebrew can never own"

--- a/tests/test_brainbar_build_app_guards.py
+++ b/tests/test_brainbar_build_app_guards.py
@@ -575,6 +575,7 @@ def test_build_app_refuses_to_clobber_notarized_resident_with_unnotarized_rebuil
             **_fake_build_env(tmp_path, tool_dir, bin_dir),
             "BRAINBAR_APP_DIR": f"{resident_app}/",
             "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=False)),
             "BRAINBAR_FAKE_SPCTL_LOG": str(spctl_log),
         },
     )
@@ -608,6 +609,7 @@ def test_build_app_refuses_equivalent_protected_resident_path(tmp_path: Path) ->
             **_fake_build_env(tmp_path, tool_dir, bin_dir),
             "BRAINBAR_APP_DIR": str(linked_apps / "BrainBar.app"),
             "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=False)),
             "BRAINBAR_FAKE_SPCTL_LOG": str(spctl_log),
         },
     )
@@ -641,6 +643,7 @@ def test_build_app_keeps_notarized_resident_when_notarization_fails(tmp_path: Pa
             **_fake_build_env(tmp_path, tool_dir, bin_dir),
             "BRAINBAR_APP_DIR": str(resident_app),
             "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=False)),
             "BRAINBAR_NOTARY_PROFILE": "notary-layers",
             "BRAINBAR_FAKE_NOTARYTOOL_FAIL": "1",
         },
@@ -668,6 +671,7 @@ def test_build_app_allows_notarized_resident_rebuild_when_notary_profile_is_set(
             **_fake_build_env(tmp_path, tool_dir, bin_dir),
             "BRAINBAR_APP_DIR": f"{resident_app}/",
             "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=False)),
             "BRAINBAR_NOTARY_PROFILE": "notary-layers",
         },
     )
@@ -1239,11 +1243,27 @@ def test_brainbar_package_declares_separate_ui_and_daemon_products() -> None:
 # --- drift-proof contract rule 7: stop the drift at its source ------------------------------
 
 
-def _brew_stub(tmp_path: Path, *, manages: bool, log: Path | None = None) -> Path:
+def _brew_stub(
+    tmp_path: Path,
+    *,
+    manages: bool,
+    log: Path | None = None,
+    query_error: bool = False,
+) -> Path:
     stub = tmp_path / ("brew-manages" if manages else "brew-clean")
     log_line = f"printf '%s\\n' \"$*\" >> {log}\n" if log else ""
+    list_output = "printf 'brainbar\\n'" if manages else "true"
     stub.write_text(
-        "#!/usr/bin/env bash\n" + log_line + f"exit {0 if manages else 1}\n",
+        "#!/usr/bin/env bash\n"
+        + log_line
+        + f"""if [[ "$*" == "list --cask" ]]; then
+  {"exit 42" if query_error else f"{list_output}; exit 0"}
+fi
+if [[ "$*" == "list --cask brainbar" ]]; then
+  {"exit 42" if query_error else f"exit {0 if manages else 1}"}
+fi
+exit 1
+""",
         encoding="utf-8",
     )
     stub.chmod(0o755)
@@ -1275,7 +1295,7 @@ def test_build_app_refuses_to_overwrite_a_brew_managed_resident_app(tmp_path: Pa
     assert f"refusing to build over the Homebrew-managed app at {resident_app}" in result.stderr
     assert "bash scripts/brainlayer-update-brainbar.sh" in result.stderr
     assert "BRAINBAR_APP_DIR=" in result.stderr
-    assert "list --cask brainbar" in brew_log.read_text(encoding="utf-8")
+    assert "list --cask" in brew_log.read_text(encoding="utf-8")
 
 
 def test_build_app_allows_the_resident_path_when_brew_does_not_manage_it(tmp_path: Path) -> None:
@@ -1324,3 +1344,51 @@ def test_build_app_does_not_consult_brew_for_non_resident_paths(tmp_path: Path) 
     assert result.returncode == 0, result.stdout + result.stderr
     assert str(home / "Applications" / "BrainBar.app") in result.stdout
     assert not brew_log.exists(), "consulted brew for a path Homebrew can never own"
+
+
+def test_build_app_fails_closed_when_brew_inventory_query_errors(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    resident_app.mkdir(parents=True)
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            "BRAINBAR_APP_DIR": str(resident_app),
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(_brew_stub(tmp_path, manages=False, query_error=True)),
+        },
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "could not determine whether Homebrew manages" in result.stderr
+
+
+def test_build_app_fails_closed_for_unusable_explicit_brew_path(tmp_path: Path) -> None:
+    repo, script = _prepare_build_repo(tmp_path, "brainlayer-canonical")
+    home = tmp_path / "home"
+    resident_apps = tmp_path / "Applications"
+    resident_app = resident_apps / "BrainBar.app"
+    resident_app.mkdir(parents=True)
+    missing_brew = tmp_path / "missing-brew"
+
+    result = _run_build_script(
+        repo,
+        script,
+        canonical_root=repo,
+        home=home,
+        extra_env={
+            "BRAINBAR_APP_DIR": str(resident_app),
+            "BRAINBAR_PROTECTED_APPLICATIONS_DIR": str(resident_apps),
+            "BRAINBAR_BREW_BIN": str(missing_brew),
+        },
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert str(missing_brew) in result.stderr
+    assert "could not determine whether Homebrew manages" in result.stderr

--- a/tests/test_brainbar_update_script.py
+++ b/tests/test_brainbar_update_script.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import json
 import os
 import plistlib
+import socket
 import subprocess
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -378,7 +380,7 @@ def test_ownership_guard_does_not_depend_on_bsd_or_gnu_stat() -> None:
 
 
 def test_script_never_invokes_sudo(tmp_path: Path) -> None:
-    """Behavioral, not grep: a logging `sudo` stub must never be called, from any state."""
+    """Future tripwire: the updater itself must not call a logging `sudo` stub."""
     for label, registered, installed in (
         ("unmanaged", None, "1.5.8"),
         ("stale-ledger", "1.5.2", "1.5.8"),
@@ -508,19 +510,26 @@ def test_verify_rejects_a_non_homebrew_brainlayer_shadow_on_path(tmp_path: Path)
     assert f"[FAIL] brainlayer PATH: {shadow_cli} shadows {h.bin_dir / 'brainlayer'}" in result.stdout
 
 
-def test_verify_rejects_non_login_path_without_homebrew_cli(tmp_path: Path) -> None:
+def test_verify_warns_but_passes_non_login_path_without_homebrew_cli(tmp_path: Path) -> None:
     h = _Harness(tmp_path)
     h.install_stubs(offered="1.5.8", registered="1.5.8", formula="1.5.8")
     _make_app(h.app_path, "1.5.8")
+    non_login_bin = tmp_path / "non-login-bin"
+    _write_exec(non_login_bin / "pgrep", "#!/usr/bin/env bash\nexit 0\n")
 
-    result = h.run(
-        "--verify-only",
-        BRAINLAYER_UPDATE_SKIP_VERIFY="0",
-        PATH=f"/usr/bin{os.pathsep}/bin",
-    )
+    with tempfile.TemporaryDirectory(prefix="pr729-", dir="/tmp") as socket_dir:
+        socket_path = Path(socket_dir) / "brainbar.sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as brainbar_socket:
+            brainbar_socket.bind(str(socket_path))
+            result = h.run(
+                "--verify-only",
+                BRAINLAYER_UPDATE_SKIP_VERIFY="0",
+                BRAINLAYER_UPDATE_SOCKET_PATH=str(socket_path),
+                PATH=f"{non_login_bin}{os.pathsep}/usr/bin{os.pathsep}/bin",
+            )
 
-    assert result.returncode == 1, result.stdout + result.stderr
-    assert f"[FAIL] brainlayer PATH: <not on PATH> (expected {h.bin_dir / 'brainlayer'})" in result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"[WARN] brainlayer PATH: <not on PATH>; add {h.bin_dir} to PATH" in result.stdout
 
 
 def test_verify_checks_every_contracted_signal() -> None:

--- a/tests/test_brainbar_update_script.py
+++ b/tests/test_brainbar_update_script.py
@@ -81,6 +81,21 @@ exit 0
         )
         _write_exec(self.bin_dir / "launchctl", "#!/usr/bin/env bash\nexit 0\n")
         _write_exec(
+            self.bin_dir / "defaults",
+            """#!/usr/bin/env bash
+# usage: defaults read <plist> <key>
+exec python3 - "$2" "$3" <<'PY'
+import plistlib, sys
+try:
+    with open(sys.argv[1], "rb") as handle:
+        value = plistlib.load(handle)[sys.argv[2]]
+except Exception:
+    raise SystemExit(1)
+print(value)
+PY
+""",
+        )
+        _write_exec(
             self.bin_dir / "sudo",
             f"""#!/usr/bin/env bash
 printf '%s\\n' "$*" >> {self.sudo_log!s}
@@ -96,6 +111,7 @@ exit 1
             "BRAINLAYER_UPDATE_BREW_BIN": str(self.bin_dir / "brew"),
             "BRAINLAYER_UPDATE_GIT_BIN": str(self.bin_dir / "git"),
             "BRAINLAYER_UPDATE_LAUNCHCTL_BIN": str(self.bin_dir / "launchctl"),
+            "BRAINLAYER_UPDATE_DEFAULTS_BIN": str(self.bin_dir / "defaults"),
             "BRAINLAYER_UPDATE_BRAINBAR_APP": str(self.app_path),
             "BRAINLAYER_UPDATE_TAP_DIR": str(self.tap_dir),
             "BRAINLAYER_UPDATE_QUARANTINE_DIR": str(self.quarantine),

--- a/tests/test_brainbar_update_script.py
+++ b/tests/test_brainbar_update_script.py
@@ -267,26 +267,34 @@ def test_dry_run_changes_nothing(tmp_path: Path) -> None:
 
 
 def test_root_owned_path_stops_before_touching_anything(tmp_path: Path) -> None:
+    """The guard must fire BEFORE the mv, not after — a half-destroyed install is worse."""
     h = _Harness(tmp_path)
     h.install_stubs(offered="1.5.8", registered="1.5.2")
-    _make_app(h.app_path, "1.5.8")
     (h.caskroom / "1.5.2").mkdir(parents=True)
 
-    # `stat` is what the guard consults; stub it to report a root-owned app.
-    _write_exec(
-        h.bin_dir / "stat",
-        f"""#!/usr/bin/env bash
-if [ "$3" = "{h.app_path}" ]; then printf '0\n'; else printf '%s\n' "$(id -u)"; fi
-""",
-    )
+    # A genuinely root-owned path on both macOS and Linux — no stubbing of the
+    # ownership probe, so this exercises the real `-O` check.
+    root_owned = Path("/usr")
+    assert root_owned.exists() and root_owned.stat().st_uid == 0, "precondition: /usr is root-owned"
 
-    result = h.run()
+    result = h.run(BRAINLAYER_UPDATE_BRAINBAR_APP=str(root_owned))
 
     assert result.returncode == 3, result.stdout + result.stderr
     assert "would shell out to sudo and abort without a TTY" in result.stderr
     assert "Nothing has been changed." in result.stderr
+    assert str(root_owned) in result.stderr
     assert h.caskroom.exists(), "the guard fired AFTER destroying the registration"
     assert "install --cask" not in h.brew_calls
+
+
+def test_ownership_guard_does_not_depend_on_bsd_or_gnu_stat() -> None:
+    """`stat -f` means format on BSD and FILESYSTEM on GNU; the decision must not use it."""
+    script = UPDATE_SCRIPT.read_text(encoding="utf-8")
+    guard = script[script.index("assert_no_root_owned_paths()") : script.index("# --- drift detection")]
+    decision = guard[: guard.index("owner=")]
+    code = "\n".join(line for line in decision.splitlines() if not line.lstrip().startswith("#"))
+    assert '[[ ! -O "$path" ]]' in code
+    assert "stat" not in code, "the ownership DECISION still shells out to stat"
 
 
 def test_script_never_invokes_sudo(tmp_path: Path) -> None:

--- a/tests/test_brainbar_update_script.py
+++ b/tests/test_brainbar_update_script.py
@@ -48,14 +48,24 @@ class _Harness:
         self.app_path = tmp_path / "Applications" / "BrainBar.app"
         self.brew_log = tmp_path / "brew.log"
         self.git_log = tmp_path / "git.log"
+        self.launchctl_log = tmp_path / "launchctl.log"
         self.sudo_log = tmp_path / "sudo.log"
         self.bin_dir = tmp_path / "bin"
         self.tap_dir = tmp_path / "tap"
         (self.tap_dir / ".git").mkdir(parents=True, exist_ok=True)
 
-    def install_stubs(self, *, offered: str, registered: str | None) -> None:
+    def install_stubs(
+        self,
+        *,
+        offered: str,
+        registered: str | None,
+        formula: str | None = "0.1.0",
+        install_exit: int = 0,
+        git_exit: int = 0,
+    ) -> None:
         info = json.dumps({"casks": [{"version": offered}]})
         listed_cmd = "printf '%s\\n' " + repr(f"brainbar {registered}") if registered else "true"
+        formula_cmd = "printf '%s\\n' " + repr(f"brainlayer {formula}") if formula else "exit 1"
         _write_exec(
             self.bin_dir / "brew",
             f"""#!/usr/bin/env bash
@@ -67,19 +77,28 @@ esac
 case "$*" in
   "list --versions --cask brainbar") {listed_cmd}; exit 0 ;;
   "info --cask --json=v2 {CASK_TOKEN}") printf '%s\\n' {info!r}; exit 0 ;;
-  "list --versions brainlayer") printf 'brainlayer 0.1.0\\n'; exit 0 ;;
+  "list --versions brainlayer") {formula_cmd}; exit 0 ;;
+  "install --cask --force {CASK_TOKEN}") exit {install_exit} ;;
 esac
 exit 0
 """,
         )
+        if formula:
+            _write_exec(
+                self.bin_dir / "brainlayer",
+                f"#!/usr/bin/env bash\nprintf 'brainlayer {formula}\\n'\n",
+            )
         _write_exec(
             self.bin_dir / "git",
             f"""#!/usr/bin/env bash
 printf '%s\\n' "$*" >> {self.git_log!s}
-exit 0
+exit {git_exit}
 """,
         )
-        _write_exec(self.bin_dir / "launchctl", "#!/usr/bin/env bash\nexit 0\n")
+        _write_exec(
+            self.bin_dir / "launchctl",
+            f"#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> {self.launchctl_log!s}\nexit 0\n",
+        )
         _write_exec(
             self.bin_dir / "defaults",
             """#!/usr/bin/env bash
@@ -115,6 +134,7 @@ exit 1
             "BRAINLAYER_UPDATE_BRAINBAR_APP": str(self.app_path),
             "BRAINLAYER_UPDATE_TAP_DIR": str(self.tap_dir),
             "BRAINLAYER_UPDATE_QUARANTINE_DIR": str(self.quarantine),
+            "BRAINLAYER_UPDATE_SOCKET_PATH": str(self.tmp_path / "brainbar.sock"),
             "BRAINLAYER_UPDATE_SKIP_VERIFY": "1",
         }
         env.update(extra)
@@ -141,6 +161,10 @@ exit 1
     @property
     def sudo_calls(self) -> str:
         return self.sudo_log.read_text(encoding="utf-8") if self.sudo_log.exists() else ""
+
+    @property
+    def launchctl_calls(self) -> str:
+        return self.launchctl_log.read_text(encoding="utf-8") if self.launchctl_log.exists() else ""
 
 
 # --- rule 1: detect drift before acting ---------------------------------------------------
@@ -193,6 +217,28 @@ def test_missing_install_is_reported_as_missing(tmp_path: Path) -> None:
     assert "drift:       missing" in result.stdout
 
 
+def test_unreadable_present_app_fails_closed_instead_of_guessing_drift(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8")
+    (h.app_path / "Contents").mkdir(parents=True)
+
+    result = h.run("--dry-run")
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "Could not read CFBundleShortVersionString" in result.stderr
+
+
+def test_revision_suffix_does_not_make_matching_bundle_look_stale(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8,42", registered="1.5.8,42")
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run("--dry-run")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "drift:       none" in result.stdout
+
+
 # --- rule 2: on drift, never `brew upgrade`/`reinstall`; clear the ledger and force-adopt ---
 
 
@@ -211,6 +257,40 @@ def test_drift_clears_stale_caskroom_then_force_adopts(tmp_path: Path) -> None:
     assert quarantined, "quarantine is not reversible — the old registration was destroyed"
     assert quarantined[0].read_text(encoding="utf-8") == "stale"
     assert f"install --cask --force {CASK_TOKEN}" in h.brew_calls
+
+
+def test_quarantine_destination_is_unique_when_timestamp_already_exists(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2")
+    _make_app(h.app_path, "1.5.8")
+    (h.caskroom / "1.5.2").mkdir(parents=True)
+    (h.caskroom / "1.5.2" / "new-marker").write_text("new", encoding="utf-8")
+    existing = h.quarantine / "20260823T120000Z" / "brainbar"
+    existing.mkdir(parents=True)
+    (existing / "old-marker").write_text("old", encoding="utf-8")
+    _write_exec(h.bin_dir / "date", "#!/usr/bin/env bash\nprintf '20260823T120000Z\\n'\n")
+
+    result = h.run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    quarantined = list(h.quarantine.glob("20260823T120000Z*/brainbar"))
+    assert len(quarantined) == 2
+    assert (existing / "old-marker").read_text(encoding="utf-8") == "old"
+    assert any((path / "1.5.2" / "new-marker").exists() for path in quarantined)
+
+
+def test_failed_adopt_keeps_running_services_alive(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2", install_exit=42)
+    _make_app(h.app_path, "1.5.8")
+    (h.caskroom / "1.5.2").mkdir(parents=True)
+
+    result = h.run()
+
+    assert result.returncode == 42, result.stdout + result.stderr
+    assert "bootout" not in h.launchctl_calls
+    assert h.app_path.exists(), "failed adoption removed the still-runnable app"
+    assert list(h.quarantine.glob("*/brainbar/1.5.2")), "stale receipt was not recoverable"
 
 
 def test_update_never_runs_brew_upgrade_or_reinstall(tmp_path: Path) -> None:
@@ -344,6 +424,19 @@ def test_skip_tap_update_flag_suppresses_the_pull(tmp_path: Path) -> None:
     assert h.git_calls == ""
 
 
+def test_failed_tap_refresh_aborts_before_using_stale_metadata(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2", git_exit=23)
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run()
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "Could not fast-forward" in result.stderr
+    assert "aborting" in result.stderr
+    assert "install --cask" not in h.brew_calls
+
+
 # --- rule 5: absolute brew path ------------------------------------------------------------
 
 
@@ -383,12 +476,61 @@ def test_verify_only_fails_loudly_when_not_green(tmp_path: Path) -> None:
     assert "BrainBar is NOT green" in result.stderr
 
 
+def test_verify_reports_formula_absence_and_continues_remaining_checks(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8", formula=None)
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run("--verify-only", BRAINLAYER_UPDATE_SKIP_VERIFY="0")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "[FAIL] brainlayer formula: <not installed>" in result.stdout
+    assert "[FAIL] socket:" in result.stdout, "verification stopped at the first failed probe"
+
+
+def test_verify_rejects_a_non_homebrew_brainlayer_shadow_on_path(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8", formula="1.5.8")
+    _make_app(h.app_path, "1.5.8")
+    shadow_dir = tmp_path / "pip-shadow"
+    shadow_cli = _write_exec(
+        shadow_dir / "brainlayer",
+        "#!/usr/bin/env bash\nprintf 'brainlayer 1.5.7\\n'\n",
+    )
+
+    result = h.run(
+        "--verify-only",
+        BRAINLAYER_UPDATE_SKIP_VERIFY="0",
+        PATH=f"{shadow_dir}{os.pathsep}{h.bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin",
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert f"[FAIL] brainlayer PATH: {shadow_cli} shadows {h.bin_dir / 'brainlayer'}" in result.stdout
+
+
+def test_verify_rejects_non_login_path_without_homebrew_cli(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8", formula="1.5.8")
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run(
+        "--verify-only",
+        BRAINLAYER_UPDATE_SKIP_VERIFY="0",
+        PATH=f"/usr/bin{os.pathsep}/bin",
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert f"[FAIL] brainlayer PATH: <not on PATH> (expected {h.bin_dir / 'brainlayer'})" in result.stdout
+
+
 def test_verify_checks_every_contracted_signal() -> None:
     script = UPDATE_SCRIPT.read_text(encoding="utf-8")
     for signal in (
         '"app version"',
         '"cask version"',
         '"brainlayer formula"',
+        '"canonical brainlayer CLI"',
+        '"brainlayer PATH"',
         '"BrainBar process"',
         '"launchd $label"',
         '"socket"',

--- a/tests/test_brainbar_update_script.py
+++ b/tests/test_brainbar_update_script.py
@@ -1,8 +1,15 @@
-"""BrainBar cask update and dedupe script contracts."""
+"""BrainBar cask update and dedupe script contracts.
+
+The update script implements the drift-proof contract ratified 2026-08-19
+(collab/2026-08-19-drift-proof-mac-sync.md). Every external tool is stubbed here so
+the tests exercise the real decision logic without touching Homebrew or /Applications.
+"""
 
 from __future__ import annotations
 
+import json
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 
@@ -10,71 +17,362 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 UPDATE_SCRIPT = REPO_ROOT / "scripts" / "brainlayer-update-brainbar.sh"
 DEDUPE_SCRIPT = REPO_ROOT / "scripts" / "brainlayer-dedupe-brainbar.sh"
 
-
-def _run_update(env: dict[str, str] | None = None, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", str(UPDATE_SCRIPT), *args],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        env={**os.environ, **(env or {})},
-        timeout=30,
-    )
+CASK_TOKEN = "etanhey/layers/brainbar"
 
 
-def test_update_brainbar_reinstalls_existing_homebrew_cask_in_dry_run() -> None:
-    result = _run_update({"BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED": "1"}, "--dry-run")
-
-    assert result.returncode == 0, result.stderr
-    assert "BRAINBAR APP UPDATE: brew reinstall --cask etanhey/layers/brainbar" in result.stdout
-    assert "+ brew reinstall --cask etanhey/layers/brainbar" in result.stdout
-
-
-def test_update_brainbar_installs_homebrew_cask_when_not_installed_in_dry_run() -> None:
-    result = _run_update({"BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED": "0"}, "--dry-run")
-
-    assert result.returncode == 0, result.stderr
-    assert "BRAINBAR APP UPDATE: brew install --cask etanhey/layers/brainbar" in result.stdout
-    assert "+ brew install --cask etanhey/layers/brainbar" in result.stdout
+def _write_exec(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
 
 
-def test_update_brainbar_non_dry_run_can_be_command_stubbed_for_tests() -> None:
-    result = _run_update(
-        {
-            "BRAINLAYER_UPDATE_TEST_BREW_CASK_INSTALLED": "1",
-            "BRAINLAYER_UPDATE_DRY_RUN_COMMANDS": "1",
-        }
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert "+ brew reinstall --cask etanhey/layers/brainbar" in result.stdout
+def _make_app(path: Path, version: str) -> Path:
+    contents = path / "Contents"
+    contents.mkdir(parents=True, exist_ok=True)
+    with (contents / "Info.plist").open("wb") as handle:
+        plistlib.dump({"CFBundleShortVersionString": version}, handle)
+    return path
 
 
-def test_update_brainbar_uses_configured_cask_token_for_detection(tmp_path: Path) -> None:
-    log = tmp_path / "brew.log"
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    brew = bin_dir / "brew"
-    brew.write_text(
-        f"""#!/usr/bin/env bash
-printf '%s\\n' "$*" >> "{log}"
+class _Harness:
+    """A fully stubbed world for one update-script run."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+        self.home = tmp_path / "home"
+        self.home.mkdir(parents=True, exist_ok=True)
+        self.prefix = tmp_path / "brew-prefix"
+        self.caskroom = self.prefix / "Caskroom" / "brainbar"
+        self.quarantine = tmp_path / "quarantine"
+        self.app_path = tmp_path / "Applications" / "BrainBar.app"
+        self.brew_log = tmp_path / "brew.log"
+        self.git_log = tmp_path / "git.log"
+        self.sudo_log = tmp_path / "sudo.log"
+        self.bin_dir = tmp_path / "bin"
+        self.tap_dir = tmp_path / "tap"
+        (self.tap_dir / ".git").mkdir(parents=True, exist_ok=True)
+
+    def install_stubs(self, *, offered: str, registered: str | None) -> None:
+        info = json.dumps({"casks": [{"version": offered}]})
+        listed_cmd = "printf '%s\\n' " + repr(f"brainbar {registered}") if registered else "true"
+        _write_exec(
+            self.bin_dir / "brew",
+            f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> {self.brew_log!s}
+case "$1 $2" in
+  "--prefix ") printf '%s\\n' {self.prefix!s}; exit 0 ;;
+  "--repository ") printf '%s\\n' {self.tmp_path!s}/brew-repo; exit 0 ;;
+esac
+case "$*" in
+  "list --versions --cask brainbar") {listed_cmd}; exit 0 ;;
+  "info --cask --json=v2 {CASK_TOKEN}") printf '%s\\n' {info!r}; exit 0 ;;
+  "list --versions brainlayer") printf 'brainlayer 0.1.0\\n'; exit 0 ;;
+esac
+exit 0
+""",
+        )
+        _write_exec(
+            self.bin_dir / "git",
+            f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> {self.git_log!s}
+exit 0
+""",
+        )
+        _write_exec(self.bin_dir / "launchctl", "#!/usr/bin/env bash\nexit 0\n")
+        _write_exec(
+            self.bin_dir / "sudo",
+            f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> {self.sudo_log!s}
 exit 1
 """,
-        encoding="utf-8",
-    )
-    brew.chmod(0o755)
+        )
 
-    result = _run_update(
-        {
-            "BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN": "custom/tap/custombrainbar",
-            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-        },
-        "--dry-run",
-    )
+    def env(self, **extra: str) -> dict[str, str]:
+        env = {
+            **os.environ,
+            "HOME": str(self.home),
+            "PATH": f"{self.bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "BRAINLAYER_UPDATE_BREW_BIN": str(self.bin_dir / "brew"),
+            "BRAINLAYER_UPDATE_GIT_BIN": str(self.bin_dir / "git"),
+            "BRAINLAYER_UPDATE_LAUNCHCTL_BIN": str(self.bin_dir / "launchctl"),
+            "BRAINLAYER_UPDATE_BRAINBAR_APP": str(self.app_path),
+            "BRAINLAYER_UPDATE_TAP_DIR": str(self.tap_dir),
+            "BRAINLAYER_UPDATE_QUARANTINE_DIR": str(self.quarantine),
+            "BRAINLAYER_UPDATE_SKIP_VERIFY": "1",
+        }
+        env.update(extra)
+        return env
+
+    def run(self, *args: str, **extra_env: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", str(UPDATE_SCRIPT), *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            env=self.env(**extra_env),
+            timeout=30,
+        )
+
+    @property
+    def brew_calls(self) -> str:
+        return self.brew_log.read_text(encoding="utf-8") if self.brew_log.exists() else ""
+
+    @property
+    def git_calls(self) -> str:
+        return self.git_log.read_text(encoding="utf-8") if self.git_log.exists() else ""
+
+    @property
+    def sudo_calls(self) -> str:
+        return self.sudo_log.read_text(encoding="utf-8") if self.sudo_log.exists() else ""
+
+
+# --- rule 1: detect drift before acting ---------------------------------------------------
+
+
+def test_unmanaged_app_is_reported_as_drift(tmp_path: Path) -> None:
+    """Today's VoiceBar disease: a real app brew has never heard of."""
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered=None)
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run("--dry-run")
 
     assert result.returncode == 0, result.stderr
-    assert "list --cask custombrainbar" in log.read_text(encoding="utf-8")
-    assert "BRAINBAR APP UPDATE: brew install --cask custom/tap/custombrainbar" in result.stdout
+    assert "drift:       unmanaged" in result.stdout
+    assert "app version: 1.5.8" in result.stdout
+    assert "registered:  <not registered with brew>" in result.stdout
+
+
+def test_stale_ledger_is_reported_as_drift(tmp_path: Path) -> None:
+    """Brew's ledger said 2.1.10 while /Applications held 2.2.5."""
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2")
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run("--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "drift:       stale-ledger" in result.stdout
+
+
+def test_in_sync_and_current_reports_no_drift(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8")
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run("--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "drift:       none" in result.stdout
+
+
+def test_missing_install_is_reported_as_missing(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered=None)
+
+    result = h.run("--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "drift:       missing" in result.stdout
+
+
+# --- rule 2: on drift, never `brew upgrade`/`reinstall`; clear the ledger and force-adopt ---
+
+
+def test_drift_clears_stale_caskroom_then_force_adopts(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2")
+    _make_app(h.app_path, "1.5.8")
+    (h.caskroom / "1.5.2").mkdir(parents=True)
+    (h.caskroom / "1.5.2" / "marker").write_text("stale", encoding="utf-8")
+
+    result = h.run()
+
+    assert result.returncode == 0, result.stderr
+    assert not h.caskroom.exists(), "stale Caskroom registration was not cleared"
+    quarantined = list(h.quarantine.glob("*/brainbar/1.5.2/marker"))
+    assert quarantined, "quarantine is not reversible — the old registration was destroyed"
+    assert quarantined[0].read_text(encoding="utf-8") == "stale"
+    assert f"install --cask --force {CASK_TOKEN}" in h.brew_calls
+
+
+def test_update_never_runs_brew_upgrade_or_reinstall(tmp_path: Path) -> None:
+    """upgrade/reinstall both execute the OLD saved cask's uninstall recipe."""
+    for registered in (None, "1.5.2", "1.5.8"):
+        h = _Harness(tmp_path / f"case-{registered}")
+        h.install_stubs(offered="1.5.8", registered=registered)
+        _make_app(h.app_path, "1.5.8")
+
+        result = h.run()
+
+        assert result.returncode == 0, result.stderr
+        assert "upgrade" not in h.brew_calls, f"brew upgrade ran (registered={registered})"
+        assert "reinstall" not in h.brew_calls, f"brew reinstall ran (registered={registered})"
+
+
+def test_no_drift_is_a_no_op(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8")
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run()
+
+    assert result.returncode == 0, result.stderr
+    assert "Already canonical at 1.5.8 — nothing to do." in result.stdout
+    assert "install --cask" not in h.brew_calls
+
+
+def test_missing_install_uses_force_adopt(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered=None)
+
+    result = h.run()
+
+    assert result.returncode == 0, result.stderr
+    assert f"install --cask --force {CASK_TOKEN}" in h.brew_calls
+
+
+def test_dry_run_changes_nothing(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2")
+    _make_app(h.app_path, "1.5.8")
+    (h.caskroom / "1.5.2").mkdir(parents=True)
+
+    result = h.run("--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert h.caskroom.exists(), "dry run moved the Caskroom registration"
+    assert not h.quarantine.exists()
+    assert "Dry run complete. Nothing was changed." in result.stdout
+
+
+# --- rule 3: never require sudo/TTY; stop BEFORE destroying anything -----------------------
+
+
+def test_root_owned_path_stops_before_touching_anything(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2")
+    _make_app(h.app_path, "1.5.8")
+    (h.caskroom / "1.5.2").mkdir(parents=True)
+
+    # `stat` is what the guard consults; stub it to report a root-owned app.
+    _write_exec(
+        h.bin_dir / "stat",
+        f"""#!/usr/bin/env bash
+if [ "$3" = "{h.app_path}" ]; then printf '0\n'; else printf '%s\n' "$(id -u)"; fi
+""",
+    )
+
+    result = h.run()
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "would shell out to sudo and abort without a TTY" in result.stderr
+    assert "Nothing has been changed." in result.stderr
+    assert h.caskroom.exists(), "the guard fired AFTER destroying the registration"
+    assert "install --cask" not in h.brew_calls
+
+
+def test_script_never_invokes_sudo(tmp_path: Path) -> None:
+    """Behavioral, not grep: a logging `sudo` stub must never be called, from any state."""
+    for label, registered, installed in (
+        ("unmanaged", None, "1.5.8"),
+        ("stale-ledger", "1.5.2", "1.5.8"),
+        ("current", "1.5.8", "1.5.8"),
+        ("missing", None, None),
+    ):
+        h = _Harness(tmp_path / f"sudo-{label}")
+        h.install_stubs(offered="1.5.8", registered=registered)
+        if installed:
+            _make_app(h.app_path, installed)
+        if registered:
+            (h.caskroom / registered).mkdir(parents=True)
+
+        result = h.run()
+
+        assert result.returncode == 0, f"{label}: {result.stdout}{result.stderr}"
+        assert h.sudo_calls == "", f"{label}: script shelled out to sudo: {h.sudo_calls}"
+
+
+# --- rule 4: refresh the tap explicitly ----------------------------------------------------
+
+
+def test_tap_is_pulled_explicitly_with_a_named_remote_and_branch(tmp_path: Path) -> None:
+    """`brew update` does not refresh this tap, and it has no upstream branch."""
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8")
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run()
+
+    assert result.returncode == 0, result.stderr
+    assert f"-C {h.tap_dir} pull --ff-only origin main" in h.git_calls
+
+
+def test_skip_tap_update_flag_suppresses_the_pull(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.8")
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run("--skip-tap-update")
+
+    assert result.returncode == 0, result.stderr
+    assert h.git_calls == ""
+
+
+# --- rule 5: absolute brew path ------------------------------------------------------------
+
+
+def test_script_defaults_to_the_absolute_brew_path() -> None:
+    script = UPDATE_SCRIPT.read_text(encoding="utf-8")
+    assert 'BREW_BIN="${BRAINLAYER_UPDATE_BREW_BIN:-/opt/homebrew/bin/brew}"' in script
+
+
+def test_missing_brew_fails_loudly(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered=None)
+
+    empty_bin = tmp_path / "empty-bin"
+    empty_bin.mkdir()
+    result = h.run(
+        BRAINLAYER_UPDATE_BREW_BIN=str(tmp_path / "nope" / "brew"),
+        PATH=f"{empty_bin}{os.pathsep}/usr/bin{os.pathsep}/bin",
+    )
+
+    assert result.returncode == 127, result.stdout + result.stderr
+    assert "Homebrew not found" in result.stderr
+
+
+# --- rule 6: verify at the end, fail loudly ------------------------------------------------
+
+
+def test_verify_only_fails_loudly_when_not_green(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    h.install_stubs(offered="1.5.8", registered="1.5.2")
+    _make_app(h.app_path, "1.5.2")
+
+    result = h.run("--verify-only", BRAINLAYER_UPDATE_SKIP_VERIFY="0")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "[FAIL] app version: 1.5.2 (expected 1.5.8)" in result.stdout
+    assert "[FAIL] cask version: 1.5.2 (expected 1.5.8)" in result.stdout
+    assert "BrainBar is NOT green" in result.stderr
+
+
+def test_verify_checks_every_contracted_signal() -> None:
+    script = UPDATE_SCRIPT.read_text(encoding="utf-8")
+    for signal in (
+        '"app version"',
+        '"cask version"',
+        '"brainlayer formula"',
+        '"BrainBar process"',
+        '"launchd $label"',
+        '"socket"',
+    ):
+        assert signal in script, f"verification does not cover {signal}"
+
+
+# --- documentation contract -----------------------------------------------------------------
 
 
 def test_update_brainbar_documents_recovery_no_sudo_path() -> None:
@@ -84,7 +382,6 @@ def test_update_brainbar_documents_recovery_no_sudo_path() -> None:
     assert "Contents/Resources/LaunchAgents" in script
     assert "com.brainlayer.brainbar-daemon" in script
     assert "com.brainlayer.brainbar" in script
-    assert "brew reinstall --cask etanhey/layers/brainbar" in script
 
 
 def test_dedupe_brainbar_dry_run_makes_no_filesystem_changes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Ratified ask (Etan, 2026-08-19): *"Make sure BrainLayer and VoiceLayer are always very easy to move between the macs. I can't have this happen again."*
Contract: `orchestrator/collab/2026-08-19-drift-proof-mac-sync.md`. This PR is the **BrainLayer half**.

VoiceBar lost eight weeks today. Brew's ledger said 2.1.10; `/Applications` held 2.2.5, because a build script wrote the app in place without telling brew. `brew upgrade --cask` then correctly uninstalled 2.1.10 first — running the **old** version's `delete:` recipe → `sudo rm`. No TTY over ssh, sudo aborted, the whole uninstall aborted, LaunchAgents destroyed, install never ran.

BrainBar had the identical disease waiting, verified on both Macs:

| | this Mac | M1 |
|---|---|---|
| `/Applications/BrainBar.app` | 1.5.8 | 1.5.8 |
| `brew list --versions --cask brainbar` | *nothing* | *nothing* |

Unmanaged on both, and the cask carried the same `delete:` stanza — fixed separately in EtanHey/homebrew-layers#31 (merged).

## The important mechanism

**`brew reinstall --cask` is as dangerous as `brew upgrade --cask`.** Both run the uninstall recipe first, and Homebrew reads that recipe from the **old installed version's** saved cask in `Caskroom/<cask>/.metadata/` — never the newly tapped one. So tapping a fix does **not** disarm a machine already registered at a pre-fix version.

The old `scripts/brainlayer-update-brainbar.sh` ran `brew reinstall --cask`. It would have failed today identically.

## What changed

### `scripts/brainlayer-update-brainbar.sh` — rewritten to all 8 contract rules

1. **Detect drift first** — `brew list --versions --cask` vs the real `CFBundleShortVersionString`. Classifies `unmanaged` / `stale-ledger` / `outdated` / `missing` / `none`.
2. **Never upgrade or reinstall.** Quarantine the stale registration with a user-owned reversible `mv` into `~/.brainlayer/brainbar-caskroom-quarantine/<timestamp>/`, then `brew install --cask --force` to **adopt**. (`--force` is what adopts an app already at the target path; without it brew says *"It seems there is already an App at…"* and does nothing.)
3. **Never sudo/TTY.** The ownership guard runs **before** anything moves — a root-owned path stops the run instead of half-destroying the install.
4. **Explicit tap refresh.** `brew update` does not refresh `etanhey/layers`, and the tap has no upstream tracking branch, so a bare `git pull` fails. Uses `git -C <tap> pull --ff-only origin main`.
5. **Absolute `/opt/homebrew/bin/brew`** — bare `brew` is not on the M1's non-interactive ssh PATH and silently reads as "not installed".
6. **Verify and fail loudly** — app version, cask version, formula, process, both launchd services, socket.

New: `--verify-only` (report health, change nothing) and `--skip-tap-update`.

### `brain-bar/build-app.sh` — rule 7, the root cause

Refuses to build over a Homebrew-managed `BrainBar.app` rather than silently recreating the drift. It deliberately does **not** re-register with brew afterwards — a build script that mutates Homebrew's ledger is just a second source of truth. Its notarized-resident error also stopped recommending `brew reinstall --cask`, the very command that breaks.

## Proof — real machines, real drifted state, not a clean one

```
this Mac, run 1:  drift: unmanaged → adopt → 7/7 [ok] → green at 1.5.8
M1 over ssh,  1:  drift: unmanaged → adopt → 7/7 [ok] → green at 1.5.8   (BatchMode=yes, no TTY)
this Mac, run 2:  drift: none → "Already canonical" → green              (no-op)
M1,       run 2:  drift: none → "Already canonical" → green              (no-op)
```

No sudo prompt on either machine. `--verify-only` also caught a live problem nobody had noticed: the `com.brainlayer.brainbar` UI LaunchAgent was not loaded — the app was running outside launchd. It is loaded now.

## Tests

- `tests/test_brainbar_update_script.py` — rewritten, 30 tests, one per contract rule. The old tests asserted the `brew reinstall` behaviour that is now forbidden.
- `tests/test_brainbar_build_app_guards.py` — 42 tests (3 new for rule 7). Every test now pins `BRAINBAR_BREW_BIN` so the new guard cannot depend on the developer's real machine.
- The **never-sudo test is a future tripwire**: it proves only that this updater does not invoke a stubbed `sudo` directly across four user-owned test states. It does not exercise Homebrew's own uninstall recipes and is not evidence for this change.
- Both new guards mutation-tested — they fail when the guard is removed.
- `shellcheck -S warning` clean on both scripts; `ruff check` + `ruff format` clean. Pre-push gate green.

## Follow-ups (not in this PR)

- `Casks/brainbar.rb` **caveats** still recommend `brew reinstall` as the no-sudo escape. Same defect, doc side.
- The **VoiceLayer half** of the collab is unstarted: `scripts/voicelayer-update.sh` needs the same eight rules, and `flow-bar/build-app.sh:14` (`APP_DIR="/Applications/VoiceBar.app"`) is the original root cause and still unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

golem-id: brainlayerClaude-c0ccdbb7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Rewrites the production BrainBar install/update path: it moves Caskroom state, force-adopts `/Applications/BrainBar.app`, and can leave the machine uninstalled if brew/ownership checks fail. Fail-closed guards reduce the old sudo/TTY wipe risk, but a bug here still affects the live resident app and launchd services.
> 
> **Overview**
> Stops BrainBar from drifting off Homebrew by rewriting the updater and blocking in-place builds over a brew-managed `/Applications/BrainBar.app`.
> 
> `scripts/brainlayer-update-brainbar.sh` no longer runs `brew reinstall`/`upgrade` (those execute the *old* Caskroom uninstall recipe, which can `sudo rm` and abort over ssh). It classifies drift (`unmanaged` / `stale-ledger` / `outdated` / `missing` / `none`), quarantines the stale Caskroom receipt with a reversible user-owned `mv`, then `brew install --cask --force` to adopt. It uses an absolute brew path, fast-forwards the tap with `git pull --ff-only`, refuses root-owned paths *before* any move, and verifies app/cask/formula/CLI/PATH/process/launchd/socket. New flags: `--verify-only`, `--skip-tap-update`.
> 
> `brain-bar/build-app.sh` refuses to overwrite a Homebrew-managed resident app (and fails closed if brew inventory cannot be determined). Notarized-resident errors now point at the updater instead of `brew reinstall`.
> 
> Tests for both scripts are rewritten around the contract (stubbed brew/git/launchctl; no real `/Applications`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2e7a4da4cec55a9729a8eada188e2e5cf75252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make BrainBar updater drift-proof and guard `build-app.sh` from clobbering Homebrew installs
> - Rewrites [scripts/brainlayer-update-brainbar.sh](https://github.com/EtanHey/brainlayer/pull/729/files#diff-de4bf10b145451f408303bf14ddfd55b751933051212103907482ccb92a46140) into an idempotent updater that classifies drift (none, unmanaged, stale-ledger, missing, outdated), quarantines stale Caskroom receipts, adopts the app via `brew install --cask --force`, and verifies end-to-end health — never invoking `brew upgrade` or `brew reinstall` to avoid uninstall recipes
> - Adds guards to [brain-bar/build-app.sh](https://github.com/EtanHey/brainlayer/pull/729/files#diff-0d9dd6b7c0a835baa57cc8e887bb9c526995d9a4627bd1c1749007597e9b0fcb): `brew_bin` and `brew_manages_cask` utils resolve the brew binary and detect cask registration; `refuse_brew_managed_app_dir` aborts the build if `APP_DIR` targets the protected resident path and Homebrew manages it, or if management status is uncertain (fail-closed)
> - Adds new env vars `BRAINBAR_BREW_BIN` and `BRAINBAR_CASK_NAME` to control brew discovery and the cask name; updates messaging in `protect_notarized_resident_before_rebuild` to steer users toward the updater script
> - Replaces prior tests with hermetic harnesses in [tests/test_brainbar_build_app_guards.py](https://github.com/EtanHey/brainlayer/pull/729/files#diff-55ab4f81b7c4728e3996f37748109685b4424032a223b6ffa23835b7c4de25b6) and [tests/test_brainbar_update_script.py](https://github.com/EtanHey/brainlayer/pull/729/files#diff-ab4417c58e14b5ecdbf471761f32ac80c27256acab1f34326f649b39a26afcdd) covering guard behavior, drift classification, quarantine/adoption flow, and verification semantics
> - Behavioral Change: `build-app.sh` now exits early when targeting the protected resident path if Homebrew manages the cask or if brew status cannot be determined; the updater no longer calls `brew reinstall` or `brew upgrade`, and refuses to run under sudo
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d2e7a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## 2026-08-23 rebase + live drift evidence

- Rebased cleanly onto `ca163858` (`v1.5.9`); the release metadata/docs changes from main remain authoritative and this PR keeps its updater/build-guard intent.
- Addressed all five existing Macroscope findings: formula-probe continuation, fail-closed brew inventory, unique reversible quarantine, service survival on failed adoption, and abort-on-failed tap refresh.
- Added fail-closed coverage for unreadable app metadata and cask revision suffixes such as `1.5.8,42`.
- Added a PATH/interpreter guard: the updater verifies both `/opt/homebrew/bin/brainlayer --version` and the shell-resolved `brainlayer` path.
- RED: the 10 new regression cases failed against the rebased pre-fix scripts. GREEN: those 10 passed after the patch; the two focused files pass 72/72.
- Changed-only pre-push gate passed: mapped pytest 72/72, MCP registration 3/3, isolated eval/hook routing 40/40, Bun 1/1, and the FTS5 shell regression.
- Live `--verify-only` with the default PATH fails exactly on `/Library/Frameworks/Python.framework/Versions/3.13/bin/brainlayer` shadowing `/opt/homebrew/bin/brainlayer`; Homebrew-first PATH passes every check at 1.5.9.
- Local CodeRabbit CLI timed out after about three minutes with heartbeats only; red-team/blue-team fallback found no additional critical/high issue. The lead still owns the mandatory routed review.
- Fleet-wide LaunchAgent interpreter census is intentionally out of this BrainBar updater scope and tracked in #733.

Worker endpoint: ready for lead-routed review; do not merge from this lane.

— brainlayerCodex (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a02dd0","ts":"2026-08-23T09:24:10Z"} -->