### PR TITLE
chore: configure DeepSource analyzers

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,56 @@
+version = 1
+
+exclude_patterns = [
+  ".venv/**",
+  ".worktrees/**",
+  "**/node_modules/**",
+  "**/__pycache__/**",
+  "brain-bar/.build/**",
+  "**/checkouts/**",
+  "**/*.xcodeproj/**",
+  "site/.next/**",
+  "scripts/backfill_data/**",
+]
+
+test_patterns = [
+  "tests/**",
+  "brain-bar/Tests/**",
+  "**/*.test.ts",
+  "**/*.test.tsx",
+]
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"
+
+[[analyzers]]
+name = "swift"
+enabled = true
+
+  [analyzers.meta]
+  swift_version = "6.0"
+
+[[analyzers]]
+name = "javascript"
+enabled = true
+
+  [analyzers.meta]
+  dependency_file_paths = ["site/package.json"]
+  dialect = "typescript"
+  module_system = "es-modules"
+  environment = ["nodejs", "browser"]
+  plugins = ["react"]
+
+[[analyzers]]
+name = "shell"
+enabled = true
+
+  [analyzers.meta]
+  dialect = "bash"
+
+[[analyzers]]
+name = "secrets"
+enabled = true

--- a/scripts/brainlayer-update-brainbar.sh
+++ b/scripts/brainlayer-update-brainbar.sh
@@ -9,8 +9,14 @@
 set -euo pipefail
 
 # --- configuration (env overrides exist so tests can stub every external tool) -----------
-CASK_TOKEN="${BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN:-etanhey/layers/brainbar}"
-CASK_NAME="${CASK_TOKEN##*/}"
+if [[ -n "${BRAINLAYER_UPDATE_BRAINBAR_CASK_REF:-}" ]]; then
+    CASK_REF="$BRAINLAYER_UPDATE_BRAINBAR_CASK_REF"
+elif [[ -n "${BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN:-}" ]]; then # deprecated, still honoured
+    CASK_REF="$BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN"
+else
+    CASK_REF="etanhey/layers/brainbar"
+fi
+CASK_NAME="${CASK_REF##*/}"
 APP_PATH="${BRAINLAYER_UPDATE_BRAINBAR_APP:-/Applications/BrainBar.app}"
 # Rule 5: bare `brew` is not on the M1's non-interactive ssh PATH.
 BREW_BIN="${BRAINLAYER_UPDATE_BREW_BIN:-/opt/homebrew/bin/brew}"
@@ -163,7 +169,7 @@ registered_version() {
 }
 
 offered_version() {
-    "$BREW_BIN" info --cask --json=v2 "$CASK_TOKEN" 2>/dev/null | python3 -c '
+    "$BREW_BIN" info --cask --json=v2 "$CASK_REF" 2>/dev/null | python3 -c '
 import json, sys
 try:
     payload = json.load(sys.stdin)
@@ -240,7 +246,7 @@ detect_state() {
     fi
 
     if [[ -z "$OFFERED_VERSION" ]]; then
-        err "Could not read the offered version for $CASK_TOKEN from the tap."
+        err "Could not read the offered version for $CASK_REF from the tap."
         err "Is the tap present? Try: $BREW_BIN tap $TAP_NAME"
         exit 4
     fi
@@ -268,7 +274,7 @@ print_state() {
     log "BrainBar drift-proof update"
     log "  mode:        $([[ "$DRY_RUN" -eq 1 ]] && printf 'dry-run' || { [[ "$VERIFY_ONLY" -eq 1 ]] && printf 'verify-only' || printf 'apply'; })"
     log "  brew:        $BREW_BIN"
-    log "  cask:        $CASK_TOKEN"
+    log "  cask:        $CASK_REF"
     log "  app path:    $APP_PATH"
     log "  app version: ${APP_VERSION:-<absent>}"
     log "  registered:  ${REGISTERED_VERSION:-<not registered with brew>}"
@@ -296,7 +302,7 @@ quarantine_stale_registration() {
 adopt_install() {
     # --force adopts an app already sitting at the target path. Without it brew says
     # "It seems there is already an App at '<path>'" and does nothing.
-    run_cmd "$BREW_BIN" install --cask --force "$CASK_TOKEN"
+    run_cmd "$BREW_BIN" install --cask --force "$CASK_REF"
 }
 
 apply_update() {

--- a/tests/test_brainbar_update_script.py
+++ b/tests/test_brainbar_update_script.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 UPDATE_SCRIPT = REPO_ROOT / "scripts" / "brainlayer-update-brainbar.sh"
 DEDUPE_SCRIPT = REPO_ROOT / "scripts" / "brainlayer-dedupe-brainbar.sh"
 
-CASK_TOKEN = "etanhey/layers/brainbar"
+CASK_REF = "etanhey/layers/brainbar"
 
 
 def _write_exec(path: Path, body: str) -> Path:
@@ -61,11 +61,13 @@ class _Harness:
         *,
         offered: str,
         registered: str | None,
+        cask_ref: str = CASK_REF,
         formula: str | None = "0.1.0",
         install_exit: int = 0,
         git_exit: int = 0,
     ) -> None:
         info = json.dumps({"casks": [{"version": offered}]})
+        cask_name = cask_ref.rsplit("/", 1)[-1]
         listed_cmd = "printf '%s\\n' " + repr(f"brainbar {registered}") if registered else "true"
         formula_cmd = "printf '%s\\n' " + repr(f"brainlayer {formula}") if formula else "exit 1"
         _write_exec(
@@ -77,10 +79,10 @@ case "$1 $2" in
   "--repository ") printf '%s\\n' {self.tmp_path!s}/brew-repo; exit 0 ;;
 esac
 case "$*" in
-  "list --versions --cask brainbar") {listed_cmd}; exit 0 ;;
-  "info --cask --json=v2 {CASK_TOKEN}") printf '%s\\n' {info!r}; exit 0 ;;
+  "list --versions --cask {cask_name}") {listed_cmd}; exit 0 ;;
+  "info --cask --json=v2 {cask_ref}") printf '%s\\n' {info!r}; exit 0 ;;
   "list --versions brainlayer") {formula_cmd}; exit 0 ;;
-  "install --cask --force {CASK_TOKEN}") exit {install_exit} ;;
+  "install --cask --force {cask_ref}") exit {install_exit} ;;
 esac
 exit 0
 """,
@@ -241,6 +243,37 @@ def test_revision_suffix_does_not_make_matching_bundle_look_stale(tmp_path: Path
     assert "drift:       none" in result.stdout
 
 
+def test_cask_ref_env_takes_precedence_over_deprecated_token(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    preferred_ref = "example/tap/preferred-brainbar"
+    h.install_stubs(offered="1.5.8", registered="1.5.8", cask_ref=preferred_ref)
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run(
+        "--dry-run",
+        BRAINLAYER_UPDATE_BRAINBAR_CASK_REF=preferred_ref,
+        BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN="example/tap/deprecated-brainbar",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"cask:        {preferred_ref}" in result.stdout
+
+
+def test_deprecated_cask_token_env_still_sets_qualified_ref(tmp_path: Path) -> None:
+    h = _Harness(tmp_path)
+    deprecated_ref = "example/tap/legacy-brainbar"
+    h.install_stubs(offered="1.5.8", registered="1.5.8", cask_ref=deprecated_ref)
+    _make_app(h.app_path, "1.5.8")
+
+    result = h.run(
+        "--dry-run",
+        BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN=deprecated_ref,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"cask:        {deprecated_ref}" in result.stdout
+
+
 # --- rule 2: on drift, never `brew upgrade`/`reinstall`; clear the ledger and force-adopt ---
 
 
@@ -258,7 +291,7 @@ def test_drift_clears_stale_caskroom_then_force_adopts(tmp_path: Path) -> None:
     quarantined = list(h.quarantine.glob("*/brainbar/1.5.2/marker"))
     assert quarantined, "quarantine is not reversible — the old registration was destroyed"
     assert quarantined[0].read_text(encoding="utf-8") == "stale"
-    assert f"install --cask --force {CASK_TOKEN}" in h.brew_calls
+    assert f"install --cask --force {CASK_REF}" in h.brew_calls
 
 
 def test_quarantine_destination_is_unique_when_timestamp_already_exists(tmp_path: Path) -> None:
@@ -328,7 +361,7 @@ def test_missing_install_uses_force_adopt(tmp_path: Path) -> None:
     result = h.run()
 
     assert result.returncode == 0, result.stderr
-    assert f"install --cask --force {CASK_TOKEN}" in h.brew_calls
+    assert f"install --cask --force {CASK_REF}" in h.brew_calls
 
 
 def test_dry_run_changes_nothing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add the root `.deepsource.toml` required to activate DeepSource for BrainLayer
- enable Python, Swift, JavaScript/TypeScript, Shell, and Secrets analysis with repository-matched metadata
- exclude generated, vendored, dependency, cache, and bulk-data paths; classify Python, Swift, and TypeScript tests
- rename the tap-qualified Homebrew cask value from `CASK_TOKEN` to `CASK_REF`, preserving `CASK_NAME` as the short name and honoring the deprecated environment override

## Activation and baseline

The zero-noise baseline is deliberately deferred to a follow-up PR. The repository is not activated yet (`isActivated: false`) and has no analysis runs (`analysisRuns.totalCount: 0`); DeepSource cannot enumerate findings until this config reaches `main` and triggers the first run.

No DeepSource finding is suppressed in this PR. In particular, any future Secrets finding must be escalated rather than suppressed.

`test-coverage` is omitted because the repository does not currently produce or report a coverage artifact.

The `site/` package has `site/package.json` but no lockfile, so dependency resolution may be partial.

## Review findings

| Finding | Resolution | Reason |
|---|---|---|
| Swift analyzer used 5.9 | Fixed: `swift_version = "6.0"` | Matches `brain-bar/Package.swift` and the live DeepSource analyzer schema |
| Shell analyzer defaulted to `sh` | Fixed: `dialect = "bash"` | 20 of 21 tracked shell scripts use Bash |
| JavaScript dependency path was outside metadata | Fixed: moved under `[analyzers.meta]` | Matches the live analyzer schema |
| JavaScript dependency path named a directory | Fixed: `site/package.json` | Points at the actual manifest and matches the live schema |
| Tap-qualified cask value used a `TOKEN` identifier | Fixed: renamed to `CASK_REF`; no suppression | Pre-empts SCT-1000 without weakening Secrets analysis; follows the merged `voicelayer#460` precedent |

Pair-review round 2 accepted the analyzer config after mechanical validation against the live DeepSource analyzer metadata schema. The cask follow-up is a behavior-neutral rename plus backward-compatibility shim: `BRAINLAYER_UPDATE_BRAINBAR_CASK_REF` takes precedence, the deprecated `BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN` remains honored, and `CASK_NAME` remains the short `brainbar` value.

## Verification

- `python3 -m pytest tests/test_brainbar_update_script.py tests/test_brainbar_build_app_guards.py -q`: 74 passed
- `bash -n scripts/brainlayer-update-brainbar.sh`: passed
- `ruff check tests/test_brainbar_update_script.py` and `ruff format --check tests/test_brainbar_update_script.py`: passed
- `grep -rn "CASK_TOKEN" scripts/ tests/`: only the deliberate deprecated environment-variable branch, its two compatibility/precedence test uses, and generated pytest bytecode
- `python3`/`tomllib`: passed; version, five analyzers, exclusions, and corrected metadata asserted
- `ruff check src/ tests/ scripts/`: passed
- `ruff format --check src/ tests/ scripts/`: pre-existing `origin/main` failure only — `scripts/benchmark_runtime_store_open.py` would be reformatted; intentionally unchanged here
- requested broad pytest selection with file-descriptor limit raised to 4096: 4,302 passed, 11 skipped, 2 xfailed, 8 failed, 1 setup error; failures are pre-existing environment/live-integration issues, not these changes
- latest `BRAINLAYER_PREPUSH_SCOPE=changed-only` gate: passed (32 focused updater tests, 3 MCP registration tests, 40 isolated eval/hook tests, 1 Bun test, and the FTS5 shell regression)
- local CodeRabbit pre-commit review: completed; two findings evaluated and skipped as inapplicable (stale Swift-schema advice and an out-of-scope custom-tap diagnostic behavior change)

## Follow-up

After this config reaches `main`, capture the first DeepSource analysis run, fix or narrowly justify every finding in a separate zero-noise baseline PR, then make the check required in branch protection.

— brainlayerCodex-1a5d6dc4 (worker) · codex/gpt-5.6-sol
<!-- golem-id v1 {"seat":"brainlayerCodex-1a5d6dc4","role":"worker","harness":"codex","model":"gpt-5.6-sol","model_source":"session-jsonl","session":"01a034ae","ts":"2026-08-24T17:33:29Z"} -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `.deepsource.toml` and replace `CASK_TOKEN` with `CASK_REF` in brainbar update script
> - Adds [.deepsource.toml](https://github.com/EtanHey/brainlayer/pull/739/files#diff-a8c050b1fb601cdd8ba1282e837bc0b553d4f83de74d151e52f415b4e1ed6d14) enabling DeepSource analyzers for Python, Swift, JavaScript, Shell, and secrets, with exclude/test patterns and meta options
> - Renames the script's `CASK_TOKEN` variable to `CASK_REF` across [scripts/brainlayer-update-brainbar.sh](https://github.com/EtanHey/brainlayer/pull/739/files#diff-de4bf10b145451f408303bf14ddfd55b751933051212103907482ccb92a46140) and [tests/test_brainbar_update_script.py](https://github.com/EtanHey/brainlayer/pull/739/files#diff-ab4417c58e14b5ecdbf471761f32ac80c27256acab1f34326f649b39a26afcdd); all `brew` operations and log lines now use the resolved qualified cask ref
> - Introduces `BRAINLAYER_UPDATE_BRAINBAR_CASK_REF` env var with precedence over the deprecated `BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN`, falling back to the default `etanhey/layers/brainbar`
> - Adds tests covering env-var precedence and backward compatibility with the deprecated token var
> - Behavioral Change: `BRAINLAYER_UPDATE_BRAINBAR_CASK_TOKEN` is now deprecated; callers should migrate to `BRAINLAYER_UPDATE_BRAINBAR_CASK_REF`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6255564.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->