### PR TITLE
fix(daemons): idle when idle, and never let one query peg a core forever

### DIFF
--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -45,11 +45,18 @@ MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 VECTOR_WRITE_YIELD_SECONDS = 0.005
 
 # Incident 2026-08-24: the loop slept a fixed `interval` (1.0s) whether or not a cycle
-# did any work, so an idle hotlane re-scanned a 14.8 GB SQLite DB once per second
-# forever and held ~120% CPU. Idle cycles now back off geometrically; any real work
-# snaps the cadence straight back to `interval`, so hot writes stay hot.
+# did any work, so an idle hotlane kept probing once per second forever. Idle cycles now
+# back off geometrically; any real work snaps the cadence straight back to `interval`.
+#
+# The cap is deliberately SMALL, and it is not a tuning knob to raise casually (PR #735
+# review, codex P2): a normal `brain_store` writes straight to SQLite and does not touch
+# the durable queue, so nothing here wakes on arrival — this cap IS the worst-case time a
+# freshly stored chunk stays unembedded, during which a related search can miss it.
+# Note the per-cycle idle probe is already bounded by rowid lanes (HotCandidateScanner),
+# so backing off further buys little; hotlane's real CPU burn is continuous enrichment
+# inference, tracked separately in #738.
 IDLE_BACKOFF_FACTOR = 2.0
-MAX_IDLE_INTERVAL_SECONDS = 30.0
+MAX_IDLE_INTERVAL_SECONDS = 5.0
 MAX_PENDING_CANDIDATE_SCAN_PAGES = 16
 HOT_CANDIDATE_SCAN_LIMIT = 256
 HOT_CANDIDATE_HEAD_LIMIT = HOT_CANDIDATE_SCAN_LIMIT // 2
@@ -968,10 +975,17 @@ def run(
                 )
         except Exception:
             LOGGER.exception("hotlane adapter cycle failed")
+            cycles += 1
+            # A raised cycle is a RETRY, not an idle cycle (PR #735 review, macroscope):
+            # it already slept its own backoff here, and letting it fall through to the
+            # geometric idle path would compound repeated transient failures into a much
+            # longer retry gap. Reset the idle cadence so recovery stays prompt.
+            idle_sleep = interval
             sleep_fn(min(interval * 2, 5.0))
+            continue
         cycles += 1
-        # Work resets the cadence so latency stays at `interval`; an idle cycle backs
-        # off geometrically up to MAX_IDLE_INTERVAL_SECONDS instead of re-scanning the DB.
+        # Work resets the cadence so latency stays at `interval`; an idle cycle backs off
+        # geometrically up to MAX_IDLE_INTERVAL_SECONDS instead of probing every second.
         if did_work:
             idle_sleep = interval
         sleep_fn(idle_sleep)

--- a/scripts/hotlane_brainbar_daemon.py
+++ b/scripts/hotlane_brainbar_daemon.py
@@ -43,6 +43,13 @@ MAX_BACKLOG_BATCH = 16
 DEFAULT_HOTLANE_WRITE_BUSY_TIMEOUT_MS = 1000
 MAX_APSW_BUSY_TIMEOUT_MS = 2_147_483_647
 VECTOR_WRITE_YIELD_SECONDS = 0.005
+
+# Incident 2026-08-24: the loop slept a fixed `interval` (1.0s) whether or not a cycle
+# did any work, so an idle hotlane re-scanned a 14.8 GB SQLite DB once per second
+# forever and held ~120% CPU. Idle cycles now back off geometrically; any real work
+# snaps the cadence straight back to `interval`, so hot writes stay hot.
+IDLE_BACKOFF_FACTOR = 2.0
+MAX_IDLE_INTERVAL_SECONDS = 30.0
 MAX_PENDING_CANDIDATE_SCAN_PAGES = 16
 HOT_CANDIDATE_SCAN_LIMIT = 256
 HOT_CANDIDATE_HEAD_LIMIT = HOT_CANDIDATE_SCAN_LIMIT // 2
@@ -873,9 +880,11 @@ def run(
     cycles = 0
     backlog_batch = min(max(backlog_batch, 0), MAX_BACKLOG_BATCH)
     LOGGER.info("hotlane adapter started db=%s", db_path)
+    idle_sleep = interval
     while not STOP:
         if max_cycles is not None and cycles >= max_cycles:
             break
+        did_work = False
         try:
             now = time_fn()
             queue_has_backlog = queue_depth_fn(queue_dir) > 0
@@ -888,6 +897,9 @@ def run(
                 queue_backpressure_active = True
                 if cycle_backlog_batch <= 0:
                     cycles += 1
+                    # Backpressure is not idleness: hold the configured cadence so the
+                    # reserved backlog slice resumes on time.
+                    idle_sleep = interval
                     sleep_fn(interval)
                     continue
                 cycle_recent_limit = 0
@@ -941,6 +953,10 @@ def run(
             if result.enrich_daily_cap_reached:
                 enrich_disabled = True
                 LOGGER.warning("enrichment daily cap reached; disabling hotlane enrichment until restart")
+            # A queued backlog means the system has work even when THIS cycle embedded
+            # nothing (the hot slice is deliberately suppressed to yield to the drain),
+            # so it must not be treated as idle -- backing off there would slow recovery.
+            did_work = bool(result.embedded or result.enrich_attempted) or queue_has_backlog
             if result.embedded or result.enrich_attempted:
                 LOGGER.info(
                     "embedded=%d enrich_attempted=%d enriched=%d skipped=%d failed=%d",
@@ -954,7 +970,13 @@ def run(
             LOGGER.exception("hotlane adapter cycle failed")
             sleep_fn(min(interval * 2, 5.0))
         cycles += 1
-        sleep_fn(interval)
+        # Work resets the cadence so latency stays at `interval`; an idle cycle backs
+        # off geometrically up to MAX_IDLE_INTERVAL_SECONDS instead of re-scanning the DB.
+        if did_work:
+            idle_sleep = interval
+        sleep_fn(idle_sleep)
+        if not did_work:
+            idle_sleep = min(idle_sleep * IDLE_BACKOFF_FACTOR, MAX_IDLE_INTERVAL_SECONDS)
 
 
 def main() -> None:

--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -10,17 +10,59 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import os
 import signal
 import socket
 import sys
+import threading
+import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from . import search_profile
 
 _ACCEPT_TIMEOUT_SECONDS = 0.25
 _CONNECTION_TIMEOUT_SECONDS = 5.0
+
+LOGGER = logging.getLogger(__name__)
+
+# Incident 2026-08-24: helper pid 1216 held 100% of a core for ~7 hours (46m12s of
+# CPU) inside a single query. `serve_forever()` handles one connection at a time and
+# _CONNECTION_TIMEOUT_SECONDS bounds only the SOCKET -- nothing bounded request
+# PROCESSING, so one pathological query blocked every later hybrid search forever.
+# A request that outruns this deadline is a wedge, not a slow search: we log what it
+# was running and recycle the process. BrainBar respawns the helper (verified: ~9s to
+# a warm 0%-CPU replacement), so recycling costs a warmup and loses no durable state.
+_DEFAULT_REQUEST_DEADLINE_SECONDS = 90.0
+_REQUEST_DEADLINE_EXIT_CODE = 75  # EX_TEMPFAIL -- "retryable", not a config error
+
+
+def _request_deadline_default() -> float:
+    raw = os.environ.get("BRAINLAYER_HYBRID_REQUEST_DEADLINE_S")
+    if not raw:
+        return _DEFAULT_REQUEST_DEADLINE_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_REQUEST_DEADLINE_SECONDS
+    return value if value > 0 else _DEFAULT_REQUEST_DEADLINE_SECONDS
+
+
+def _recycle_on_wedge(info: dict[str, Any]) -> None:
+    """Default abort hook: name the wedging request, then let BrainBar respawn us.
+
+    os._exit is deliberate -- the wedged thread is stuck inside SQLite and will not
+    unwind, so a graceful shutdown would just hang next to it.
+    """
+    LOGGER.critical(
+        "hybrid helper request exceeded deadline (%.1fs elapsed, limit %.1fs); recycling. request=%s",
+        info.get("elapsed_seconds", -1.0),
+        info.get("deadline_seconds", -1.0),
+        info.get("request"),
+    )
+    sys.stderr.flush()
+    os._exit(_REQUEST_DEADLINE_EXIT_CODE)
 
 
 def _json_safe(value: Any) -> Any:
@@ -36,12 +78,47 @@ def _json_safe(value: Any) -> Any:
 
 
 class HybridSearchHelper:
-    def __init__(self, socket_path: Path, db_path: Path):
+    def __init__(
+        self,
+        socket_path: Path,
+        db_path: Path,
+        request_deadline_seconds: float | None = None,
+        on_deadline_expired: Callable[[dict[str, Any]], None] = _recycle_on_wedge,
+    ):
         self.socket_path = socket_path
         self.db_path = db_path
+        self.request_deadline_seconds = (
+            _request_deadline_default() if request_deadline_seconds is None else float(request_deadline_seconds)
+        )
+        self._on_deadline_expired = on_deadline_expired
         self._stopped = False
         self._warm_called = False
         self._ready = False
+
+    def _dispatch_with_deadline(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Run one request under a hard wall-clock deadline.
+
+        The timer fires on a separate thread because the request thread is exactly the
+        one that is stuck; it cannot time itself out.
+        """
+        started = time.monotonic()
+
+        def _expired() -> None:
+            self._on_deadline_expired(
+                {
+                    "elapsed_seconds": time.monotonic() - started,
+                    "deadline_seconds": self.request_deadline_seconds,
+                    "request": request,
+                }
+            )
+
+        timer = threading.Timer(self.request_deadline_seconds, _expired)
+        timer.daemon = True
+        timer.start()
+        try:
+            return self._handle_request(request)
+        finally:
+            timer.cancel()
 
     def warm(self) -> None:
         self._warm_called = True
@@ -102,7 +179,7 @@ class HybridSearchHelper:
         try:
             raw = self._read_line(conn)
             request = json.loads(raw.decode("utf-8"))
-            response = self._handle_request(request)
+            response = self._dispatch_with_deadline(request)
         except Exception as exc:
             response = {"ok": False, "error": str(exc)}
 

--- a/src/brainlayer/brainbar_hybrid_helper.py
+++ b/src/brainlayer/brainbar_hybrid_helper.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -49,6 +50,39 @@ def _request_deadline_default() -> float:
     return value if value > 0 else _DEFAULT_REQUEST_DEADLINE_SECONDS
 
 
+_LOG_SAFE_ARG_KEYS = frozenset(
+    {"project", "source", "tag", "num_results", "max_results", "detail", "content_class", "importance_min"}
+)
+
+
+def _describe_request_for_log(request: Any) -> dict[str, Any]:
+    """Bounded, non-sensitive descriptor of a request, for the deadline log.
+
+    The helper inherits BrainBar's stderr, which launchd redirects to brainbar.err.log, so
+    logging the raw request would write a second plaintext copy of potentially personal or
+    secret-bearing memory to disk (PR #735 review, codex P2). Keep the shape and a stable
+    fingerprint -- enough to diagnose and to correlate repeat wedges -- never the text.
+    """
+    if not isinstance(request, dict):
+        return {"method": "<malformed>", "query_chars": 0, "query_sha256": ""}
+
+    arguments = request.get("arguments")
+    arguments = arguments if isinstance(arguments, dict) else {}
+    query = arguments.get("query")
+    query = query if isinstance(query, str) else ""
+
+    described: dict[str, Any] = {
+        "method": str(request.get("method") or "<none>"),
+        "query_chars": len(query),
+        "query_sha256": hashlib.sha256(query.encode("utf-8")).hexdigest()[:16],
+        "arg_keys": sorted(str(key) for key in arguments),
+    }
+    # Structural filters are safe and are often the thing that makes a query pathological.
+    for key in sorted(_LOG_SAFE_ARG_KEYS & set(arguments)):
+        described[key] = arguments[key]
+    return described
+
+
 def _recycle_on_wedge(info: dict[str, Any]) -> None:
     """Default abort hook: name the wedging request, then let BrainBar respawn us.
 
@@ -59,7 +93,7 @@ def _recycle_on_wedge(info: dict[str, Any]) -> None:
         "hybrid helper request exceeded deadline (%.1fs elapsed, limit %.1fs); recycling. request=%s",
         info.get("elapsed_seconds", -1.0),
         info.get("deadline_seconds", -1.0),
-        info.get("request"),
+        info.get("request_descriptor"),
     )
     sys.stderr.flush()
     os._exit(_REQUEST_DEADLINE_EXIT_CODE)
@@ -108,7 +142,9 @@ class HybridSearchHelper:
                 {
                     "elapsed_seconds": time.monotonic() - started,
                     "deadline_seconds": self.request_deadline_seconds,
-                    "request": request,
+                    # Descriptor only -- the raw request must not reach stderr, which
+                    # launchd redirects to brainbar.err.log (PR #735 review, codex P2).
+                    "request_descriptor": _describe_request_for_log(request),
                 }
             )
 

--- a/tests/test_daemon_idle_backoff.py
+++ b/tests/test_daemon_idle_backoff.py
@@ -1,0 +1,114 @@
+"""Incident 2026-08-24: BrainLayer daemons must go idle when there is no work.
+
+hotlane pinned 120% CPU for 29 minutes because `run()` slept a FIXED `interval`
+(1.0s) after every cycle, working or not -- so it re-scanned a 14.8 GB SQLite DB
+once per second forever. These tests pin the contract: an idle cycle backs off,
+and any real work snaps the cadence straight back to `interval`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _load_hotlane_module():
+    importlib.invalidate_caches()
+    sys.modules.pop("scripts.hotlane_brainbar_daemon", None)
+    return importlib.import_module("scripts.hotlane_brainbar_daemon")
+
+
+class _FakeStore:
+    def close(self):
+        pass
+
+
+class _FakeModel:
+    def embed_query(self, _text):
+        return [0.0]
+
+    def embed_texts(self, texts):
+        return [[0.0] * 1024 for _text in texts]
+
+
+def _run(hotlane, *, cycle_fn, cycles, sleeps, interval=1.0, **extra):
+    hotlane.run(
+        db_path=Path("/tmp/unused.db"),
+        interval=interval,
+        recent_limit=5,
+        backlog_interval=10.0,
+        backlog_batch=0,
+        enrich_interval=10.0,
+        enrich_limit=0,
+        enrich_since_hours=8760,
+        vector_store_cls=lambda _path: _FakeStore(),
+        model_factory=_FakeModel,
+        cycle_fn=cycle_fn,
+        queue_depth_fn=lambda _queue_dir: 0,
+        high_priority_queue_depth_fn=lambda _queue_dir: 0,
+        time_fn=iter([float(n) for n in range(cycles + 2)]).__next__,
+        sleep_fn=sleeps.append,
+        max_cycles=cycles,
+        **extra,
+    )
+
+
+def test_idle_cycles_back_off_instead_of_rescanning_every_second():
+    """No work for 5 cycles => the sleep must grow, not stay pinned at interval."""
+    hotlane = _load_hotlane_module()
+    sleeps: list[float] = []
+
+    _run(hotlane, cycle_fn=lambda **_k: hotlane.CycleResult(), cycles=5, sleeps=sleeps)
+
+    assert sleeps[0] == 1.0, "first idle cycle keeps the configured interval"
+    assert sleeps[-1] > sleeps[0], f"idle cadence never backed off: {sleeps}"
+    assert sleeps == sorted(sleeps), f"backoff must be monotonic: {sleeps}"
+
+
+def test_idle_backoff_is_capped():
+    """Backoff must not grow without bound -- a hot lane still has to be hot."""
+    hotlane = _load_hotlane_module()
+    sleeps: list[float] = []
+
+    _run(hotlane, cycle_fn=lambda **_k: hotlane.CycleResult(), cycles=40, sleeps=sleeps)
+
+    assert max(sleeps) <= hotlane.MAX_IDLE_INTERVAL_SECONDS, (
+        f"backoff exceeded its cap: max={max(sleeps)} cap={hotlane.MAX_IDLE_INTERVAL_SECONDS}"
+    )
+
+
+def test_work_snaps_cadence_back_to_interval():
+    """The moment a cycle embeds anything, latency must return to `interval`."""
+    hotlane = _load_hotlane_module()
+    sleeps: list[float] = []
+    calls = {"n": 0}
+
+    def cycle_fn(**_kwargs):
+        calls["n"] += 1
+        # idle for the first 4 cycles, then real work on the 5th
+        if calls["n"] == 5:
+            return hotlane.CycleResult(embedded=1)
+        return hotlane.CycleResult()
+
+    _run(hotlane, cycle_fn=cycle_fn, cycles=6, sleeps=sleeps)
+
+    assert sleeps[3] > 1.0, f"should have backed off while idle: {sleeps}"
+    assert sleeps[4] == 1.0, f"work must snap cadence back to interval: {sleeps}"
+
+
+def test_enrichment_attempt_also_counts_as_work():
+    """Enrichment is work too -- it must reset the backoff, not just embedding."""
+    hotlane = _load_hotlane_module()
+    sleeps: list[float] = []
+    calls = {"n": 0}
+
+    def cycle_fn(**_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 5:
+            return hotlane.CycleResult(enrich_attempted=1)
+        return hotlane.CycleResult()
+
+    _run(hotlane, cycle_fn=cycle_fn, cycles=6, sleeps=sleeps)
+
+    assert sleeps[4] == 1.0, f"enrichment work must reset backoff: {sleeps}"

--- a/tests/test_daemon_idle_backoff.py
+++ b/tests/test_daemon_idle_backoff.py
@@ -112,3 +112,33 @@ def test_enrichment_attempt_also_counts_as_work():
     _run(hotlane, cycle_fn=cycle_fn, cycles=6, sleeps=sleeps)
 
     assert sleeps[4] == 1.0, f"enrichment work must reset backoff: {sleeps}"
+
+
+def test_failing_cycle_is_a_retry_not_an_idle_cycle():
+    """Review finding (macroscope, PR #735): a raised cycle must not compound delays.
+
+    The exception handler already sleeps its own backoff. If the failed cycle then also
+    took the geometric idle path, repeated transient failures would stretch the retry
+    gap to ~35s (5s exception delay + a 30s idle sleep).
+    """
+    hotlane = _load_hotlane_module()
+    sleeps: list[float] = []
+
+    def always_raises(**_kwargs):
+        raise RuntimeError("transient")
+
+    _run(hotlane, cycle_fn=always_raises, cycles=6, sleeps=sleeps)
+
+    # Only the exception delay should be slept -- never a grown idle sleep on top.
+    assert max(sleeps) <= 5.0, f"failure path compounded into the idle backoff: {sleeps}"
+    assert all(s <= 5.0 for s in sleeps), f"unexpected long sleep on the failure path: {sleeps}"
+
+
+def test_idle_cap_keeps_hot_write_latency_bounded():
+    """Review finding (codex P2, PR #735): brain_store writes SQLite directly.
+
+    Nothing interrupts an idle sleep when a hot write lands, so the cap IS the
+    worst-case embed latency for a freshly stored chunk. Keep it small.
+    """
+    hotlane = _load_hotlane_module()
+    assert hotlane.MAX_IDLE_INTERVAL_SECONDS <= 5.0, "idle cap is the worst-case hot-write embed latency; keep it small"

--- a/tests/test_hybrid_helper_request_deadline.py
+++ b/tests/test_hybrid_helper_request_deadline.py
@@ -63,11 +63,13 @@ def test_fast_request_does_not_trip_the_deadline(tmp_path):
     assert not tripped.is_set(), "a fast request must never trip the deadline"
 
 
-def test_deadline_hook_receives_the_query_for_diagnosis(tmp_path):
-    """When a query wedges the helper we must be able to name it afterwards.
+def test_deadline_hook_receives_enough_to_diagnose_without_the_raw_query(tmp_path):
+    """When a query wedges the helper we must be able to characterise it afterwards.
 
-    The 2026-08-24 wedge was unattributable because the process died with no record
-    of what it was running.
+    The 2026-08-24 wedge was unattributable because the process died with no record of
+    what it was running. But the record must be a DESCRIPTOR, not the text: the helper's
+    stderr lands in brainbar.err.log, so the raw query would become a second plaintext
+    copy of personal memory (PR #735 review, codex P2).
     """
     seen: list[dict] = []
     helper = _helper(tmp_path, request_deadline_seconds=0.05, on_deadline_expired=seen.append)
@@ -83,5 +85,36 @@ def test_deadline_hook_receives_the_query_for_diagnosis(tmp_path):
     done.set()
 
     assert seen, "abort hook never fired"
-    assert "the wedging query" in str(seen[0]), f"hook must carry the query text: {seen[0]}"
+    rendered = str(seen[0])
+    assert "the wedging query" not in rendered, f"raw query must not reach the hook: {rendered}"
+    assert "brain_search" in rendered, "must still identify the method"
+    assert "query_sha256" in rendered, "must still carry a correlatable fingerprint"
     assert seen[0].get("elapsed_seconds") is not None
+
+
+def test_deadline_log_does_not_leak_the_raw_query(caplog):
+    """Review finding (codex P2, PR #735): the helper inherits BrainBar's stderr, which
+    launchd redirects to brainbar.err.log. Logging the full request would write a
+    plaintext copy of potentially personal or secret-bearing memory to a second file.
+
+    The hook still needs enough to DIAGNOSE the wedge, so a bounded descriptor is kept.
+    """
+    import logging
+
+    from brainlayer.brainbar_hybrid_helper import _describe_request_for_log
+
+    secret = "my private therapy notes about SECRET_TOKEN_abc123"
+    described = _describe_request_for_log(
+        {"method": "brain_search", "arguments": {"query": secret, "project": "brainlayer", "num_results": 5}}
+    )
+    rendered = str(described)
+
+    assert secret not in rendered, f"raw query leaked into the log payload: {rendered}"
+    assert "SECRET_TOKEN_abc123" not in rendered
+    # still diagnosable
+    assert "brain_search" in rendered
+    assert "query_chars" in rendered, "must keep enough shape to diagnose the wedge"
+    assert "query_sha256" in rendered, "a stable fingerprint lets repeat wedges be correlated"
+    # non-sensitive structural fields are useful and safe
+    assert "brainlayer" in rendered or "project" in rendered
+    del caplog, logging

--- a/tests/test_hybrid_helper_request_deadline.py
+++ b/tests/test_hybrid_helper_request_deadline.py
@@ -1,0 +1,87 @@
+"""Incident 2026-08-24: one unbounded query pegged a core for ~7 hours.
+
+`brainbar_hybrid_helper` pid 1216 sat at 100% CPU with 46m12s of CPU burned.
+Proof it was wedged rather than loaded: SIGTERM it, BrainBar respawns against the
+SAME db and the SAME client traffic, and the fresh process measures 0% CPU.
+
+`serve_forever()` handles one connection at a time and `_CONNECTION_TIMEOUT_SECONDS`
+bounds only the SOCKET -- nothing bounds request PROCESSING. So a single pathological
+query blocks every subsequent hybrid search for as long as it runs, which is forever.
+
+These tests pin a hard request deadline that fails LOUDLY. It must not fail quietly:
+returning empty results on timeout would silently degrade retrieval, which BrainLayer
+forbids.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from brainlayer.brainbar_hybrid_helper import HybridSearchHelper
+
+
+def _helper(tmp_path, **kwargs):
+    return HybridSearchHelper(socket_path=tmp_path / "helper.sock", db_path=tmp_path / "brain.db", **kwargs)
+
+
+def test_request_deadline_is_configurable_and_has_a_default(tmp_path):
+    helper = _helper(tmp_path)
+    assert helper.request_deadline_seconds > 0, "a helper with no deadline can peg a core forever"
+
+    tuned = _helper(tmp_path, request_deadline_seconds=12.5)
+    assert tuned.request_deadline_seconds == 12.5
+
+
+def test_slow_request_trips_the_deadline(tmp_path):
+    """A request that outruns the deadline must trigger the abort hook."""
+    tripped = threading.Event()
+    helper = _helper(tmp_path, request_deadline_seconds=0.05, on_deadline_expired=lambda _info: tripped.set())
+
+    started = threading.Event()
+
+    def slow_request(_request):
+        started.set()
+        tripped.wait(timeout=5.0)
+        return {"ok": True}
+
+    helper._handle_request = slow_request  # type: ignore[method-assign]
+    helper._dispatch_with_deadline({"method": "brain_search", "arguments": {"query": "x"}})
+
+    assert started.is_set()
+    assert tripped.is_set(), "deadline expired but the abort hook never fired"
+
+
+def test_fast_request_does_not_trip_the_deadline(tmp_path):
+    """The common case must be untouched -- no false positives."""
+    tripped = threading.Event()
+    helper = _helper(tmp_path, request_deadline_seconds=5.0, on_deadline_expired=lambda _info: tripped.set())
+
+    helper._handle_request = lambda _request: {"ok": True, "text": "fast"}  # type: ignore[method-assign]
+    response = helper._dispatch_with_deadline({"method": "brain_search", "arguments": {"query": "x"}})
+
+    assert response == {"ok": True, "text": "fast"}
+    assert not tripped.is_set(), "a fast request must never trip the deadline"
+
+
+def test_deadline_hook_receives_the_query_for_diagnosis(tmp_path):
+    """When a query wedges the helper we must be able to name it afterwards.
+
+    The 2026-08-24 wedge was unattributable because the process died with no record
+    of what it was running.
+    """
+    seen: list[dict] = []
+    helper = _helper(tmp_path, request_deadline_seconds=0.05, on_deadline_expired=seen.append)
+
+    done = threading.Event()
+
+    def slow_request(_request):
+        done.wait(timeout=5.0)
+        return {"ok": True}
+
+    helper._handle_request = slow_request  # type: ignore[method-assign]
+    helper._dispatch_with_deadline({"method": "brain_search", "arguments": {"query": "the wedging query"}})
+    done.set()
+
+    assert seen, "abort hook never fired"
+    assert "the wedging query" in str(seen[0]), f"hook must carry the query text: {seen[0]}"
+    assert seen[0].get("elapsed_seconds") is not None


### PR DESCRIPTION
## Summary

Incident 2026-08-24: BrainLayer daemons held ~3 cores continuously (load avg **21.64**) and stalled
cmux typing. Two code defects, both reproduced by tests before being fixed.

Unparked by orcClaude ruling (2026-08-24 20:15): the hybrid-helper wedge is a **recurring 100%-of-a-core**
failure, measured three times today, so this is relief rather than sprint work.

### 1. hotlane — was 120% CPU for 29 minutes

`run()` slept a **fixed** `interval` (1.0s) after every cycle, working or not, so an idle hotlane
re-scanned a **14.8 GB** SQLite DB once per second, forever. Idle cycles now back off geometrically to
a 30s cap; any real work snaps the cadence straight back to `interval`, so hot writes stay hot.

A queued backlog is explicitly **not** idle: when the durable queue has work the daemon is deliberately
yielding its hot slice to the drain, and backing off there would slow recovery. That keeps the existing
reserved-backlog-slice contract intact — `test_hotlane_run_repeats_reserved_backlog_slice_during_continuous_pressure`
caught exactly this during development and is still green.

### 2. brainbar_hybrid_helper — was 100% CPU for ~7h (46m12s of CPU burned)

`serve_forever()` handles one connection at a time, and `_CONNECTION_TIMEOUT_SECONDS = 5.0` bounds only
the **socket** — nothing bounded request **processing**. One pathological query blocked every later
hybrid search indefinitely.

Adds a hard wall-clock request deadline (default 90s, override `BRAINLAYER_HYBRID_REQUEST_DEADLINE_S`)
that fails **loudly**: it logs the offending request and recycles the process so BrainBar respawns it.

It must fail loudly rather than return empty results — a quiet empty result would silently degrade
retrieval, which BrainLayer forbids. This is also why the fix is *not* "add a timeout to the FTS path":
`_fetch_fts_rows` returns `[]` on timeout, so broadening that would silently drop results.

## Evidence this was a wedge, not load

SIGTERM'd pid 1216 (100% CPU) and BrainBar respawned against **the same DB and the same client
traffic** — the replacement measured **0% CPU**. Same code, same load, 100% → 0%.

`sample` put **4150/4150** busy-thread samples in `sqlite3_step → sqlite3VdbeExec`, dominated by
`VdbeMemSetText`/`VdbeMemGrow` (row-by-row text materialization) with **no fts5 symbols** in the hot
path — a scan over `chunks`, not an index seek.

Recycling is verified safe: BrainBar respawns a warm replacement in ~9s, and the helper holds no
durable state. Observed wedges today: **19:04, 19:20, 20:14**.

## What this does NOT fix (stated so nobody assumes it)

- The exact wedging query is still unidentified. I will not guess it.
- The hotlane plist passes `--enrich-since-hours 87600` (**10 years**) on a 1.0s tick, making the *hot*
  lane also a *backlog* lane. Backoff cannot help while unenriched chunks always exist in a 1M-row DB.
  That is an enrichment-coverage **policy** call, not a code bug.

## Test plan

- [x] 4 new hotlane backoff tests + 4 new helper deadline tests — all written **red first**
- [x] Existing suites still green: hotlane 44, helper 11
- [x] Full suite: **4283 passed, 11 skipped, 2 xfailed**
- [x] The 8 remaining failures + 1 error are **pre-existing real-DB/latency tests** — verified by
      checking out `main` and re-running the identical set: same result (7 failed, 1 passed, 1 error).
      The one differing test (`test_cli_stats_p95_under_200ms`) is a **latency** test that passes in
      isolation on both branches and only failed in the big run because the wedged helper was eating a
      core at the time.
- [x] `ruff check src/ tests/ scripts/` — All checks passed; `ruff format --check` clean
- [x] Pushed through `BRAINLAYER_PREPUSH_SCOPE=changed-only` — BrainLayer test gate passed

## Deploy note

Per the closing order this must be deployed via `scripts/launchd/install.sh` (never a manual copy),
then `installed == main` proven before the daemons come back. Deploy drift is what caused half of this
incident: PR #667's watchdog guard has been in main since 2026-08-08 while the executing copy is dated
Jul 18 — that stale artifact SIGKILLed the watcher **991 times**.

— brainlayerClaude (lead) · claude-code/claude-opus-5
<!-- golem-id v1 {"seat":"brainlayerClaude","role":"lead","harness":"claude-code","model":"claude-opus-5","model_source":"session-env","session":"689aac26","ts":"2026-08-24T17:20:00Z"} -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hotlane idle cap bounds worst-case delay before new chunks get embedded; hybrid helper process exit on slow queries causes brief retrieval interruption until respawn (intentional tradeoff for wedge recovery).
> 
> **Overview**
> Addresses **2026-08-24** CPU incidents: the hotlane daemon no longer polls at a fixed **1s** when idle, and the BrainBar hybrid search helper can no longer run a single query without bound.
> 
> **hotlane (`hotlane_brainbar_daemon`)** — Idle cycles now sleep with **geometric backoff** (factor **2.0**, cap **`MAX_IDLE_INTERVAL_SECONDS` = 5s**). Embedding, enrichment attempts, or **any durable queue backlog** count as work and reset sleep to the configured **`interval`**. Failed cycles use only the existing exception backoff (no stacked idle delay); high-priority queue backpressure keeps the normal cadence so backlog draining is not slowed.
> 
> **hybrid helper (`brainbar_hybrid_helper`)** — Each request runs under a wall-clock deadline (default **90s**, override **`BRAINLAYER_HYBRID_REQUEST_DEADLINE_S`**) via **`threading.Timer`**. On expiry the default hook logs a **bounded request descriptor** (method, arg keys, `query_sha256` — not raw query text) and **`os._exit(75)`** so BrainBar can respawn a wedged process instead of blocking all hybrid searches.
> 
> New tests lock in backoff, failure/retry behavior, deadline firing, and log privacy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70871f4ca98c9828fc0fe5563676a1ce006c3dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add idle backoff to daemon and per-request deadline to `HybridSearchHelper`
> - `scripts/hotlane_brainbar_daemon.py` replaces fixed-interval sleeping with geometric idle backoff, capped at `MAX_IDLE_INTERVAL_SECONDS=5.0`. It resets immediately to the base interval after doing work.
> - `src/brainlayer/brainbar_hybrid_helper.py` bounds each request with a wall-clock deadline via `_dispatch_with_deadline`, defaulting to `_DEFAULT_REQUEST_DEADLINE_SECONDS=90.0`.
> - When a request exceeds the deadline, `_recycle_on_wedge` logs a sanitized descriptor and terminates the process with exit code 75.
> - Risk: `HybridSearchHelper` now exits the entire process on wedged requests instead of hanging, relying on an external supervisor to respawn it. The daemon loop's sleep cadence changes from fixed intervals to dynamic backoff.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70871f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Idle background processing now progressively backs off, up to 30 seconds, when no work is available.
  - New work or queued backlog immediately restores the configured processing cadence.

- **Reliability**
  - Hybrid search requests now enforce a configurable 90-second deadline by default.
  - Stalled requests trigger clear failure handling instead of remaining indefinitely blocked.

- **Tests**
  - Added coverage for idle backoff, cadence resets, request deadlines, timeout handling, and diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->